### PR TITLE
edgesync: unified CLI — 35 commands, merge system, SQLite driver adapter

### DIFF
--- a/.github/workflows/dst.yml
+++ b/.github/workflows/dst.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test dst (scenarios)
         run: go test ./dst/ -run 'TestScenario|TestE2E|TestMockFossil|TestSimulator|TestCheck' -count=1
 
-  # DST seed sweep — 16 seeds x 3 severity levels = 48 jobs
+  # DST seed sweep — 16 seeds x 3 severity levels x 3 drivers = 144 jobs
   dst:
     needs: test
     runs-on: ubuntu-latest
@@ -31,17 +31,29 @@ jobs:
       matrix:
         seed: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
         level: [normal, adversarial, hostile]
+        driver:
+          - name: default
+            tags: ""
+            cgo: "0"
+          - name: ncruces
+            tags: "-tags ncruces"
+            cgo: "0"
+          - name: mattn
+            tags: "-tags mattn"
+            cgo: "1"
+    env:
+      DST_SEED: ${{ matrix.seed }}
+      DST_LEVEL: ${{ matrix.level }}
+      CGO_ENABLED: ${{ matrix.driver.cgo }}
+      BUILD_TAGS: ${{ matrix.driver.tags }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
       - name: Run DST
-        env:
-          DST_SEED: ${{ matrix.seed }}
-          DST_LEVEL: ${{ matrix.level }}
         run: |
-          go test ./dst/ -v -run TestDST \
+          go test $BUILD_TAGS ./dst/ -v -run TestDST \
             -seed="$DST_SEED" \
             -level="$DST_LEVEL" \
             -steps=50000 \

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@ libfossil/libfossil.fossil
 
 # Build artifacts
 /soak
+/edgesync
+.worktrees/
+
+# Merge test artifacts
+*.LOCAL
+*.REMOTE
+*.BASE
+*.BASELINE
+*.MERGE
+f.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean leaf bridge dst dst-full dst-hostile
+.PHONY: build test clean leaf bridge dst dst-full dst-hostile dst-drivers
 
 build: leaf bridge
 
@@ -40,6 +40,23 @@ dst-full:
 	done; \
 	if [ $$fail -eq 1 ]; then echo "=== DST FAILED ==="; exit 1; fi
 	@echo "=== DST full sweep passed ==="
+
+# DST across all 3 SQLite drivers: 4 seeds × hostile × 3 drivers
+dst-drivers:
+	@echo "=== DST driver sweep (4 seeds × hostile × 3 drivers) ==="
+	@fail=0; \
+	for driver in "default:" "ncruces:-tags=ncruces" "mattn:-tags=mattn"; do \
+		name=$${driver%%:*}; \
+		tags=$${driver#*:}; \
+		cgo=0; \
+		if [ "$$name" = "mattn" ]; then cgo=1; fi; \
+		for seed in 1 2 3 4; do \
+			echo "  driver=$$name seed=$$seed ..."; \
+			(cd dst && CGO_ENABLED=$$cgo go test $$tags -run TestDST -seed=$$seed -level=hostile -steps=10000 -timeout 60s) || fail=1; \
+		done; \
+	done; \
+	if [ $$fail -eq 1 ]; then echo "=== DST drivers FAILED ==="; exit 1; fi
+	@echo "=== DST driver sweep passed ==="
 
 # Hostile-only DST: 16 seeds, hostile level
 dst-hostile:

--- a/bridge/bridge/bridge.go
+++ b/bridge/bridge/bridge.go
@@ -65,6 +65,11 @@ func (b *Bridge) Start() error {
 	if err != nil {
 		return fmt.Errorf("bridge: subscribe: %w", err)
 	}
+	// Flush ensures the subscription is acknowledged by the server before
+	// Start returns, preventing "no responders" races in tests/CI.
+	if err := b.conn.Flush(); err != nil {
+		return fmt.Errorf("bridge: flush after subscribe: %w", err)
+	}
 	log.Printf("bridge started: subject=%s fossil=%s", subject, b.config.FossilURL)
 	return nil
 }

--- a/bridge/bridge/integration_test.go
+++ b/bridge/bridge/integration_test.go
@@ -19,7 +19,7 @@ import (
 
 // startFossilServer starts a fossil server on a free port and returns the URL
 // and a cleanup function. The server is shut down when the test ends.
-func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func()) {
+func startFossilServer(t *testing.T, repoPath string) string {
 	t.Helper()
 
 	bin := testutil.FossilBinary()
@@ -58,10 +58,13 @@ func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func(
 
 ready:
 	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	return serverURL, func() {
+	t.Cleanup(func() {
 		cmd.Process.Kill()
 		cmd.Wait()
-	}
+		os.Remove(repoPath + "-wal")
+		os.Remove(repoPath + "-shm")
+	})
+	return serverURL
 }
 
 func TestIntegrationLeafBridgeFossil(t *testing.T) {
@@ -102,8 +105,7 @@ func TestIntegrationLeafBridgeFossil(t *testing.T) {
 	}
 
 	// 3. Start fossil server on the remote.
-	fossilURL, fossilCleanup := startFossilServer(t, remotePath)
-	defer fossilCleanup()
+	fossilURL := startFossilServer(t, remotePath)
 
 	// 4. Start embedded NATS.
 	natsURL := startEmbeddedNATS(t)

--- a/cmd/edgesync/bridge_serve.go
+++ b/cmd/edgesync/bridge_serve.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dmestas/edgesync/bridge/bridge"
+)
+
+type BridgeServeCmd struct {
+	NATSUrl   string `help:"NATS server URL" default:"nats://localhost:4222"`
+	FossilURL string `required:"" help:"Fossil server HTTP URL"`
+	Project   string `required:"" help:"Project code for NATS subject"`
+}
+
+func (c *BridgeServeCmd) Run(g *Globals) error {
+	b, err := bridge.New(bridge.Config{
+		NATSUrl:     c.NATSUrl,
+		FossilURL:   c.FossilURL,
+		ProjectCode: c.Project,
+	})
+	if err != nil {
+		return fmt.Errorf("bridge: %w", err)
+	}
+
+	if err := b.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	log.Printf("edgesync bridge running (nats=%s fossil=%s project=%s)", c.NATSUrl, c.FossilURL, c.Project)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	log.Printf("shutting down...")
+	return b.Stop()
+}

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -29,6 +29,11 @@ type RepoCmd struct {
 	Timeline RepoTimelineCmd `cmd:"" help:"Show repository history"`
 	Cat      RepoCatCmd      `cmd:"" help:"Output artifact content"`
 	Info     RepoInfoCmd     `cmd:"" help:"Repository statistics"`
+	Hash     RepoHashCmd     `cmd:"" help:"Hash files (SHA1 or SHA3)"`
+	Delta    RepoDeltaCmd    `cmd:"" help:"Delta create/apply operations"`
+	Config   RepoConfigCmd   `cmd:"" help:"Repository configuration"`
+	Query    RepoQueryCmd    `cmd:"" help:"Execute SQL against repository"`
+	Verify   RepoVerifyCmd   `cmd:"" help:"Verify repository integrity"`
 }
 
 type SyncCmd struct {

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -44,7 +44,10 @@ type RepoCmd struct {
 	Rm       RepoRmCmd       `cmd:"" help:"Stage files for removal"`
 	Rename   RepoRenameCmd   `cmd:"" help:"Rename a tracked file"`
 	Revert   RepoRevertCmd   `cmd:"" help:"Undo staging changes"`
-	Diff     RepoDiffCmd     `cmd:"" help:"Show changes vs a version"`
+	Diff      RepoDiffCmd         `cmd:"" help:"Show changes vs a version"`
+	Merge      RepoMergeCmd        `cmd:"" help:"Merge a divergent version"`
+	Conflicts  RepoConflictsCmd    `cmd:"" help:"List unresolved conflicts"`
+	Unresolve  RepoMergeResolveCmd `cmd:"" name:"mark-resolved" help:"Mark a conflict as resolved"`
 }
 
 type SyncCmd struct {

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -34,6 +34,12 @@ type RepoCmd struct {
 	Config   RepoConfigCmd   `cmd:"" help:"Repository configuration"`
 	Query    RepoQueryCmd    `cmd:"" help:"Execute SQL against repository"`
 	Verify   RepoVerifyCmd   `cmd:"" help:"Verify repository integrity"`
+	Resolve  RepoResolveCmd  `cmd:"" help:"Resolve symbolic name to UUID"`
+	Extract  RepoExtractCmd  `cmd:"" help:"Extract files from a version"`
+	Wiki     RepoWikiCmd     `cmd:"" help:"Wiki page operations"`
+	Tag      RepoTagCmd      `cmd:"" help:"Tag operations"`
+	Open     RepoOpenCmd     `cmd:"" help:"Open a checkout in a directory"`
+	Status   RepoStatusCmd   `cmd:"" help:"Show working directory changes"`
 }
 
 type SyncCmd struct {
@@ -52,8 +58,12 @@ func openRepo(g *Globals) (*repo.Repo, error) {
 	return repo.Open(g.Repo)
 }
 
+// resolveRID resolves a version string to a rid.
+// Accepts: empty/"tip" (most recent checkin), "trunk" (tagged trunk tip),
+// UUID prefix (min 4 chars), or full UUID.
 func resolveRID(r *repo.Repo, version string) (libfossil.FslID, error) {
-	if version == "" {
+	switch version {
+	case "", "tip":
 		var rid int64
 		err := r.DB().QueryRow(
 			"SELECT objid FROM event WHERE type='ci' ORDER BY mtime DESC LIMIT 1",
@@ -62,15 +72,34 @@ func resolveRID(r *repo.Repo, version string) (libfossil.FslID, error) {
 			return 0, fmt.Errorf("no checkins found")
 		}
 		return libfossil.FslID(rid), nil
+
+	case "trunk":
+		// trunk = most recent checkin tagged "trunk"
+		var rid int64
+		err := r.DB().QueryRow(`
+			SELECT tagxref.rid FROM tagxref
+			JOIN tag ON tag.tagid=tagxref.tagid
+			WHERE tag.tagname='sym-trunk'
+			  AND tagxref.tagtype>0
+			ORDER BY tagxref.mtime DESC LIMIT 1`,
+		).Scan(&rid)
+		if err != nil {
+			// Fallback to tip if no trunk tag
+			return resolveRID(r, "tip")
+		}
+		return libfossil.FslID(rid), nil
+
+	default:
+		// UUID or prefix lookup
+		var rid int64
+		err := r.DB().QueryRow(
+			"SELECT rid FROM blob WHERE uuid LIKE ?", version+"%",
+		).Scan(&rid)
+		if err != nil {
+			return 0, fmt.Errorf("artifact %q not found", version)
+		}
+		return libfossil.FslID(rid), nil
 	}
-	var rid int64
-	err := r.DB().QueryRow(
-		"SELECT rid FROM blob WHERE uuid LIKE ?", version+"%",
-	).Scan(&rid)
-	if err != nil {
-		return 0, fmt.Errorf("artifact %q not found", version)
-	}
-	return libfossil.FslID(rid), nil
 }
 
 func currentUser() string {

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -46,8 +46,8 @@ type RepoCmd struct {
 	Revert   RepoRevertCmd   `cmd:"" help:"Undo staging changes"`
 	Diff      RepoDiffCmd         `cmd:"" help:"Show changes vs a version"`
 	Merge      RepoMergeCmd        `cmd:"" help:"Merge a divergent version"`
-	Conflicts  RepoConflictsCmd    `cmd:"" help:"List unresolved conflicts"`
-	Unresolve  RepoMergeResolveCmd `cmd:"" name:"mark-resolved" help:"Mark a conflict as resolved"`
+	Conflicts   RepoConflictsCmd    `cmd:"" help:"List/manage unresolved conflicts"`
+	MarkResolved RepoMergeResolveCmd `cmd:"" name:"mark-resolved" help:"Mark a conflict as resolved"`
 }
 
 type SyncCmd struct {

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -40,6 +40,11 @@ type RepoCmd struct {
 	Tag      RepoTagCmd      `cmd:"" help:"Tag operations"`
 	Open     RepoOpenCmd     `cmd:"" help:"Open a checkout in a directory"`
 	Status   RepoStatusCmd   `cmd:"" help:"Show working directory changes"`
+	Add      RepoAddCmd      `cmd:"" help:"Stage files for addition"`
+	Rm       RepoRmCmd       `cmd:"" help:"Stage files for removal"`
+	Rename   RepoRenameCmd   `cmd:"" help:"Rename a tracked file"`
+	Revert   RepoRevertCmd   `cmd:"" help:"Undo staging changes"`
+	Diff     RepoDiffCmd     `cmd:"" help:"Show changes vs a version"`
 }
 
 type SyncCmd struct {

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os/user"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+type CLI struct {
+	Globals
+
+	Repo   RepoCmd   `cmd:"" help:"Repository operations"`
+	Sync   SyncCmd   `cmd:"" help:"Leaf agent sync"`
+	Bridge BridgeCmd `cmd:"" help:"NATS-to-Fossil bridge"`
+}
+
+type Globals struct {
+	Repo    string `short:"R" help:"Path to repository file" type:"path"`
+	Verbose bool   `short:"v" help:"Verbose output"`
+}
+
+type RepoCmd struct {
+	New      RepoNewCmd      `cmd:"" help:"Create a new repository"`
+	Ci       RepoCiCmd       `cmd:"" help:"Checkin file changes"`
+	Co       RepoCoCmd       `cmd:"" help:"Checkout a version"`
+	Ls       RepoLsCmd       `cmd:"" help:"List files in a version"`
+	Timeline RepoTimelineCmd `cmd:"" help:"Show repository history"`
+	Cat      RepoCatCmd      `cmd:"" help:"Output artifact content"`
+	Info     RepoInfoCmd     `cmd:"" help:"Repository statistics"`
+}
+
+type SyncCmd struct {
+	Start SyncStartCmd `cmd:"" help:"Start leaf agent daemon"`
+	Now   SyncNowCmd   `cmd:"" help:"Trigger immediate sync"`
+}
+
+type BridgeCmd struct {
+	Serve BridgeServeCmd `cmd:"" help:"Start NATS-to-Fossil bridge"`
+}
+
+func openRepo(g *Globals) (*repo.Repo, error) {
+	if g.Repo == "" {
+		return nil, fmt.Errorf("no repository specified (use -R <path>)")
+	}
+	return repo.Open(g.Repo)
+}
+
+func resolveRID(r *repo.Repo, version string) (libfossil.FslID, error) {
+	if version == "" {
+		var rid int64
+		err := r.DB().QueryRow(
+			"SELECT objid FROM event WHERE type='ci' ORDER BY mtime DESC LIMIT 1",
+		).Scan(&rid)
+		if err != nil {
+			return 0, fmt.Errorf("no checkins found")
+		}
+		return libfossil.FslID(rid), nil
+	}
+	var rid int64
+	err := r.DB().QueryRow(
+		"SELECT rid FROM blob WHERE uuid LIKE ?", version+"%",
+	).Scan(&rid)
+	if err != nil {
+		return 0, fmt.Errorf("artifact %q not found", version)
+	}
+	return libfossil.FslID(rid), nil
+}
+
+func currentUser() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return "anonymous"
+}

--- a/cmd/edgesync/main.go
+++ b/cmd/edgesync/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/alecthomas/kong"
+
+func main() {
+	var cli CLI
+	ctx := kong.Parse(&cli,
+		kong.Name("edgesync"),
+		kong.Description("EdgeSync — Fossil repo operations, NATS sync, and bridge"),
+		kong.UsageOnError(),
+	)
+	err := ctx.Run(&cli.Globals)
+	ctx.FatalIfErrorf(err)
+}

--- a/cmd/edgesync/repo_add.go
+++ b/cmd/edgesync/repo_add.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type RepoAddCmd struct {
+	Files []string `arg:"" required:"" help:"Files to stage for addition"`
+	Dir   string   `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoAddCmd) Run(g *Globals) error {
+	ckout, err := openCheckout(c.Dir)
+	if err != nil {
+		return err
+	}
+	defer ckout.Close()
+
+	vid, err := checkoutVid(ckout)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range c.Files {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(c.Dir, absPath)
+		if err != nil {
+			return fmt.Errorf("file %s is not within checkout directory", path)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		h := sha1.Sum(data)
+		mhash := hex.EncodeToString(h[:])
+
+		isExe := info.Mode()&0o111 != 0
+
+		// Check if already tracked.
+		var existingID int64
+		err = ckout.QueryRow("SELECT id FROM vfile WHERE pathname=? AND vid=?", relPath, vid).Scan(&existingID)
+		if err == nil {
+			// Already tracked — mark as changed.
+			ckout.Exec("UPDATE vfile SET chnged=1, deleted=0, mhash=? WHERE id=?", mhash, existingID)
+			fmt.Printf("UPDATED  %s\n", relPath)
+		} else {
+			// New file — insert.
+			ckout.Exec(`INSERT INTO vfile(vid, chnged, deleted, isexe, islink, rid, mrid, mtime, pathname, mhash)
+				VALUES(?, 1, 0, ?, 0, 0, 0, ?, ?, ?)`,
+				vid, isExe, info.ModTime().Unix(), relPath, mhash)
+			fmt.Printf("ADDED    %s\n", relPath)
+		}
+	}
+	return nil
+}
+
+// openCheckout opens the .fslckout database in the given directory.
+func openCheckout(dir string) (*sql.DB, error) {
+	ckoutPath := filepath.Join(dir, ".fslckout")
+	if _, err := os.Stat(ckoutPath); err != nil {
+		ckoutPath = filepath.Join(dir, "_FOSSIL_")
+		if _, err := os.Stat(ckoutPath); err != nil {
+			return nil, fmt.Errorf("no checkout found in %s (run 'edgesync repo open' first)", dir)
+		}
+	}
+	return sql.Open("sqlite", ckoutPath)
+}
+
+// checkoutVid returns the current checkout version ID from vvar.
+func checkoutVid(db *sql.DB) (int64, error) {
+	var vid int64
+	err := db.QueryRow("SELECT value FROM vvar WHERE name='checkout'").Scan(&vid)
+	if err != nil {
+		return 0, fmt.Errorf("reading checkout version: %w", err)
+	}
+	return vid, nil
+}

--- a/cmd/edgesync/repo_cat.go
+++ b/cmd/edgesync/repo_cat.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+)
+
+type RepoCatCmd struct {
+	Artifact string `arg:"" help:"Artifact UUID or prefix"`
+	Raw      bool   `help:"Output raw blob (no delta expansion)"`
+}
+
+func (c *RepoCatCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Artifact)
+	if err != nil {
+		return err
+	}
+
+	var data []byte
+	if c.Raw {
+		data, err = blob.Load(r.DB(), rid)
+	} else {
+		data, err = content.Expand(r.DB(), rid)
+	}
+	if err != nil {
+		return fmt.Errorf("reading artifact: %w", err)
+	}
+
+	os.Stdout.Write(data)
+	return nil
+}

--- a/cmd/edgesync/repo_ci.go
+++ b/cmd/edgesync/repo_ci.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoCiCmd struct {
+	Message string   `short:"m" required:"" help:"Checkin comment"`
+	Files   []string `arg:"" required:"" help:"Files to checkin"`
+	User    string   `help:"Checkin user (default: OS username)"`
+	Parent  string   `help:"Parent version UUID (default: tip)"`
+}
+
+func (c *RepoCiCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	var parentRid libfossil.FslID
+	if c.Parent != "" {
+		parentRid, err = resolveRID(r, c.Parent)
+		if err != nil {
+			return fmt.Errorf("resolving parent: %w", err)
+		}
+	} else {
+		parentRid, _ = resolveRID(r, "") // ignore error for initial checkin
+	}
+
+	files := make([]manifest.File, len(c.Files))
+	for i, path := range c.Files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		files[i] = manifest.File{
+			Name:    filepath.Base(path),
+			Content: data,
+		}
+	}
+
+	user := c.User
+	if user == "" {
+		user = currentUser()
+	}
+
+	rid, uuid, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   files,
+		Comment: c.Message,
+		User:    user,
+		Parent:  parentRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("checkin %s (rid=%d)\n", uuid[:10], rid)
+	return nil
+}

--- a/cmd/edgesync/repo_co.go
+++ b/cmd/edgesync/repo_co.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoCoCmd struct {
+	Version string `arg:"" optional:"" help:"Version to checkout (default: tip)"`
+	Dir     string `short:"d" help:"Output directory (default: current dir)" default:"."`
+	Force   bool   `help:"Overwrite existing files"`
+}
+
+func (c *RepoCoCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		fileRid, ok := blob.Exists(r.DB(), f.UUID)
+		if !ok {
+			return fmt.Errorf("blob %s not found for file %s", f.UUID, f.Name)
+		}
+		data, err := content.Expand(r.DB(), fileRid)
+		if err != nil {
+			return fmt.Errorf("expanding %s: %w", f.Name, err)
+		}
+
+		outPath := filepath.Join(c.Dir, f.Name)
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
+
+		if !c.Force {
+			if _, err := os.Stat(outPath); err == nil {
+				return fmt.Errorf("file exists: %s (use --force to overwrite)", outPath)
+			}
+		}
+
+		perm := os.FileMode(0o644)
+		if f.Perm == "x" {
+			perm = 0o755
+		}
+		if err := os.WriteFile(outPath, data, perm); err != nil {
+			return err
+		}
+
+		fmt.Printf("  %s\n", f.Name)
+	}
+
+	fmt.Printf("checked out %d files\n", len(files))
+	return nil
+}

--- a/cmd/edgesync/repo_config.go
+++ b/cmd/edgesync/repo_config.go
@@ -1,0 +1,75 @@
+package main
+
+import "fmt"
+
+type RepoConfigCmd struct {
+	Ls  RepoConfigLsCmd  `cmd:"" help:"List all config entries"`
+	Get RepoConfigGetCmd `cmd:"" help:"Get a config value"`
+	Set RepoConfigSetCmd `cmd:"" help:"Set a config value"`
+}
+
+type RepoConfigLsCmd struct{}
+
+func (c *RepoConfigLsCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rows, err := r.DB().Query("SELECT name, value FROM config ORDER BY name")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, value string
+		rows.Scan(&name, &value)
+		fmt.Printf("%-20s %s\n", name, value)
+	}
+	return rows.Err()
+}
+
+type RepoConfigGetCmd struct {
+	Key string `arg:"" help:"Config key to get"`
+}
+
+func (c *RepoConfigGetCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	var value string
+	err = r.DB().QueryRow("SELECT value FROM config WHERE name=?", c.Key).Scan(&value)
+	if err != nil {
+		return fmt.Errorf("config key %q not found", c.Key)
+	}
+	fmt.Println(value)
+	return nil
+}
+
+type RepoConfigSetCmd struct {
+	Key   string `arg:"" help:"Config key"`
+	Value string `arg:"" help:"Config value"`
+}
+
+func (c *RepoConfigSetCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	_, err = r.DB().Exec(
+		"INSERT OR REPLACE INTO config(name, value, mtime) VALUES(?, ?, strftime('%s','now'))",
+		c.Key, c.Value,
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s = %s\n", c.Key, c.Value)
+	return nil
+}

--- a/cmd/edgesync/repo_conflicts.go
+++ b/cmd/edgesync/repo_conflicts.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/merge"
+)
+
+type RepoConflictsCmd struct {
+	Dir string `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoConflictsCmd) Run(g *Globals) error {
+	found := 0
+
+	// Check vfile.chnged=5 for standard merge conflicts.
+	ckout, err := openCheckout(c.Dir)
+	if err == nil {
+		defer ckout.Close()
+		vid, _ := checkoutVid(ckout)
+		rows, err := ckout.Query("SELECT pathname FROM vfile WHERE chnged=5 AND vid=?", vid)
+		if err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var name string
+				rows.Scan(&name)
+				fmt.Printf("CONFLICT  %s\n", name)
+				found++
+			}
+		}
+	}
+
+	// Check conflict table for conflict-fork entries.
+	r, err := openRepo(g)
+	if err == nil {
+		defer r.Close()
+		forks, err := merge.ListConflictForks(r)
+		if err == nil {
+			for _, name := range forks {
+				fmt.Printf("FORK      %s\n", name)
+				found++
+			}
+		}
+	}
+
+	if found == 0 {
+		fmt.Println("no conflicts")
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_conflicts.go
+++ b/cmd/edgesync/repo_conflicts.go
@@ -2,18 +2,37 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
 	"github.com/dmestas/edgesync/go-libfossil/merge"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
 )
 
 type RepoConflictsCmd struct {
-	Dir string `short:"d" help:"Checkout directory" default:"."`
+	Ls      RepoConflictsLsCmd      `cmd:"" default:"1" help:"List all conflicts"`
+	Show    RepoConflictsShowCmd    `cmd:"" help:"Show all versions of a conflicted file"`
+	Pick    RepoConflictsPickCmd    `cmd:"" help:"Resolve by picking one version"`
+	Merge   RepoConflictsMergeCmd   `cmd:"" help:"Resolve by re-merging with a different strategy"`
+	Extract RepoConflictsExtractCmd `cmd:"" help:"Extract all versions to disk for manual editing"`
+	Dir     string                  `short:"d" help:"Checkout directory" default:"."`
 }
 
-func (c *RepoConflictsCmd) Run(g *Globals) error {
+type RepoConflictsLsCmd struct{}
+
+func (c *RepoConflictsLsCmd) Run(g *Globals) error {
+	// Delegate to parent's listing logic.
+	return (&RepoConflictsCmd{Dir: "."}).list(g)
+}
+
+func (c *RepoConflictsCmd) list(g *Globals) error {
 	found := 0
 
-	// Check vfile.chnged=5 for standard merge conflicts.
+	// Standard merge conflicts (vfile.chnged=5).
 	ckout, err := openCheckout(c.Dir)
 	if err == nil {
 		defer ckout.Close()
@@ -30,14 +49,15 @@ func (c *RepoConflictsCmd) Run(g *Globals) error {
 		}
 	}
 
-	// Check conflict table for conflict-fork entries.
+	// Conflict-fork entries.
 	r, err := openRepo(g)
 	if err == nil {
 		defer r.Close()
-		forks, err := merge.ListConflictForks(r)
+		entries, err := listConflictForkDetails(r)
 		if err == nil {
-			for _, name := range forks {
-				fmt.Printf("FORK      %s\n", name)
+			for _, e := range entries {
+				fmt.Printf("FORK      %s  (base=%d local=%d remote=%d)\n",
+					e.filename, e.baseRid, e.localRid, e.remoteRid)
 				found++
 			}
 		}
@@ -46,5 +66,239 @@ func (c *RepoConflictsCmd) Run(g *Globals) error {
 	if found == 0 {
 		fmt.Println("no conflicts")
 	}
+	return nil
+}
+
+type conflictForkEntry struct {
+	filename  string
+	baseRid   int64
+	localRid  int64
+	remoteRid int64
+}
+
+func listConflictForkDetails(r *repo.Repo) ([]conflictForkEntry, error) {
+	var count int
+	if r.DB().QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='conflict'").Scan(&count); count == 0 {
+		return nil, nil
+	}
+	rows, err := r.DB().Query("SELECT filename, base_rid, local_rid, remote_rid FROM conflict ORDER BY mtime DESC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var entries []conflictForkEntry
+	for rows.Next() {
+		var e conflictForkEntry
+		rows.Scan(&e.filename, &e.baseRid, &e.localRid, &e.remoteRid)
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+func loadConflictFork(r *repo.Repo, filename string) (*conflictForkEntry, error) {
+	var count int
+	if r.DB().QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='conflict'").Scan(&count); count == 0 {
+		return nil, fmt.Errorf("%s: no conflict-fork entries", filename)
+	}
+	var e conflictForkEntry
+	e.filename = filename
+	err := r.DB().QueryRow("SELECT base_rid, local_rid, remote_rid FROM conflict WHERE filename=?", filename).
+		Scan(&e.baseRid, &e.localRid, &e.remoteRid)
+	if err != nil {
+		return nil, fmt.Errorf("%s: not found in conflict table", filename)
+	}
+	return &e, nil
+}
+
+func expandForkFile(r *repo.Repo, checkinRid int64, filename string) ([]byte, error) {
+	if checkinRid <= 0 {
+		return nil, nil
+	}
+	files, err := manifest.ListFiles(r, libfossil.FslID(checkinRid))
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range files {
+		if f.Name == filename {
+			frid, ok := blob.Exists(r.DB(), f.UUID)
+			if !ok {
+				return nil, fmt.Errorf("blob %s not found", f.UUID)
+			}
+			return content.Expand(r.DB(), frid)
+		}
+	}
+	return nil, fmt.Errorf("file %s not found in checkin %d", filename, checkinRid)
+}
+
+// --- Show ---
+
+type RepoConflictsShowCmd struct {
+	File string `arg:"" help:"Conflicted file to show"`
+}
+
+func (c *RepoConflictsShowCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	entry, err := loadConflictFork(r, c.File)
+	if err != nil {
+		return err
+	}
+
+	base, _ := expandForkFile(r, entry.baseRid, c.File)
+	local, _ := expandForkFile(r, entry.localRid, c.File)
+	remote, _ := expandForkFile(r, entry.remoteRid, c.File)
+
+	fmt.Printf("=== BASE (ancestor, rid=%d) ===\n", entry.baseRid)
+	os.Stdout.Write(base)
+	fmt.Printf("\n=== LOCAL (your version, rid=%d) ===\n", entry.localRid)
+	os.Stdout.Write(local)
+	fmt.Printf("\n=== REMOTE (their version, rid=%d) ===\n", entry.remoteRid)
+	os.Stdout.Write(remote)
+	fmt.Println()
+	return nil
+}
+
+// --- Pick ---
+
+type RepoConflictsPickCmd struct {
+	File   string `arg:"" help:"Conflicted file to resolve"`
+	Local  bool   `help:"Keep local version" xor:"version"`
+	Remote bool   `help:"Keep remote version" xor:"version"`
+	Base   bool   `help:"Revert to base version" xor:"version"`
+	Dir    string `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoConflictsPickCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	entry, err := loadConflictFork(r, c.File)
+	if err != nil {
+		return err
+	}
+
+	var picked []byte
+	var label string
+	switch {
+	case c.Remote:
+		picked, _ = expandForkFile(r, entry.remoteRid, c.File)
+		label = "remote"
+	case c.Base:
+		picked, _ = expandForkFile(r, entry.baseRid, c.File)
+		label = "base"
+	default:
+		picked, _ = expandForkFile(r, entry.localRid, c.File)
+		label = "local"
+	}
+
+	outPath := filepath.Join(c.Dir, c.File)
+	os.MkdirAll(filepath.Dir(outPath), 0o755)
+	if err := os.WriteFile(outPath, picked, 0o644); err != nil {
+		return err
+	}
+
+	merge.ResolveConflictFork(r, c.File)
+	fmt.Printf("resolved: %s (picked %s)\n", c.File, label)
+	return nil
+}
+
+// --- Merge ---
+
+type RepoConflictsMergeCmd struct {
+	File     string `arg:"" help:"Conflicted file to re-merge"`
+	Strategy string `help:"Strategy to use" default:"three-way"`
+	Dir      string `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoConflictsMergeCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	entry, err := loadConflictFork(r, c.File)
+	if err != nil {
+		return err
+	}
+
+	strat, ok := merge.StrategyByName(c.Strategy)
+	if !ok {
+		return fmt.Errorf("unknown strategy: %s", c.Strategy)
+	}
+
+	base, _ := expandForkFile(r, entry.baseRid, c.File)
+	local, _ := expandForkFile(r, entry.localRid, c.File)
+	remote, _ := expandForkFile(r, entry.remoteRid, c.File)
+
+	result, err := strat.Merge(base, local, remote)
+	if err != nil {
+		return err
+	}
+
+	outPath := filepath.Join(c.Dir, c.File)
+	os.MkdirAll(filepath.Dir(outPath), 0o755)
+	if err := os.WriteFile(outPath, result.Content, 0o644); err != nil {
+		return err
+	}
+
+	if result.Clean {
+		merge.ResolveConflictFork(r, c.File)
+		fmt.Printf("resolved: %s (merged with %s, clean)\n", c.File, c.Strategy)
+	} else {
+		// Write sidecar files for remaining conflicts.
+		os.WriteFile(outPath+".LOCAL", local, 0o644)
+		os.WriteFile(outPath+".BASELINE", base, 0o644)
+		os.WriteFile(outPath+".MERGE", remote, 0o644)
+		fmt.Printf("merged: %s (%s, %d conflicts remain — edit and run mark-resolved)\n",
+			c.File, c.Strategy, len(result.Conflicts))
+	}
+	return nil
+}
+
+// --- Extract ---
+
+type RepoConflictsExtractCmd struct {
+	File string `arg:"" help:"Conflicted file to extract"`
+	Dir  string `short:"d" help:"Output directory" default:"."`
+}
+
+func (c *RepoConflictsExtractCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	entry, err := loadConflictFork(r, c.File)
+	if err != nil {
+		return err
+	}
+
+	base, _ := expandForkFile(r, entry.baseRid, c.File)
+	local, _ := expandForkFile(r, entry.localRid, c.File)
+	remote, _ := expandForkFile(r, entry.remoteRid, c.File)
+
+	os.MkdirAll(c.Dir, 0o755)
+
+	basePath := filepath.Join(c.Dir, c.File+".BASE")
+	localPath := filepath.Join(c.Dir, c.File+".LOCAL")
+	remotePath := filepath.Join(c.Dir, c.File+".REMOTE")
+
+	os.MkdirAll(filepath.Dir(basePath), 0o755)
+	os.WriteFile(basePath, base, 0o644)
+	os.WriteFile(localPath, local, 0o644)
+	os.WriteFile(remotePath, remote, 0o644)
+
+	fmt.Printf("  %s\n", basePath)
+	fmt.Printf("  %s\n", localPath)
+	fmt.Printf("  %s\n", remotePath)
 	return nil
 }

--- a/cmd/edgesync/repo_delta.go
+++ b/cmd/edgesync/repo_delta.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dmestas/edgesync/go-libfossil/delta"
+)
+
+type RepoDeltaCmd struct {
+	Create RepoDeltaCreateCmd `cmd:"" help:"Create a delta between two files"`
+	Apply  RepoDeltaApplyCmd  `cmd:"" help:"Apply a delta to a source file"`
+}
+
+type RepoDeltaCreateCmd struct {
+	Source string `arg:"" help:"Source (original) file"`
+	Target string `arg:"" help:"Target (new) file"`
+	Output string `short:"o" help:"Output file (default: stdout)"`
+}
+
+func (c *RepoDeltaCreateCmd) Run(g *Globals) error {
+	src, err := os.ReadFile(c.Source)
+	if err != nil {
+		return fmt.Errorf("reading source: %w", err)
+	}
+	tgt, err := os.ReadFile(c.Target)
+	if err != nil {
+		return fmt.Errorf("reading target: %w", err)
+	}
+
+	d := delta.Create(src, tgt)
+
+	if c.Output != "" {
+		return os.WriteFile(c.Output, d, 0o644)
+	}
+	os.Stdout.Write(d)
+	return nil
+}
+
+type RepoDeltaApplyCmd struct {
+	Source string `arg:"" help:"Source (original) file"`
+	Delta  string `arg:"" help:"Delta file"`
+	Output string `short:"o" help:"Output file (default: stdout)"`
+}
+
+func (c *RepoDeltaApplyCmd) Run(g *Globals) error {
+	src, err := os.ReadFile(c.Source)
+	if err != nil {
+		return fmt.Errorf("reading source: %w", err)
+	}
+	d, err := os.ReadFile(c.Delta)
+	if err != nil {
+		return fmt.Errorf("reading delta: %w", err)
+	}
+
+	result, err := delta.Apply(src, d)
+	if err != nil {
+		return fmt.Errorf("applying delta: %w", err)
+	}
+
+	if c.Output != "" {
+		return os.WriteFile(c.Output, result, 0o644)
+	}
+	os.Stdout.Write(result)
+	return nil
+}

--- a/cmd/edgesync/repo_diff.go
+++ b/cmd/edgesync/repo_diff.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+)
+
+type RepoDiffCmd struct {
+	Version string `arg:"" optional:"" help:"Version to diff against (default: tip)"`
+	Dir     string `short:"d" help:"Working directory to compare" default:"."`
+	Unified int    `short:"U" help:"Lines of context" default:"3"`
+}
+
+func (c *RepoDiffCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	hasDiff := false
+	for _, f := range files {
+		diskPath := filepath.Join(c.Dir, f.Name)
+		diskData, err := os.ReadFile(diskPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Printf("--- a/%s\n+++ /dev/null\n@@ deleted @@\n", f.Name)
+				hasDiff = true
+				continue
+			}
+			return err
+		}
+
+		repoContent, err := expandFile(r, f.UUID)
+		if err != nil {
+			return fmt.Errorf("%s: %w", f.Name, err)
+		}
+
+		repoStr := string(repoContent)
+		diskStr := string(diskData)
+
+		if repoStr == diskStr {
+			continue
+		}
+
+		edits := myers.ComputeEdits(span.URIFromPath(f.Name), repoStr, diskStr)
+		diff := fmt.Sprint(gotextdiff.ToUnified("a/"+f.Name, "b/"+f.Name, repoStr, edits))
+		if diff != "" {
+			fmt.Print(diff)
+			hasDiff = true
+		}
+	}
+
+	if !hasDiff {
+		fmt.Println("no changes")
+	}
+	return nil
+}
+
+func expandFile(r *repo.Repo, uuid string) ([]byte, error) {
+	rid, ok := blob.Exists(r.DB(), uuid)
+	if !ok {
+		return nil, fmt.Errorf("blob %s not found", uuid)
+	}
+	return content.Expand(r.DB(), rid)
+}

--- a/cmd/edgesync/repo_extract.go
+++ b/cmd/edgesync/repo_extract.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoExtractCmd struct {
+	Version string   `help:"Version to extract from (default: tip)"`
+	Files   []string `arg:"" optional:"" help:"Files to extract (default: all)"`
+	Dir     string   `short:"d" help:"Output directory" default:"."`
+}
+
+func (c *RepoExtractCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	allFiles, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	// Filter to requested files if specified.
+	var files []manifest.FileEntry
+	if len(c.Files) > 0 {
+		wanted := make(map[string]bool)
+		for _, f := range c.Files {
+			wanted[f] = true
+		}
+		for _, f := range allFiles {
+			if wanted[f.Name] {
+				files = append(files, f)
+			}
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("no matching files found")
+		}
+	} else {
+		files = allFiles
+	}
+
+	for _, f := range files {
+		fileRid, ok := blob.Exists(r.DB(), f.UUID)
+		if !ok {
+			return fmt.Errorf("blob %s not found for %s", f.UUID, f.Name)
+		}
+		data, err := content.Expand(r.DB(), fileRid)
+		if err != nil {
+			return fmt.Errorf("expanding %s: %w", f.Name, err)
+		}
+
+		outPath := filepath.Join(c.Dir, f.Name)
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
+
+		perm := os.FileMode(0o644)
+		if f.Perm == "x" {
+			perm = 0o755
+		}
+		if err := os.WriteFile(outPath, data, perm); err != nil {
+			return err
+		}
+		fmt.Println(f.Name)
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_hash.go
+++ b/cmd/edgesync/repo_hash.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dmestas/edgesync/go-libfossil/hash"
+)
+
+type RepoHashCmd struct {
+	Files []string `arg:"" required:"" help:"Files to hash"`
+	SHA3  bool     `name:"sha3" help:"Use SHA3-256 instead of SHA1"`
+}
+
+func (c *RepoHashCmd) Run(g *Globals) error {
+	for _, path := range c.Files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		var h string
+		if c.SHA3 {
+			h = hash.SHA3(data)
+		} else {
+			h = hash.SHA1(data)
+		}
+		fmt.Printf("%s  %s\n", h, path)
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_info.go
+++ b/cmd/edgesync/repo_info.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+type RepoInfoCmd struct{}
+
+func (c *RepoInfoCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	var blobCount, deltaCount, phantomCount int
+	var totalSize int64
+	var projectCode, serverCode string
+
+	r.DB().QueryRow("SELECT count(*) FROM blob WHERE size >= 0").Scan(&blobCount)
+	r.DB().QueryRow("SELECT count(*) FROM delta").Scan(&deltaCount)
+	r.DB().QueryRow("SELECT count(*) FROM phantom").Scan(&phantomCount)
+	r.DB().QueryRow("SELECT coalesce(sum(size),0) FROM blob WHERE size >= 0").Scan(&totalSize)
+	r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode)
+	r.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&serverCode)
+
+	fmt.Printf("project-code:  %s\n", projectCode)
+	fmt.Printf("server-code:   %s\n", serverCode)
+	fmt.Printf("blobs:         %d\n", blobCount)
+	fmt.Printf("deltas:        %d\n", deltaCount)
+	fmt.Printf("phantoms:      %d\n", phantomCount)
+	fmt.Printf("total size:    %d bytes\n", totalSize)
+	return nil
+}

--- a/cmd/edgesync/repo_ls.go
+++ b/cmd/edgesync/repo_ls.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoLsCmd struct {
+	Version string `arg:"" optional:"" help:"Version to list (default: tip)"`
+	Long    bool   `short:"l" help:"Show sizes and hashes"`
+}
+
+func (c *RepoLsCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if c.Long {
+			fmt.Printf("%s  %s  %s\n", f.UUID[:10], f.Perm, f.Name)
+		} else {
+			fmt.Println(f.Name)
+		}
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_merge.go
+++ b/cmd/edgesync/repo_merge.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/merge"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+type RepoMergeCmd struct {
+	Version  string             `arg:"" help:"Version to merge into current checkout"`
+	Strategy string             `help:"Override merge strategy for all files"`
+	DryRun   bool               `help:"Show what would be merged without writing"`
+	Dir      string             `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoMergeCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// Resolve local (tip) and remote versions.
+	localRid, err := resolveRID(r, "tip")
+	if err != nil {
+		return fmt.Errorf("resolving local tip: %w", err)
+	}
+	remoteRid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return fmt.Errorf("resolving remote version: %w", err)
+	}
+
+	// Find common ancestor.
+	ancestorRid, err := merge.FindCommonAncestor(r, localRid, remoteRid)
+	if err != nil {
+		return fmt.Errorf("finding common ancestor: %w", err)
+	}
+
+	var ancestorUUID string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", ancestorRid).Scan(&ancestorUUID)
+	if len(ancestorUUID) > 10 {
+		ancestorUUID = ancestorUUID[:10]
+	}
+	fmt.Printf("common ancestor: %s (rid=%d)\n", ancestorUUID, ancestorRid)
+
+	// Load file lists for all three versions.
+	baseFiles, err := manifest.ListFiles(r, ancestorRid)
+	if err != nil {
+		return fmt.Errorf("listing ancestor files: %w", err)
+	}
+	localFiles, err := manifest.ListFiles(r, localRid)
+	if err != nil {
+		return fmt.Errorf("listing local files: %w", err)
+	}
+	remoteFiles, err := manifest.ListFiles(r, remoteRid)
+	if err != nil {
+		return fmt.Errorf("listing remote files: %w", err)
+	}
+
+	// Build maps: filename → UUID.
+	baseMap := fileMap(baseFiles)
+	localMap := fileMap(localFiles)
+	remoteMap := fileMap(remoteFiles)
+
+	// Load resolver for strategy selection.
+	resolver := merge.LoadResolver(r, localRid)
+
+	// Open checkout DB for vfile updates.
+	ckout, err := openCheckout(c.Dir)
+	if err != nil && !c.DryRun {
+		return err
+	}
+	if ckout != nil {
+		defer ckout.Close()
+	}
+	vid, _ := checkoutVid(ckout)
+
+	merged, conflicts := 0, 0
+
+	// Find files that differ between local and remote.
+	allFiles := make(map[string]bool)
+	for name := range localMap {
+		allFiles[name] = true
+	}
+	for name := range remoteMap {
+		allFiles[name] = true
+	}
+
+	for name := range allFiles {
+		localUUID := localMap[name]
+		remoteUUID := remoteMap[name]
+		baseUUID := baseMap[name]
+
+		// Skip if both sides have the same content.
+		if localUUID == remoteUUID {
+			continue
+		}
+
+		// Determine strategy.
+		stratName := c.Strategy
+		if stratName == "" {
+			stratName = resolver.Resolve(name)
+		}
+		strat, ok := merge.StrategyByName(stratName)
+		if !ok {
+			return fmt.Errorf("unknown strategy %q for %s", stratName, name)
+		}
+
+		// Load content for the three versions.
+		baseContent := loadBlobByUUID(r, baseUUID)
+		localContent := loadBlobByUUID(r, localUUID)
+		remoteContent := loadBlobByUUID(r, remoteUUID)
+
+		if c.DryRun {
+			fmt.Printf("  [%s] %s\n", stratName, name)
+			continue
+		}
+
+		result, err := strat.Merge(baseContent, localContent, remoteContent)
+		if err != nil {
+			return fmt.Errorf("merging %s: %w", name, err)
+		}
+
+		outPath := filepath.Join(c.Dir, name)
+		os.MkdirAll(filepath.Dir(outPath), 0o755)
+
+		if result.Clean {
+			os.WriteFile(outPath, result.Content, 0o644)
+			if ckout != nil {
+				ckout.Exec("UPDATE vfile SET chnged=1 WHERE pathname=? AND vid=?", name, vid)
+			}
+			fmt.Printf("  [merged]   %s (%s)\n", name, stratName)
+			merged++
+		} else if strat.Name() == "conflict-fork" {
+			// ConflictFork: write to conflict table, keep local in working dir.
+			merge.EnsureConflictTable(r)
+			var baseRID, localRID, remoteRID int64
+			r.DB().QueryRow("SELECT rid FROM blob WHERE uuid=?", baseUUID).Scan(&baseRID)
+			r.DB().QueryRow("SELECT rid FROM blob WHERE uuid=?", localUUID).Scan(&localRID)
+			r.DB().QueryRow("SELECT rid FROM blob WHERE uuid=?", remoteUUID).Scan(&remoteRID)
+			merge.RecordConflictFork(r, name, baseRID, localRID, remoteRID)
+			fmt.Printf("  [fork]     %s (conflict-fork: all versions preserved)\n", name)
+			conflicts++
+		} else {
+			// Standard conflict: markers + sidecar files + vfile.chnged=5.
+			os.WriteFile(outPath, result.Content, 0o644)
+			os.WriteFile(outPath+".LOCAL", localContent, 0o644)
+			os.WriteFile(outPath+".BASELINE", baseContent, 0o644)
+			os.WriteFile(outPath+".MERGE", remoteContent, 0o644)
+			if ckout != nil {
+				ckout.Exec("UPDATE vfile SET chnged=5 WHERE pathname=? AND vid=?", name, vid)
+			}
+			fmt.Printf("  [CONFLICT] %s (%s, %d regions)\n", name, stratName, len(result.Conflicts))
+			conflicts++
+		}
+	}
+
+	fmt.Printf("\n%d files merged, %d conflicts\n", merged, conflicts)
+	return nil
+}
+
+func fileMap(files []manifest.FileEntry) map[string]string {
+	m := make(map[string]string)
+	for _, f := range files {
+		m[f.Name] = f.UUID
+	}
+	return m
+}
+
+func loadBlobByUUID(r *repo.Repo, uuid string) []byte {
+	if uuid == "" {
+		return nil
+	}
+	rid, ok := blob.Exists(r.DB(), uuid)
+	if !ok {
+		return nil
+	}
+	data, err := content.Expand(r.DB(), rid)
+	if err != nil {
+		return nil
+	}
+	return data
+}

--- a/cmd/edgesync/repo_merge_resolve.go
+++ b/cmd/edgesync/repo_merge_resolve.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/merge"
+)
+
+type RepoMergeResolveCmd struct {
+	File string `arg:"" help:"File to mark as resolved"`
+	Dir  string `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoMergeResolveCmd) Run(g *Globals) error {
+	resolved := false
+
+	// Try standard conflict: reset vfile.chnged from 5 to 1.
+	ckout, err := openCheckout(c.Dir)
+	if err == nil {
+		defer ckout.Close()
+		vid, _ := checkoutVid(ckout)
+		result, err := ckout.Exec("UPDATE vfile SET chnged=1 WHERE pathname=? AND vid=? AND chnged=5", c.File, vid)
+		if err == nil {
+			affected, _ := result.RowsAffected()
+			if affected > 0 {
+				// Delete sidecar files.
+				base := filepath.Join(c.Dir, c.File)
+				os.Remove(base + ".LOCAL")
+				os.Remove(base + ".BASELINE")
+				os.Remove(base + ".MERGE")
+				fmt.Printf("resolved: %s (conflict markers)\n", c.File)
+				resolved = true
+			}
+		}
+	}
+
+	// Try conflict-fork: delete from conflict table.
+	r, err := openRepo(g)
+	if err == nil {
+		defer r.Close()
+		err := merge.ResolveConflictFork(r, c.File)
+		if err == nil {
+			fmt.Printf("resolved: %s (conflict-fork)\n", c.File)
+			resolved = true
+		}
+	}
+
+	if !resolved {
+		return fmt.Errorf("%s: no conflict found", c.File)
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_new.go
+++ b/cmd/edgesync/repo_new.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+)
+
+type RepoNewCmd struct {
+	Path string `arg:"" help:"Path for new repository file"`
+	User string `help:"Default user name" default:""`
+}
+
+func (c *RepoNewCmd) Run(g *Globals) error {
+	user := c.User
+	if user == "" {
+		user = currentUser()
+	}
+	r, err := repo.Create(c.Path, user, simio.CryptoRand{})
+	if err != nil {
+		return err
+	}
+	r.Close()
+	fmt.Printf("created repository: %s\n", c.Path)
+	return nil
+}

--- a/cmd/edgesync/repo_open.go
+++ b/cmd/edgesync/repo_open.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "modernc.org/sqlite"
+)
+
+type RepoOpenCmd struct {
+	Dir string `arg:"" optional:"" help:"Checkout directory (default: current dir)" default:"."`
+}
+
+func (c *RepoOpenCmd) Run(g *Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+
+	absRepo, err := filepath.Abs(g.Repo)
+	if err != nil {
+		return err
+	}
+
+	ckoutPath := filepath.Join(c.Dir, ".fslckout")
+	if _, err := os.Stat(ckoutPath); err == nil {
+		return fmt.Errorf("checkout already exists: %s", ckoutPath)
+	}
+
+	// Create checkout database with vfile, vvar, vmerge tables.
+	db, err := sql.Open("sqlite", ckoutPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	schema := `
+		CREATE TABLE vvar(
+			name TEXT PRIMARY KEY NOT NULL,
+			value CLOB,
+			CHECK(typeof(name)='text' AND length(name)>=1)
+		) WITHOUT ROWID;
+		CREATE TABLE vfile(
+			id INTEGER PRIMARY KEY,
+			vid INTEGER,
+			chnged INT DEFAULT 0,
+			deleted BOOLEAN DEFAULT 0,
+			isexe BOOLEAN,
+			islink BOOLEAN,
+			rid INTEGER,
+			mrid INTEGER,
+			mtime INTEGER,
+			pathname TEXT,
+			origname TEXT,
+			mhash TEXT,
+			UNIQUE(pathname,vid)
+		);
+		CREATE TABLE vmerge(
+			id INTEGER REFERENCES vfile,
+			merge INTEGER,
+			mhash TEXT
+		);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		os.Remove(ckoutPath)
+		return fmt.Errorf("creating checkout schema: %w", err)
+	}
+
+	// Resolve tip checkin from repo.
+	r, err := openRepo(g)
+	if err != nil {
+		os.Remove(ckoutPath)
+		return err
+	}
+	tipRid, err := resolveRID(r, "tip")
+	if err != nil {
+		// Empty repo — no checkins yet.
+		tipRid = 0
+	}
+	var tipHash string
+	if tipRid > 0 {
+		r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", tipRid).Scan(&tipHash)
+	}
+	r.Close()
+
+	// Populate vvar with checkout metadata.
+	vvars := map[string]string{
+		"repository":     absRepo,
+		"checkout":       fmt.Sprintf("%d", tipRid),
+		"checkout-hash":  tipHash,
+		"undo_available": "0",
+		"undo_checkout":  "0",
+	}
+	for k, v := range vvars {
+		if _, err := db.Exec("INSERT INTO vvar(name,value) VALUES(?,?)", k, v); err != nil {
+			return fmt.Errorf("setting vvar %s: %w", k, err)
+		}
+	}
+
+	fmt.Printf("opened checkout in %s (repo: %s)\n", c.Dir, absRepo)
+	if tipRid > 0 {
+		fmt.Printf("checked out version %s\n", tipHash[:10])
+	} else {
+		fmt.Println("empty repository — no checkins yet")
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_open.go
+++ b/cmd/edgesync/repo_open.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
 	_ "modernc.org/sqlite"
 )
 
@@ -96,6 +97,27 @@ func (c *RepoOpenCmd) Run(g *Globals) error {
 		if _, err := db.Exec("INSERT INTO vvar(name,value) VALUES(?,?)", k, v); err != nil {
 			return fmt.Errorf("setting vvar %s: %w", k, err)
 		}
+	}
+
+	// Populate vfile from tip manifest.
+	if tipRid > 0 {
+		rr, err := openRepo(g)
+		if err != nil {
+			return err
+		}
+		files, err := manifest.ListFiles(rr, tipRid)
+		if err == nil {
+			for _, f := range files {
+				isExe := f.Perm == "x"
+				// Look up the blob rid for this file's UUID.
+				var fileRid int64
+				rr.DB().QueryRow("SELECT rid FROM blob WHERE uuid=?", f.UUID).Scan(&fileRid)
+				db.Exec(`INSERT INTO vfile(vid, chnged, deleted, isexe, islink, rid, mrid, pathname, mhash)
+					VALUES(?, 0, 0, ?, 0, ?, ?, ?, ?)`,
+					tipRid, isExe, fileRid, fileRid, f.Name, f.UUID)
+			}
+		}
+		rr.Close()
 	}
 
 	fmt.Printf("opened checkout in %s (repo: %s)\n", c.Dir, absRepo)

--- a/cmd/edgesync/repo_query.go
+++ b/cmd/edgesync/repo_query.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RepoQueryCmd struct {
+	SQL string `arg:"" help:"SQL query to execute"`
+}
+
+func (c *RepoQueryCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	sql := strings.TrimSpace(c.SQL)
+
+	// SELECT queries return rows; everything else returns affected count.
+	if strings.HasPrefix(strings.ToUpper(sql), "SELECT") || strings.HasPrefix(strings.ToUpper(sql), "PRAGMA") {
+		rows, err := r.DB().Query(sql)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		if err != nil {
+			return err
+		}
+
+		// Print header
+		fmt.Println(strings.Join(cols, "|"))
+
+		// Print rows
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		for rows.Next() {
+			rows.Scan(ptrs...)
+			parts := make([]string, len(cols))
+			for i, v := range vals {
+				parts[i] = fmt.Sprintf("%v", v)
+			}
+			fmt.Println(strings.Join(parts, "|"))
+		}
+		return rows.Err()
+	}
+
+	result, err := r.DB().Exec(sql)
+	if err != nil {
+		return err
+	}
+	affected, _ := result.RowsAffected()
+	fmt.Printf("%d rows affected\n", affected)
+	return nil
+}

--- a/cmd/edgesync/repo_rename.go
+++ b/cmd/edgesync/repo_rename.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+)
+
+type RepoRenameCmd struct {
+	From string `arg:"" help:"Current file name"`
+	To   string `arg:"" help:"New file name"`
+	Dir  string `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoRenameCmd) Run(g *Globals) error {
+	ckout, err := openCheckout(c.Dir)
+	if err != nil {
+		return err
+	}
+	defer ckout.Close()
+
+	vid, err := checkoutVid(ckout)
+	if err != nil {
+		return err
+	}
+
+	var id int64
+	err = ckout.QueryRow("SELECT id FROM vfile WHERE pathname=? AND vid=?", c.From, vid).Scan(&id)
+	if err != nil {
+		return fmt.Errorf("%s: not tracked in checkout", c.From)
+	}
+
+	// Check target doesn't already exist in vfile.
+	var existing int64
+	if ckout.QueryRow("SELECT id FROM vfile WHERE pathname=? AND vid=?", c.To, vid).Scan(&existing) == nil {
+		return fmt.Errorf("%s: already tracked in checkout", c.To)
+	}
+
+	_, err = ckout.Exec("UPDATE vfile SET pathname=?, origname=?, chnged=1 WHERE id=?", c.To, c.From, id)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("RENAMED  %s -> %s\n", c.From, c.To)
+	return nil
+}

--- a/cmd/edgesync/repo_resolve.go
+++ b/cmd/edgesync/repo_resolve.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+
+type RepoResolveCmd struct {
+	Name string `arg:"" help:"Symbolic name, UUID, or prefix to resolve (e.g. trunk, tip, UUID prefix)"`
+}
+
+func (c *RepoResolveCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Name)
+	if err != nil {
+		return err
+	}
+
+	var uuid string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", rid).Scan(&uuid)
+
+	fmt.Printf("rid:  %d\n", rid)
+	fmt.Printf("uuid: %s\n", uuid)
+	return nil
+}

--- a/cmd/edgesync/repo_revert.go
+++ b/cmd/edgesync/repo_revert.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+)
+
+type RepoRevertCmd struct {
+	Files []string `arg:"" optional:"" help:"Files to revert (default: all)"`
+	Dir   string   `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoRevertCmd) Run(g *Globals) error {
+	ckout, err := openCheckout(c.Dir)
+	if err != nil {
+		return err
+	}
+	defer ckout.Close()
+
+	vid, err := checkoutVid(ckout)
+	if err != nil {
+		return err
+	}
+
+	if len(c.Files) == 0 {
+		// Revert all: reset changed/deleted flags, remove untracked additions.
+		result, err := ckout.Exec("UPDATE vfile SET chnged=0, deleted=0, origname=NULL WHERE vid=? AND (chnged=1 OR deleted=1)", vid)
+		if err != nil {
+			return err
+		}
+		affected, _ := result.RowsAffected()
+
+		// Remove files that were newly added (rid=0 means not in repo yet).
+		removed, err := ckout.Exec("DELETE FROM vfile WHERE vid=? AND rid=0", vid)
+		if err != nil {
+			return err
+		}
+		removedCount, _ := removed.RowsAffected()
+
+		fmt.Printf("reverted %d files, removed %d staged additions\n", affected, removedCount)
+	} else {
+		for _, name := range c.Files {
+			var id, rid int64
+			err := ckout.QueryRow("SELECT id, rid FROM vfile WHERE pathname=? AND vid=?", name, vid).Scan(&id, &rid)
+			if err != nil {
+				return fmt.Errorf("%s: not tracked in checkout", name)
+			}
+			if rid == 0 {
+				// Newly added — remove from vfile.
+				ckout.Exec("DELETE FROM vfile WHERE id=?", id)
+				fmt.Printf("UNSTAGED %s\n", name)
+			} else {
+				// Existing — reset flags.
+				ckout.Exec("UPDATE vfile SET chnged=0, deleted=0, origname=NULL WHERE id=?", id)
+				fmt.Printf("REVERTED %s\n", name)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_rm.go
+++ b/cmd/edgesync/repo_rm.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+)
+
+type RepoRmCmd struct {
+	Files []string `arg:"" required:"" help:"Files to stage for removal"`
+	Dir   string   `short:"d" help:"Checkout directory" default:"."`
+}
+
+func (c *RepoRmCmd) Run(g *Globals) error {
+	ckout, err := openCheckout(c.Dir)
+	if err != nil {
+		return err
+	}
+	defer ckout.Close()
+
+	vid, err := checkoutVid(ckout)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range c.Files {
+		var id int64
+		err := ckout.QueryRow("SELECT id FROM vfile WHERE pathname=? AND vid=?", name, vid).Scan(&id)
+		if err != nil {
+			return fmt.Errorf("%s: not tracked in checkout", name)
+		}
+		ckout.Exec("UPDATE vfile SET deleted=1 WHERE id=?", id)
+		fmt.Printf("REMOVED  %s\n", name)
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_status.go
+++ b/cmd/edgesync/repo_status.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoStatusCmd struct {
+	Dir string `short:"d" help:"Checkout directory to scan" default:"."`
+}
+
+func (c *RepoStatusCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	tipRid, err := resolveRID(r, "tip")
+	if err != nil {
+		fmt.Println("empty repository — no checkins")
+		return nil
+	}
+
+	// Get manifest files for tip.
+	manifestFiles, err := manifest.ListFiles(r, tipRid)
+	if err != nil {
+		return err
+	}
+
+	// Build map of manifest files: name → UUID.
+	expected := make(map[string]string)
+	for _, f := range manifestFiles {
+		expected[f.Name] = f.UUID
+	}
+
+	// Scan working directory.
+	seen := make(map[string]bool)
+	err = filepath.WalkDir(c.Dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == ".fslckout" || name == "_FOSSIL_" || name == ".fsl" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, err := filepath.Rel(c.Dir, path)
+		if err != nil {
+			return err
+		}
+		// Skip hidden files and the checkout DB.
+		if strings.HasPrefix(filepath.Base(relPath), ".") {
+			return nil
+		}
+
+		seen[relPath] = true
+
+		uuid, inManifest := expected[relPath]
+		if !inManifest {
+			fmt.Printf("EXTRA    %s\n", relPath)
+			return nil
+		}
+
+		// Check if content changed by comparing SHA1 hash.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		h := sha1.Sum(data)
+		diskHash := hex.EncodeToString(h[:])
+
+		if diskHash != uuid {
+			// Also check against expanded blob content in case of deltas.
+			fileRid, ok := blob.Exists(r.DB(), uuid)
+			if ok {
+				blobData, err := content.Expand(r.DB(), fileRid)
+				if err == nil {
+					bh := sha1.Sum(blobData)
+					blobHash := hex.EncodeToString(bh[:])
+					if blobHash == diskHash {
+						return nil // matches expanded content
+					}
+				}
+			}
+			fmt.Printf("EDITED   %s\n", relPath)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Check for missing files.
+	for name := range expected {
+		if !seen[name] {
+			fmt.Printf("MISSING  %s\n", name)
+		}
+	}
+
+	return nil
+}

--- a/cmd/edgesync/repo_tag.go
+++ b/cmd/edgesync/repo_tag.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+)
+
+type RepoTagCmd struct {
+	Ls  RepoTagLsCmd  `cmd:"" help:"List tags on an artifact"`
+	Add RepoTagAddCmd `cmd:"" help:"Add a tag to an artifact"`
+}
+
+type RepoTagLsCmd struct {
+	Version string `arg:"" optional:"" help:"Version to list tags for (default: tip)"`
+}
+
+func (c *RepoTagLsCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	rows, err := r.DB().Query(`
+		SELECT t.tagname, tx.value,
+		       CASE tx.tagtype WHEN 1 THEN '+' WHEN 2 THEN '*' ELSE '-' END as type
+		FROM tagxref tx
+		JOIN tag t ON t.tagid=tx.tagid
+		WHERE tx.rid=? AND tx.tagtype>0
+		ORDER BY t.tagname`, rid)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, value, tagtype string
+		rows.Scan(&name, &value, &tagtype)
+		if value != "" {
+			fmt.Printf("%s%s=%s\n", tagtype, name, value)
+		} else {
+			fmt.Printf("%s%s\n", tagtype, name)
+		}
+	}
+	return rows.Err()
+}
+
+type RepoTagAddCmd struct {
+	Tag     string `arg:"" help:"Tag name"`
+	Value   string `arg:"" optional:"" help:"Tag value (optional)"`
+	Version string `help:"Version to tag (default: tip)"`
+}
+
+func (c *RepoTagAddCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	// Get or create the tag ID.
+	tagName := "sym-" + c.Tag
+	var tagID int64
+	err = r.DB().QueryRow("SELECT tagid FROM tag WHERE tagname=?", tagName).Scan(&tagID)
+	if err != nil {
+		result, err := r.DB().Exec("INSERT INTO tag(tagname) VALUES(?)", tagName)
+		if err != nil {
+			return fmt.Errorf("creating tag: %w", err)
+		}
+		tagID, _ = result.LastInsertId()
+	}
+
+	// Insert tagxref: tagtype 1 = singleton (+), 2 = propagating (*)
+	_, err = r.DB().Exec(`
+		INSERT OR REPLACE INTO tagxref(tagid, tagtype, srcid, rid, mtime, value)
+		VALUES(?, 1, 0, ?, julianday('now'), ?)`,
+		tagID, rid, c.Value)
+	if err != nil {
+		return fmt.Errorf("applying tag: %w", err)
+	}
+
+	var uuid string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", rid).Scan(&uuid)
+	if len(uuid) > 10 {
+		uuid = uuid[:10]
+	}
+	fmt.Printf("tagged %s with %s\n", uuid, c.Tag)
+	return nil
+}

--- a/cmd/edgesync/repo_timeline.go
+++ b/cmd/edgesync/repo_timeline.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoTimelineCmd struct {
+	Limit int `short:"n" default:"20" help:"Number of entries"`
+}
+
+func (c *RepoTimelineCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	tipRid, err := resolveRID(r, "")
+	if err != nil {
+		return err
+	}
+
+	entries, err := manifest.Log(r, manifest.LogOpts{Start: tipRid, Limit: c.Limit})
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		uuid := e.UUID
+		if len(uuid) > 10 {
+			uuid = uuid[:10]
+		}
+		fmt.Printf("%s  %s  %s  %s\n", uuid, e.Time.Format("2006-01-02 15:04"), e.User, e.Comment)
+	}
+	return nil
+}

--- a/cmd/edgesync/repo_verify.go
+++ b/cmd/edgesync/repo_verify.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+type RepoVerifyCmd struct{}
+
+func (c *RepoVerifyCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := r.Verify(); err != nil {
+		return fmt.Errorf("verification failed: %w", err)
+	}
+	fmt.Println("repository integrity verified")
+	return nil
+}

--- a/cmd/edgesync/repo_wiki.go
+++ b/cmd/edgesync/repo_wiki.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/deck"
+)
+
+type RepoWikiCmd struct {
+	Ls     RepoWikiLsCmd     `cmd:"" help:"List wiki pages"`
+	Export RepoWikiExportCmd `cmd:"" help:"Export a wiki page"`
+}
+
+type RepoWikiLsCmd struct{}
+
+func (c *RepoWikiLsCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// Wiki pages are stored as artifacts with an L-card (page title).
+	// Find them by scanning events of type 'w' (wiki), or by looking for
+	// blobs that parse as wiki manifests.
+	rows, err := r.DB().Query(`
+		SELECT DISTINCT b.uuid, b.rid FROM event e
+		JOIN blob b ON b.rid=e.objid
+		WHERE e.type='w'
+		ORDER BY e.mtime DESC`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var uuid string
+		var rid int64
+		rows.Scan(&uuid, &rid)
+
+		data, err := content.Expand(r.DB(), libfossil.FslID(rid))
+		if err != nil {
+			continue
+		}
+		d, err := deck.Parse(data)
+		if err != nil {
+			continue
+		}
+		if d.L != "" {
+			fmt.Printf("%-40s %s\n", d.L, uuid[:10])
+		}
+	}
+	return rows.Err()
+}
+
+type RepoWikiExportCmd struct {
+	Page   string `arg:"" help:"Wiki page name or artifact UUID"`
+	Output string `short:"o" help:"Output file (default: stdout)"`
+}
+
+func (c *RepoWikiExportCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// Try as UUID first, then search by page name.
+	var data []byte
+
+	rid, err := resolveRID(r, c.Page)
+	if err == nil {
+		// Resolved as UUID — expand and check if it's a wiki artifact.
+		data, err = content.Expand(r.DB(), rid)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Search by page title in wiki events.
+		rows, err := r.DB().Query(`
+			SELECT b.rid FROM event e
+			JOIN blob b ON b.rid=e.objid
+			WHERE e.type='w'
+			ORDER BY e.mtime DESC`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		found := false
+		for rows.Next() {
+			var rid int64
+			rows.Scan(&rid)
+			d, err := content.Expand(r.DB(), libfossil.FslID(rid))
+			if err != nil {
+				continue
+			}
+			parsed, err := deck.Parse(d)
+			if err != nil {
+				continue
+			}
+			if parsed.L == c.Page {
+				data = parsed.W
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("wiki page %q not found", c.Page)
+		}
+	}
+
+	// If we got raw artifact data (UUID path), parse it to extract W card.
+	if data != nil && rid > 0 {
+		parsed, err := deck.Parse(data)
+		if err == nil && len(parsed.W) > 0 {
+			data = parsed.W
+		}
+		// If not parseable as wiki, output raw content.
+	}
+
+	if c.Output != "" {
+		return os.WriteFile(c.Output, data, 0o644)
+	}
+	os.Stdout.Write(data)
+	return nil
+}

--- a/cmd/edgesync/sync_now.go
+++ b/cmd/edgesync/sync_now.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"syscall"
+)
+
+type SyncNowCmd struct {
+	PID int `arg:"" help:"PID of running agent to signal"`
+}
+
+func (c *SyncNowCmd) Run(g *Globals) error {
+	if c.PID <= 0 {
+		return fmt.Errorf("invalid PID: %d", c.PID)
+	}
+	return syscall.Kill(c.PID, syscall.SIGUSR1)
+}

--- a/cmd/edgesync/sync_start.go
+++ b/cmd/edgesync/sync_start.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dmestas/edgesync/leaf/agent"
+)
+
+type SyncStartCmd struct {
+	NATSUrl      string        `help:"NATS server URL" default:"nats://localhost:4222"`
+	PollInterval time.Duration `help:"Sync poll interval" default:"5s"`
+	Push         bool          `help:"Enable push" default:"true" negatable:""`
+	Pull         bool          `help:"Enable pull" default:"true" negatable:""`
+}
+
+func (c *SyncStartCmd) Run(g *Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+
+	a, err := agent.New(agent.Config{
+		RepoPath:     g.Repo,
+		NATSUrl:      c.NATSUrl,
+		PollInterval: c.PollInterval,
+		Push:         c.Push,
+		Pull:         c.Pull,
+	})
+	if err != nil {
+		return fmt.Errorf("agent: %w", err)
+	}
+
+	if err := a.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	log.Printf("edgesync sync agent running (repo=%s nats=%s poll=%s)", g.Repo, c.NATSUrl, c.PollInterval)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	log.Printf("shutting down...")
+	return a.Stop()
+}

--- a/docs/superpowers/plans/2026-03-16-edgesync-cli.md
+++ b/docs/superpowers/plans/2026-03-16-edgesync-cli.md
@@ -1,0 +1,811 @@
+# EdgeSync Unified CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `edgesync`, a single binary with kong-based grouped subcommands for repo operations (new, ci, co, ls, timeline, cat, info), sync agent (start, now), and bridge (serve).
+
+**Architecture:** Kong struct-tag CLI with one file per command in `cmd/edgesync/`. Commands delegate to existing go-libfossil packages. Shared `resolveRID` and `openRepo` helpers handle repo discovery and version resolution.
+
+**Tech Stack:** Go 1.23, `github.com/alecthomas/kong`, go-libfossil packages, leaf/agent, bridge/bridge
+
+**Spec:** `docs/superpowers/specs/2026-03-16-edgesync-cli-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `cmd/edgesync/main.go` | Entry point: kong.Parse + ctx.Run |
+| `cmd/edgesync/cli.go` | CLI struct tree, Globals, RepoCmd, SyncCmd, BridgeCmd, helpers (resolveRID, openRepo) |
+| `cmd/edgesync/repo_new.go` | RepoNewCmd — create repository |
+| `cmd/edgesync/repo_ci.go` | RepoCiCmd — checkin files |
+| `cmd/edgesync/repo_co.go` | RepoCoCmd — checkout version |
+| `cmd/edgesync/repo_ls.go` | RepoLsCmd — list files |
+| `cmd/edgesync/repo_timeline.go` | RepoTimelineCmd — show history |
+| `cmd/edgesync/repo_cat.go` | RepoCatCmd — dump artifact |
+| `cmd/edgesync/repo_info.go` | RepoInfoCmd — repo statistics |
+| `cmd/edgesync/sync_start.go` | SyncStartCmd — start leaf agent |
+| `cmd/edgesync/sync_now.go` | SyncNowCmd — signal running agent |
+| `cmd/edgesync/bridge_serve.go` | BridgeServeCmd — start bridge |
+
+---
+
+## Task 1: Kong dependency + main.go + cli.go scaffold
+
+**Files:**
+- Create: `cmd/edgesync/main.go`
+- Create: `cmd/edgesync/cli.go`
+
+- [ ] **Step 1: Add kong dependency**
+
+Run: `go get github.com/alecthomas/kong@latest`
+
+- [ ] **Step 2: Create main.go**
+
+```go
+package main
+
+import "github.com/alecthomas/kong"
+
+func main() {
+	var cli CLI
+	ctx := kong.Parse(&cli,
+		kong.Name("edgesync"),
+		kong.Description("EdgeSync — Fossil repo operations, NATS sync, and bridge"),
+		kong.UsageOnError(),
+	)
+	err := ctx.Run(&cli.Globals)
+	ctx.FatalIfErrorf(err)
+}
+```
+
+- [ ] **Step 3: Create cli.go with struct tree and helpers**
+
+```go
+package main
+
+import (
+	"fmt"
+	"os/user"
+	"time"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+type CLI struct {
+	Globals
+
+	Repo   RepoCmd   `cmd:"" help:"Repository operations"`
+	Sync   SyncCmd   `cmd:"" help:"Leaf agent sync"`
+	Bridge BridgeCmd `cmd:"" help:"NATS-to-Fossil bridge"`
+}
+
+type Globals struct {
+	Repo    string `short:"R" help:"Path to repository file" type:"path"`
+	Verbose bool   `short:"v" help:"Verbose output"`
+}
+
+type RepoCmd struct {
+	New      RepoNewCmd      `cmd:"" help:"Create a new repository"`
+	Ci       RepoCiCmd       `cmd:"" help:"Checkin file changes"`
+	Co       RepoCoCmd       `cmd:"" help:"Checkout a version"`
+	Ls       RepoLsCmd       `cmd:"" help:"List files in a version"`
+	Timeline RepoTimelineCmd `cmd:"" help:"Show repository history"`
+	Cat      RepoCatCmd      `cmd:"" help:"Output artifact content"`
+	Info     RepoInfoCmd     `cmd:"" help:"Repository statistics"`
+}
+
+type SyncCmd struct {
+	Start SyncStartCmd `cmd:"" help:"Start leaf agent daemon"`
+	Now   SyncNowCmd   `cmd:"" help:"Trigger immediate sync"`
+}
+
+type BridgeCmd struct {
+	Serve BridgeServeCmd `cmd:"" help:"Start NATS-to-Fossil bridge"`
+}
+
+// openRepo opens the repository specified by -R flag.
+func openRepo(g *Globals) (*repo.Repo, error) {
+	if g.Repo == "" {
+		return nil, fmt.Errorf("no repository specified (use -R <path>)")
+	}
+	return repo.Open(g.Repo)
+}
+
+// resolveRID resolves a version string to a rid.
+// Empty string = tip (most recent checkin). Otherwise UUID or prefix.
+func resolveRID(r *repo.Repo, version string) (libfossil.FslID, error) {
+	if version == "" {
+		var rid int64
+		err := r.DB().QueryRow(
+			"SELECT objid FROM event WHERE type='ci' ORDER BY mtime DESC LIMIT 1",
+		).Scan(&rid)
+		if err != nil {
+			return 0, fmt.Errorf("no checkins found")
+		}
+		return libfossil.FslID(rid), nil
+	}
+	var rid int64
+	err := r.DB().QueryRow(
+		"SELECT rid FROM blob WHERE uuid LIKE ?", version+"%",
+	).Scan(&rid)
+	if err != nil {
+		return 0, fmt.Errorf("artifact %q not found", version)
+	}
+	return libfossil.FslID(rid), nil
+}
+
+// currentUser returns the OS username for default checkin user.
+func currentUser() string {
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return "anonymous"
+}
+```
+
+Note: The command structs (`RepoNewCmd`, etc.) are defined in their own files. For now, create stubs so it compiles:
+
+- [ ] **Step 4: Create stub command files**
+
+Create each of the 10 command files with minimal structs and `Run` methods that return `nil`. Example for `repo_new.go`:
+
+```go
+package main
+
+type RepoNewCmd struct {
+	Path string `arg:"" help:"Path for new repository file"`
+	User string `help:"Default user name" default:""`
+}
+
+func (c *RepoNewCmd) Run(g *Globals) error {
+	return fmt.Errorf("not implemented")
+}
+```
+
+Do the same for all 10 commands — just the struct + `Run` returning "not implemented". This lets the CLI scaffold compile and show help.
+
+- [ ] **Step 5: Verify build and help output**
+
+Run: `go build ./cmd/edgesync/ && ./edgesync --help`
+Expected: Shows help with repo, sync, bridge groups.
+
+Run: `./edgesync repo --help`
+Expected: Shows new, ci, co, ls, timeline, cat, info subcommands.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/edgesync/ go.mod go.sum
+git commit -m "edgesync: scaffold CLI with kong, struct tree, and stub commands"
+```
+
+---
+
+## Task 2: repo new + repo info
+
+**Files:**
+- Modify: `cmd/edgesync/repo_new.go`
+- Modify: `cmd/edgesync/repo_info.go`
+
+- [ ] **Step 1: Implement repo new**
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+)
+
+type RepoNewCmd struct {
+	Path string `arg:"" help:"Path for new repository file"`
+	User string `help:"Default user name" default:""`
+}
+
+func (c *RepoNewCmd) Run(g *Globals) error {
+	user := c.User
+	if user == "" {
+		user = currentUser()
+	}
+	r, err := repo.Create(c.Path, user, simio.CryptoRand{})
+	if err != nil {
+		return err
+	}
+	r.Close()
+	fmt.Printf("created repository: %s\n", c.Path)
+	return nil
+}
+```
+
+- [ ] **Step 2: Implement repo info**
+
+```go
+package main
+
+import "fmt"
+
+type RepoInfoCmd struct{}
+
+func (c *RepoInfoCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	var blobCount, deltaCount, phantomCount int
+	var totalSize int64
+	var projectCode, serverCode string
+
+	r.DB().QueryRow("SELECT count(*) FROM blob WHERE size >= 0").Scan(&blobCount)
+	r.DB().QueryRow("SELECT count(*) FROM delta").Scan(&deltaCount)
+	r.DB().QueryRow("SELECT count(*) FROM phantom").Scan(&phantomCount)
+	r.DB().QueryRow("SELECT coalesce(sum(size),0) FROM blob WHERE size >= 0").Scan(&totalSize)
+	r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode)
+	r.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&serverCode)
+
+	fmt.Printf("project-code:  %s\n", projectCode)
+	fmt.Printf("server-code:   %s\n", serverCode)
+	fmt.Printf("blobs:         %d\n", blobCount)
+	fmt.Printf("deltas:        %d\n", deltaCount)
+	fmt.Printf("phantoms:      %d\n", phantomCount)
+	fmt.Printf("total size:    %d bytes\n", totalSize)
+	return nil
+}
+```
+
+- [ ] **Step 3: Test manually**
+
+Run: `go build ./cmd/edgesync/ && ./edgesync repo new /tmp/test-cli.fossil && ./edgesync -R /tmp/test-cli.fossil repo info && rm /tmp/test-cli.fossil`
+
+Expected: Creates repo, shows stats (1 blob from initial config, 0 deltas, etc.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/edgesync/repo_new.go cmd/edgesync/repo_info.go
+git commit -m "edgesync: implement repo new and repo info commands"
+```
+
+---
+
+## Task 3: repo ls + repo timeline + repo cat
+
+**Files:**
+- Modify: `cmd/edgesync/repo_ls.go`
+- Modify: `cmd/edgesync/repo_timeline.go`
+- Modify: `cmd/edgesync/repo_cat.go`
+
+- [ ] **Step 1: Implement repo ls**
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoLsCmd struct {
+	Version string `arg:"" optional:"" help:"Version to list (default: tip)"`
+	Long    bool   `short:"l" help:"Show sizes and hashes"`
+}
+
+func (c *RepoLsCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if c.Long {
+			fmt.Printf("%s  %s  %s\n", f.UUID[:10], f.Perm, f.Name)
+		} else {
+			fmt.Println(f.Name)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Implement repo timeline**
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoTimelineCmd struct {
+	Limit int `short:"n" default:"20" help:"Number of entries"`
+}
+
+func (c *RepoTimelineCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	tipRid, err := resolveRID(r, "")
+	if err != nil {
+		return err
+	}
+
+	entries, err := manifest.Log(r, manifest.LogOpts{Start: tipRid, Limit: c.Limit})
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		uuid := e.UUID
+		if len(uuid) > 10 {
+			uuid = uuid[:10]
+		}
+		fmt.Printf("%s  %s  %s  %s\n", uuid, e.Time.Format("2006-01-02 15:04"), e.User, e.Comment)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Implement repo cat**
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+)
+
+type RepoCatCmd struct {
+	Artifact string `arg:"" help:"Artifact UUID or prefix"`
+	Raw      bool   `help:"Output raw blob (no delta expansion)"`
+}
+
+func (c *RepoCatCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Artifact)
+	if err != nil {
+		return err
+	}
+
+	var data []byte
+	if c.Raw {
+		data, err = blob.Load(r.DB(), rid)
+	} else {
+		data, err = content.Expand(r.DB(), rid)
+	}
+	if err != nil {
+		return fmt.Errorf("reading artifact: %w", err)
+	}
+
+	os.Stdout.Write(data)
+	return nil
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `go build ./cmd/edgesync/`
+Expected: Compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/edgesync/repo_ls.go cmd/edgesync/repo_timeline.go cmd/edgesync/repo_cat.go
+git commit -m "edgesync: implement repo ls, timeline, and cat commands"
+```
+
+---
+
+## Task 4: repo ci + repo co
+
+**Files:**
+- Modify: `cmd/edgesync/repo_ci.go`
+- Modify: `cmd/edgesync/repo_co.go`
+
+- [ ] **Step 1: Implement repo ci**
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoCiCmd struct {
+	Message string   `short:"m" required:"" help:"Checkin comment"`
+	Files   []string `arg:"" required:"" help:"Files to checkin"`
+	User    string   `help:"Checkin user (default: OS username)"`
+	Parent  string   `help:"Parent version UUID (default: tip)"`
+}
+
+func (c *RepoCiCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// Resolve parent
+	var parentRid libfossil.FslID
+	if c.Parent != "" {
+		parentRid, err = resolveRID(r, c.Parent)
+		if err != nil {
+			return fmt.Errorf("resolving parent: %w", err)
+		}
+	}
+	// If no parent specified and repo has checkins, use tip
+	if c.Parent == "" {
+		parentRid, _ = resolveRID(r, "") // ignore error for initial checkin
+	}
+
+	// Read files
+	files := make([]manifest.File, len(c.Files))
+	for i, path := range c.Files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		files[i] = manifest.File{
+			Name:    filepath.Base(path),
+			Content: data,
+		}
+	}
+
+	user := c.User
+	if user == "" {
+		user = currentUser()
+	}
+
+	rid, uuid, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   files,
+		Comment: c.Message,
+		User:    user,
+		Parent:  parentRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("checkin %s (rid=%d)\n", uuid[:10], rid)
+	return nil
+}
+```
+
+Note: Add `libfossil "github.com/dmestas/edgesync/go-libfossil"` to imports for the `FslID` type.
+
+- [ ] **Step 2: Implement repo co**
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+)
+
+type RepoCoCmd struct {
+	Version string `arg:"" optional:"" help:"Version to checkout (default: tip)"`
+	Dir     string `short:"d" help:"Output directory (default: current dir)" default:"."`
+	Force   bool   `help:"Overwrite existing files"`
+}
+
+func (c *RepoCoCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	rid, err := resolveRID(r, c.Version)
+	if err != nil {
+		return err
+	}
+
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		fileRid, ok := blob.Exists(r.DB(), f.UUID)
+		if !ok {
+			return fmt.Errorf("blob %s not found for file %s", f.UUID, f.Name)
+		}
+		data, err := content.Expand(r.DB(), fileRid)
+		if err != nil {
+			return fmt.Errorf("expanding %s: %w", f.Name, err)
+		}
+
+		outPath := filepath.Join(c.Dir, f.Name)
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return err
+		}
+
+		if !c.Force {
+			if _, err := os.Stat(outPath); err == nil {
+				return fmt.Errorf("file exists: %s (use --force to overwrite)", outPath)
+			}
+		}
+
+		perm := os.FileMode(0o644)
+		if f.Perm == "x" {
+			perm = 0o755
+		}
+		if err := os.WriteFile(outPath, data, perm); err != nil {
+			return err
+		}
+
+		fmt.Printf("  %s\n", f.Name)
+	}
+
+	fmt.Printf("checked out %d files\n", len(files))
+	return nil
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `go build ./cmd/edgesync/`
+Expected: Compiles.
+
+- [ ] **Step 4: Manual end-to-end test**
+
+```bash
+./edgesync repo new /tmp/cli-test.fossil
+echo "hello world" > /tmp/hello.txt
+./edgesync -R /tmp/cli-test.fossil repo ci -m "initial commit" /tmp/hello.txt
+./edgesync -R /tmp/cli-test.fossil repo ls
+./edgesync -R /tmp/cli-test.fossil repo timeline
+mkdir -p /tmp/cli-checkout
+./edgesync -R /tmp/cli-test.fossil repo co -d /tmp/cli-checkout
+cat /tmp/cli-checkout/hello.txt
+rm -rf /tmp/cli-test.fossil /tmp/hello.txt /tmp/cli-checkout
+```
+
+Expected: Full lifecycle works — create, commit, list, timeline, checkout.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/edgesync/repo_ci.go cmd/edgesync/repo_co.go
+git commit -m "edgesync: implement repo ci and co commands"
+```
+
+---
+
+## Task 5: sync start + sync now + bridge serve
+
+**Files:**
+- Modify: `cmd/edgesync/sync_start.go`
+- Modify: `cmd/edgesync/sync_now.go`
+- Modify: `cmd/edgesync/bridge_serve.go`
+
+- [ ] **Step 1: Implement sync start**
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/dmestas/edgesync/leaf/agent"
+)
+
+type SyncStartCmd struct {
+	NATSUrl      string        `help:"NATS server URL" default:"nats://localhost:4222"`
+	PollInterval time.Duration `help:"Sync poll interval" default:"5s"`
+	Push         bool          `help:"Enable push" default:"true" negatable:""`
+	Pull         bool          `help:"Enable pull" default:"true" negatable:""`
+}
+
+func (c *SyncStartCmd) Run(g *Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+
+	a, err := agent.New(agent.Config{
+		RepoPath:     g.Repo,
+		NATSUrl:      c.NATSUrl,
+		PollInterval: c.PollInterval,
+		Push:         c.Push,
+		Pull:         c.Pull,
+	})
+	if err != nil {
+		return fmt.Errorf("agent: %w", err)
+	}
+
+	if err := a.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	log.Printf("edgesync sync agent running (repo=%s nats=%s poll=%s)", g.Repo, c.NATSUrl, c.PollInterval)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	log.Printf("shutting down...")
+	return a.Stop()
+}
+```
+
+- [ ] **Step 2: Implement sync now**
+
+```go
+package main
+
+import (
+	"fmt"
+	"syscall"
+)
+
+type SyncNowCmd struct {
+	PID int `arg:"" help:"PID of running agent to signal"`
+}
+
+func (c *SyncNowCmd) Run(g *Globals) error {
+	if c.PID <= 0 {
+		return fmt.Errorf("invalid PID: %d", c.PID)
+	}
+	return syscall.Kill(c.PID, syscall.SIGUSR1)
+}
+```
+
+- [ ] **Step 3: Implement bridge serve**
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dmestas/edgesync/bridge/bridge"
+)
+
+type BridgeServeCmd struct {
+	NATSUrl   string `help:"NATS server URL" default:"nats://localhost:4222"`
+	FossilURL string `required:"" help:"Fossil server HTTP URL"`
+	Project   string `required:"" help:"Project code for NATS subject"`
+}
+
+func (c *BridgeServeCmd) Run(g *Globals) error {
+	b, err := bridge.New(bridge.Config{
+		NATSUrl:     c.NATSUrl,
+		FossilURL:   c.FossilURL,
+		ProjectCode: c.Project,
+	})
+	if err != nil {
+		return fmt.Errorf("bridge: %w", err)
+	}
+
+	if err := b.Start(); err != nil {
+		return fmt.Errorf("start: %w", err)
+	}
+
+	log.Printf("edgesync bridge running (nats=%s fossil=%s project=%s)", c.NATSUrl, c.FossilURL, c.Project)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+
+	log.Printf("shutting down...")
+	return b.Stop()
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `go build ./cmd/edgesync/`
+Expected: Compiles. Don't run sync/bridge without NATS — just verify build.
+
+- [ ] **Step 5: Verify help**
+
+Run: `./edgesync sync --help && ./edgesync bridge --help`
+Expected: Shows start/now and serve subcommands with flags.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/edgesync/sync_start.go cmd/edgesync/sync_now.go cmd/edgesync/bridge_serve.go
+git commit -m "edgesync: implement sync start, sync now, and bridge serve commands"
+```
+
+---
+
+## Task 6: Full integration test
+
+- [ ] **Step 1: Run the full lifecycle**
+
+```bash
+go build ./cmd/edgesync/
+
+# Create repo
+./edgesync repo new /tmp/e2e-test.fossil
+
+# Check info
+./edgesync -R /tmp/e2e-test.fossil repo info
+
+# Commit a file
+echo "test content" > /tmp/testfile.txt
+./edgesync -R /tmp/e2e-test.fossil repo ci -m "first commit" /tmp/testfile.txt
+
+# List files
+./edgesync -R /tmp/e2e-test.fossil repo ls
+
+# Timeline
+./edgesync -R /tmp/e2e-test.fossil repo timeline
+
+# Cat the checkin manifest
+./edgesync -R /tmp/e2e-test.fossil repo cat <UUID-from-timeline>
+
+# Checkout
+mkdir -p /tmp/e2e-checkout
+./edgesync -R /tmp/e2e-test.fossil repo co -d /tmp/e2e-checkout --force
+cat /tmp/e2e-checkout/testfile.txt
+
+# Verify fossil CLI can read our repo
+fossil info /tmp/e2e-test.fossil
+
+# Cleanup
+rm -rf /tmp/e2e-test.fossil /tmp/testfile.txt /tmp/e2e-checkout
+```
+
+- [ ] **Step 2: Commit final state**
+
+```bash
+git add -A
+git commit -m "edgesync: CLI MVP complete — repo, sync, bridge commands"
+```

--- a/docs/superpowers/plans/2026-03-16-merge.md
+++ b/docs/superpowers/plans/2026-03-16-merge.md
@@ -1,0 +1,805 @@
+# 3-Way Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a 3-way merge system with swappable strategies (three-way text, last-writer-wins, binary, conflict-fork) in `go-libfossil/merge/`, with CLI commands in `cmd/edgesync/`.
+
+**Architecture:** `Strategy` interface with 4 implementations. Fork detection via leaf/plink tables. Resolver reads `.edgesync-merge` file + config fallback. Standard conflicts use Fossil-native `vfile.chnged=5` + sidecar files. Conflict-fork strategy uses an idiomatic Fossil `conflict` table.
+
+**Tech Stack:** Go 1.23, `gotextdiff/myers`, go-libfossil packages
+
+**Spec:** `docs/superpowers/specs/2026-03-16-merge-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `go-libfossil/merge/strategy.go` | Strategy interface, Result, Conflict, Fork types |
+| `go-libfossil/merge/ancestor.go` | FindCommonAncestor — BFS on plink |
+| `go-libfossil/merge/detect.go` | DetectForks — find divergent leaves |
+| `go-libfossil/merge/threeway.go` | ThreeWayText — Myers diff line-level merge |
+| `go-libfossil/merge/threeway_test.go` | Tests for 3-way merge |
+| `go-libfossil/merge/lastwriter.go` | LastWriterWins strategy |
+| `go-libfossil/merge/binary.go` | Binary strategy (always conflict) |
+| `go-libfossil/merge/fork.go` | ConflictFork strategy + conflict table |
+| `go-libfossil/merge/resolve.go` | Resolver — .edgesync-merge + config pattern matching |
+| `go-libfossil/merge/ancestor_test.go` | Tests for ancestor finding |
+| `go-libfossil/merge/detect_test.go` | Tests for fork detection |
+| `cmd/edgesync/repo_merge.go` | repo merge CLI command |
+| `cmd/edgesync/repo_conflicts.go` | repo conflicts CLI command |
+| `cmd/edgesync/repo_merge_resolve.go` | repo merge resolve CLI command |
+
+---
+
+## Task 1: Core types + Strategy interface
+
+**Files:**
+- Create: `go-libfossil/merge/strategy.go`
+
+- [ ] **Step 1: Create the merge package with core types**
+
+```go
+package merge
+
+import libfossil "github.com/dmestas/edgesync/go-libfossil"
+
+// Strategy merges three versions of content.
+type Strategy interface {
+	Name() string
+	Merge(base, local, remote []byte) (*Result, error)
+}
+
+// Result of a merge operation.
+type Result struct {
+	Content   []byte     // merged output (may contain conflict markers)
+	Conflicts []Conflict // unresolved conflict regions
+	Clean     bool       // true if no conflicts
+}
+
+// Conflict describes one conflicting region.
+type Conflict struct {
+	StartLine int
+	EndLine   int
+	Local     []byte
+	Remote    []byte
+	Base      []byte
+}
+
+// Fork represents two divergent checkins sharing a common ancestor.
+type Fork struct {
+	Ancestor  libfossil.FslID
+	LocalTip  libfossil.FslID
+	RemoteTip libfossil.FslID
+}
+
+// StrategyByName returns a strategy implementation by name.
+func StrategyByName(name string) (Strategy, bool) {
+	s, ok := strategies[name]
+	return s, ok
+}
+
+var strategies = map[string]Strategy{}
+
+// Register adds a strategy to the registry.
+func Register(s Strategy) {
+	strategies[s.Name()] = s
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./go-libfossil/merge/`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go-libfossil/merge/
+git commit -m "merge: add Strategy interface, Result, Conflict, Fork types"
+```
+
+---
+
+## Task 2: FindCommonAncestor
+
+**Files:**
+- Create: `go-libfossil/merge/ancestor.go`
+- Create: `go-libfossil/merge/ancestor_test.go`
+
+- [ ] **Step 1: Implement BFS ancestor finding**
+
+```go
+package merge
+
+import (
+	"fmt"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// FindCommonAncestor walks the plink DAG backwards from two checkin rids
+// to find their most recent common ancestor. Returns 0 if no common
+// ancestor exists (e.g., unrelated branches).
+func FindCommonAncestor(r *repo.Repo, ridA, ridB libfossil.FslID) (libfossil.FslID, error) {
+	if ridA == ridB {
+		return ridA, nil
+	}
+
+	visitedA := map[libfossil.FslID]bool{ridA: true}
+	visitedB := map[libfossil.FslID]bool{ridB: true}
+	queueA := []libfossil.FslID{ridA}
+	queueB := []libfossil.FslID{ridB}
+
+	for len(queueA) > 0 || len(queueB) > 0 {
+		// Expand A frontier.
+		if len(queueA) > 0 {
+			current := queueA[0]
+			queueA = queueA[1:]
+			if visitedB[current] {
+				return current, nil
+			}
+			rows, err := r.DB().Query("SELECT pid FROM plink WHERE cid=?", current)
+			if err != nil {
+				return 0, err
+			}
+			for rows.Next() {
+				var pid int64
+				rows.Scan(&pid)
+				rid := libfossil.FslID(pid)
+				if !visitedA[rid] {
+					visitedA[rid] = true
+					if visitedB[rid] {
+						rows.Close()
+						return rid, nil
+					}
+					queueA = append(queueA, rid)
+				}
+			}
+			rows.Close()
+		}
+
+		// Expand B frontier.
+		if len(queueB) > 0 {
+			current := queueB[0]
+			queueB = queueB[1:]
+			if visitedA[current] {
+				return current, nil
+			}
+			rows, err := r.DB().Query("SELECT pid FROM plink WHERE cid=?", current)
+			if err != nil {
+				return 0, err
+			}
+			for rows.Next() {
+				var pid int64
+				rows.Scan(&pid)
+				rid := libfossil.FslID(pid)
+				if !visitedB[rid] {
+					visitedB[rid] = true
+					if visitedA[rid] {
+						rows.Close()
+						return rid, nil
+					}
+					queueB = append(queueB, rid)
+				}
+			}
+			rows.Close()
+		}
+	}
+
+	return 0, fmt.Errorf("no common ancestor for rid %d and %d", ridA, ridB)
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+Test with a repo that has linear history (ancestor = parent) and branched history (ancestor = fork point). Use `manifest.Checkin` to create the history, then verify ancestor resolution.
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./go-libfossil/merge/ -v -count=1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go-libfossil/merge/
+git commit -m "merge: implement FindCommonAncestor via BFS on plink DAG"
+```
+
+---
+
+## Task 3: DetectForks
+
+**Files:**
+- Create: `go-libfossil/merge/detect.go`
+
+- [ ] **Step 1: Implement fork detection using the leaf table**
+
+```go
+package merge
+
+import (
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// DetectForks finds divergent branches in the repo.
+// Uses the leaf table (maintained by Fossil/manifest.Checkin) to find
+// checkins with no children, then finds common ancestors for each pair.
+func DetectForks(r *repo.Repo) ([]Fork, error) {
+	rows, err := r.DB().Query(`
+		SELECT l.rid FROM leaf l
+		JOIN event e ON e.objid=l.rid
+		WHERE e.type='ci'
+		ORDER BY e.mtime DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var leaves []libfossil.FslID
+	for rows.Next() {
+		var rid int64
+		rows.Scan(&rid)
+		leaves = append(leaves, libfossil.FslID(rid))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(leaves) <= 1 {
+		return nil, nil // no fork
+	}
+
+	// For each pair of leaves, find their common ancestor.
+	// In practice, most repos will have 2 leaves (one local, one remote).
+	var forks []Fork
+	for i := 0; i < len(leaves); i++ {
+		for j := i + 1; j < len(leaves); j++ {
+			ancestor, err := FindCommonAncestor(r, leaves[i], leaves[j])
+			if err != nil {
+				continue // unrelated branches
+			}
+			forks = append(forks, Fork{
+				Ancestor:  ancestor,
+				LocalTip:  leaves[i],
+				RemoteTip: leaves[j],
+			})
+		}
+	}
+	return forks, nil
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./go-libfossil/merge/ -v -count=1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go-libfossil/merge/detect.go
+git commit -m "merge: implement DetectForks using leaf table + FindCommonAncestor"
+```
+
+---
+
+## Task 4: ThreeWayText strategy
+
+**Files:**
+- Create: `go-libfossil/merge/threeway.go`
+- Create: `go-libfossil/merge/threeway_test.go`
+
+- [ ] **Step 1: Implement 3-way text merge**
+
+This is the core algorithm. Uses `gotextdiff/myers` to compute edit scripts from base→local and base→remote, then combines them:
+
+```go
+package merge
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/hexops/gotextdiff/myers"
+	"github.com/hexops/gotextdiff/span"
+)
+
+func init() { Register(&ThreeWayText{}) }
+
+type ThreeWayText struct{}
+
+func (t *ThreeWayText) Name() string { return "three-way" }
+
+func (t *ThreeWayText) Merge(base, local, remote []byte) (*Result, error) {
+	baseLines := splitLines(base)
+	localLines := splitLines(local)
+	remoteLines := splitLines(remote)
+
+	// Compute edit scripts.
+	baseStr := string(base)
+	localEdits := myers.ComputeEdits(span.URIFromPath("base"), baseStr, string(local))
+	remoteEdits := myers.ComputeEdits(span.URIFromPath("base"), baseStr, string(remote))
+
+	// Build line-level change maps: line number → new content.
+	localChanges := buildChangeMap(baseLines, localLines)
+	remoteChanges := buildChangeMap(baseLines, remoteLines)
+
+	// Merge line by line.
+	var result bytes.Buffer
+	var conflicts []Conflict
+	clean := true
+
+	// Walk through base lines, applying changes from both sides.
+	// ... (line-by-line merge logic)
+	// For MVP, use a simpler approach: if both changed the same region
+	// differently, emit conflict markers.
+
+	_ = localEdits
+	_ = remoteEdits
+
+	// Simplified approach for MVP: work at the whole-file level.
+	// If local == remote, they made the same change — use either.
+	if bytes.Equal(local, remote) {
+		return &Result{Content: local, Clean: true}, nil
+	}
+	// If only one side changed from base, use that side.
+	if bytes.Equal(base, local) {
+		return &Result{Content: remote, Clean: true}, nil
+	}
+	if bytes.Equal(base, remote) {
+		return &Result{Content: local, Clean: true}, nil
+	}
+
+	// Both changed differently — do line-level merge.
+	merged, confs := mergeLines(baseLines, localLines, remoteLines)
+	if len(confs) > 0 {
+		clean = false
+		conflicts = confs
+	}
+	result.WriteString(strings.Join(merged, ""))
+
+	return &Result{
+		Content:   result.Bytes(),
+		Conflicts: conflicts,
+		Clean:     clean,
+	}, nil
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	lines := strings.SplitAfter(string(data), "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// buildChangeMap computes which lines changed between base and modified.
+// Returns a map of base line index → modified content.
+func buildChangeMap(base, modified []string) map[int]string {
+	// Use longest common subsequence to align lines.
+	changes := make(map[int]string)
+	// ... implementation
+	return changes
+}
+
+// mergeLines does line-level 3-way merge.
+func mergeLines(base, local, remote []string) ([]string, []Conflict) {
+	// Use LCS to find matching regions, then merge non-matching regions.
+	// This is the core of the algorithm — implement carefully.
+	//
+	// For each region of base:
+	//   - If local and remote both match base: keep base
+	//   - If only local differs: take local
+	//   - If only remote differs: take remote
+	//   - If both differ identically: take either
+	//   - If both differ differently: conflict markers
+
+	var result []string
+	var conflicts []Conflict
+
+	// MVP: simple line-by-line comparison using diff hunks.
+	// ... full implementation needed here
+
+	return result, conflicts
+}
+```
+
+Note: The full line-level merge algorithm is complex. The implementer should reference `fossil/src/merge3.c` for the edit-triple approach, or use a simpler LCS-based approach. The key invariant: non-overlapping edits merge cleanly, overlapping identical edits take one copy, overlapping different edits produce conflict markers.
+
+- [ ] **Step 2: Write comprehensive tests**
+
+```go
+func TestThreeWayCleanMerge(t *testing.T) {
+	// Only local changed — take local.
+	base := []byte("line1\nline2\nline3\n")
+	local := []byte("line1\nmodified\nline3\n")
+	remote := []byte("line1\nline2\nline3\n")
+	r, _ := (&ThreeWayText{}).Merge(base, local, remote)
+	assert(t, r.Clean)
+	assert(t, string(r.Content) == "line1\nmodified\nline3\n")
+}
+
+func TestThreeWayBothChangedSame(t *testing.T) {
+	// Both made same change — no conflict.
+	base := []byte("old\n")
+	local := []byte("new\n")
+	remote := []byte("new\n")
+	r, _ := (&ThreeWayText{}).Merge(base, local, remote)
+	assert(t, r.Clean)
+}
+
+func TestThreeWayConflict(t *testing.T) {
+	// Both changed differently — conflict.
+	base := []byte("original\n")
+	local := []byte("local version\n")
+	remote := []byte("remote version\n")
+	r, _ := (&ThreeWayText{}).Merge(base, local, remote)
+	assert(t, !r.Clean)
+	assert(t, strings.Contains(string(r.Content), "<<<<<<<"))
+}
+
+func TestThreeWayNonOverlapping(t *testing.T) {
+	// Changes in different regions — merge cleanly.
+	base := []byte("aaa\nbbb\nccc\n")
+	local := []byte("AAA\nbbb\nccc\n")
+	remote := []byte("aaa\nbbb\nCCC\n")
+	r, _ := (&ThreeWayText{}).Merge(base, local, remote)
+	assert(t, r.Clean)
+	assert(t, string(r.Content) == "AAA\nbbb\nCCC\n")
+}
+```
+
+- [ ] **Step 3: Iterate until tests pass**
+
+The ThreeWayText implementation will need iteration. Start with the fast-path checks (both same, only one changed), then build the line-level merge.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add go-libfossil/merge/threeway.go go-libfossil/merge/threeway_test.go
+git commit -m "merge: implement ThreeWayText strategy with Myers diff"
+```
+
+---
+
+## Task 5: LastWriterWins + Binary + ConflictFork strategies
+
+**Files:**
+- Create: `go-libfossil/merge/lastwriter.go`
+- Create: `go-libfossil/merge/binary.go`
+- Create: `go-libfossil/merge/fork.go`
+
+- [ ] **Step 1: Implement LastWriterWins**
+
+```go
+package merge
+
+func init() { Register(&LastWriterWins{}) }
+
+type LastWriterWins struct{}
+
+func (l *LastWriterWins) Name() string { return "last-writer-wins" }
+
+func (l *LastWriterWins) Merge(base, local, remote []byte) (*Result, error) {
+	// The caller (CLI) passes the newer version as remote.
+	// Always clean — just pick remote.
+	return &Result{Content: remote, Clean: true}, nil
+}
+```
+
+- [ ] **Step 2: Implement Binary**
+
+```go
+package merge
+
+func init() { Register(&Binary{}) }
+
+type Binary struct{}
+
+func (b *Binary) Name() string { return "binary" }
+
+func (b *Binary) Merge(base, local, remote []byte) (*Result, error) {
+	// Binary files can never be auto-merged.
+	return &Result{
+		Content: local, // keep local, flag conflict
+		Clean:   false,
+		Conflicts: []Conflict{{
+			Local:  local,
+			Remote: remote,
+			Base:   base,
+		}},
+	}, nil
+}
+```
+
+- [ ] **Step 3: Implement ConflictFork**
+
+```go
+package merge
+
+import (
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+func init() { Register(&ConflictFork{}) }
+
+type ConflictFork struct{}
+
+func (c *ConflictFork) Name() string { return "conflict-fork" }
+
+func (c *ConflictFork) Merge(base, local, remote []byte) (*Result, error) {
+	// Don't merge — preserve all versions.
+	// The CLI orchestrator writes to the conflict table.
+	return &Result{
+		Content: local, // keep local in working dir
+		Clean:   false,
+		Conflicts: []Conflict{{
+			Local:  local,
+			Remote: remote,
+			Base:   base,
+		}},
+	}, nil
+}
+
+// EnsureConflictTable creates the conflict table if it doesn't exist.
+// Follows Fossil conventions: REFERENCES blob, julianday mtime.
+func EnsureConflictTable(r *repo.Repo) error {
+	_, err := r.DB().Exec(`CREATE TABLE IF NOT EXISTS conflict(
+		cid INTEGER PRIMARY KEY,
+		filename TEXT NOT NULL,
+		base_rid INTEGER REFERENCES blob,
+		local_rid INTEGER REFERENCES blob,
+		remote_rid INTEGER REFERENCES blob,
+		mtime REAL NOT NULL
+	)`)
+	return err
+}
+
+// RecordConflictFork inserts a conflict-fork entry.
+func RecordConflictFork(r *repo.Repo, filename string, baseRID, localRID, remoteRID int64) error {
+	_, err := r.DB().Exec(
+		"INSERT INTO conflict(filename, base_rid, local_rid, remote_rid, mtime) VALUES(?, ?, ?, ?, julianday('now'))",
+		filename, baseRID, localRID, remoteRID,
+	)
+	return err
+}
+
+// ResolveConflictFork deletes a resolved conflict-fork entry.
+func ResolveConflictFork(r *repo.Repo, filename string) error {
+	_, err := r.DB().Exec("DELETE FROM conflict WHERE filename=?", filename)
+	return err
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `go test ./go-libfossil/merge/ -v -count=1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-libfossil/merge/
+git commit -m "merge: add LastWriterWins, Binary, ConflictFork strategies"
+```
+
+---
+
+## Task 6: Strategy Resolver
+
+**Files:**
+- Create: `go-libfossil/merge/resolve.go`
+
+- [ ] **Step 1: Implement resolver with .edgesync-merge + config fallback**
+
+```go
+package merge
+
+import (
+	"bufio"
+	"path/filepath"
+	"strings"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+type PatternRule struct {
+	Glob     string
+	Strategy string
+}
+
+type Resolver struct {
+	patterns []PatternRule
+	fallback string
+}
+
+// LoadResolver reads the .edgesync-merge file from the repo at the given
+// version, plus the merge-strategy config key as fallback.
+func LoadResolver(r *repo.Repo, tipRid libfossil.FslID) *Resolver {
+	res := &Resolver{fallback: "three-way"}
+
+	// Try config table fallback.
+	var cfgDefault string
+	if r.DB().QueryRow("SELECT value FROM config WHERE name='merge-strategy'").Scan(&cfgDefault) == nil && cfgDefault != "" {
+		res.fallback = cfgDefault
+	}
+
+	// Try .edgesync-merge file from the tip manifest.
+	if tipRid > 0 {
+		files, err := manifest.ListFiles(r, tipRid)
+		if err == nil {
+			for _, f := range files {
+				if f.Name == ".edgesync-merge" {
+					rid, ok := blob.Exists(r.DB(), f.UUID)
+					if ok {
+						data, err := content.Expand(r.DB(), rid)
+						if err == nil {
+							res.patterns = parseMergeFile(data)
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return res
+}
+
+// Resolve returns the strategy name for a filename.
+func (res *Resolver) Resolve(filename string) string {
+	for _, p := range res.patterns {
+		matched, _ := filepath.Match(p.Glob, filepath.Base(filename))
+		if matched {
+			return p.Strategy
+		}
+	}
+	return res.fallback
+}
+
+func parseMergeFile(data []byte) []PatternRule {
+	var rules []PatternRule
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			rules = append(rules, PatternRule{Glob: parts[0], Strategy: parts[1]})
+		}
+	}
+	return rules
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./go-libfossil/merge/ -v -count=1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go-libfossil/merge/resolve.go
+git commit -m "merge: add Resolver with .edgesync-merge file + config fallback"
+```
+
+---
+
+## Task 7: CLI commands — merge, conflicts, merge resolve
+
+**Files:**
+- Create: `cmd/edgesync/repo_merge.go`
+- Create: `cmd/edgesync/repo_conflicts.go`
+- Create: `cmd/edgesync/repo_merge_resolve.go`
+- Modify: `cmd/edgesync/cli.go`
+
+- [ ] **Step 1: Implement repo merge**
+
+The orchestrator: opens repo, finds ancestor, loads resolver, merges each divergent file, writes results with Fossil-idiomatic conflict handling.
+
+```go
+type RepoMergeCmd struct {
+	Version  string `arg:"" help:"Version to merge"`
+	Strategy string `help:"Override merge strategy for all files"`
+	DryRun   bool   `help:"Show what would be merged without writing"`
+	Dir      string `short:"d" help:"Checkout directory" default:"."`
+}
+```
+
+Key logic:
+- Resolve both versions to rids
+- `merge.FindCommonAncestor()` to get the base
+- `manifest.ListFiles()` on all three (base, local, remote)
+- For each file that differs: pick strategy via resolver, load content, call `strategy.Merge()`
+- Clean merge: write to checkout, set `vfile.chnged=1`
+- Conflict (three-way/binary): write markers + sidecar files, set `vfile.chnged=5`
+- Conflict-fork: `merge.EnsureConflictTable()`, `merge.RecordConflictFork()`, keep local in working dir
+
+- [ ] **Step 2: Implement repo conflicts**
+
+```go
+type RepoConflictsCmd struct {
+	Dir string `short:"d" help:"Checkout directory" default:"."`
+}
+```
+
+Checks both sources:
+1. `SELECT pathname FROM vfile WHERE chnged=5` (standard conflicts)
+2. `SELECT filename FROM conflict` (conflict-fork entries, if table exists)
+
+- [ ] **Step 3: Implement repo merge resolve**
+
+```go
+type RepoMergeResolveCmd struct {
+	File string `arg:"" help:"File to mark as resolved"`
+	Dir  string `short:"d" help:"Checkout directory" default:"."`
+}
+```
+
+For standard conflicts: reset `vfile.chnged=1`, delete sidecar files.
+For conflict-fork: `merge.ResolveConflictFork()` (deletes row).
+
+- [ ] **Step 4: Register commands in cli.go**
+
+Add to RepoCmd:
+```go
+Merge     RepoMergeCmd        `cmd:"" help:"Merge a divergent version"`
+Conflicts RepoConflictsCmd    `cmd:"" help:"List unresolved conflicts"`
+```
+
+Note: `repo merge resolve` can be a subcommand of merge: `RepoMergeCmd` has a `Resolve` sub-struct.
+
+- [ ] **Step 5: Build and test**
+
+Run: `go build -buildvcs=false ./cmd/edgesync/`
+
+Manual test: create a repo, make two divergent checkins (by manipulating the leaf table), run `edgesync repo merge`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/edgesync/ go-libfossil/merge/
+git commit -m "edgesync: add repo merge, conflicts, and merge resolve commands"
+```
+
+---
+
+## Task 8: Integration test + sync advisory
+
+- [ ] **Step 1: Create an integration test**
+
+In `go-libfossil/merge/`, create a test that:
+1. Creates a repo
+2. Makes an initial checkin with a file
+3. Makes two divergent checkins (same parent, different content)
+4. Calls DetectForks — should find one fork
+5. Calls FindCommonAncestor — should return the initial checkin
+6. Calls ThreeWayText.Merge with the file content
+7. Verifies clean merge or conflict markers
+
+- [ ] **Step 2: Test Fossil compatibility**
+
+After a merge with conflicts, verify:
+```bash
+fossil changes -R repo.fossil  # should show conflicted files
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add go-libfossil/merge/
+git commit -m "merge: add integration tests and Fossil compatibility verification"
+```

--- a/docs/superpowers/specs/2026-03-16-edgesync-cli-design.md
+++ b/docs/superpowers/specs/2026-03-16-edgesync-cli-design.md
@@ -1,0 +1,318 @@
+# EdgeSync Unified CLI
+
+**Date:** 2026-03-16
+**Status:** Draft
+**Scope:** `cmd/edgesync/` — single binary for repo ops, sync agent, and bridge
+
+## Problem
+
+The project has three separate entry points (`cmd/leaf/main.go`, `cmd/bridge/main.go`, and ad-hoc repo operations via tests). There's no unified CLI for developers, admins, or platform builders to manage repos, inspect content, run sync, and operate the bridge.
+
+## Goals
+
+Build `edgesync`, a single binary that:
+1. Provides grouped subcommands for repo operations, sync, and bridge
+2. Uses kong for struct-tag-based command dispatch
+3. Wraps existing go-libfossil packages — no new domain logic
+4. Replaces the need for the `fossil` binary for basic repo operations
+5. Becomes the primary entry point for the EdgeSync stack
+
+## Non-Goals
+
+- Replacing `fossil` for merge, diff, annotate, or blame (Phase 3+)
+- Checkout DB staging operations (add/rm — Phase 2)
+- Web UI or TUI
+
+## Command Structure
+
+```
+edgesync repo new <path>              Create a new repository
+edgesync repo ci -m "..."             Checkin file changes
+edgesync repo co [<version>]          Checkout a version
+edgesync repo ls [<version>]          List files in a version
+edgesync repo timeline [-n 20]        Show repository history
+edgesync repo cat <artifact>          Output artifact content
+edgesync repo info                    Repository statistics
+
+edgesync sync start                   Start leaf agent daemon
+edgesync sync now                     Trigger immediate sync
+
+edgesync bridge serve                 Start NATS-to-Fossil bridge
+```
+
+## Architecture
+
+### Framework: Kong
+
+Kong uses struct tags for command definitions. The CLI is a tree of Go structs, each with a `Run()` method. Kong handles parsing, help generation, shell completion, and validation.
+
+### File Layout
+
+```
+cmd/edgesync/
+    main.go              Entry point: kong.Parse + Run
+    cli.go               CLI struct tree (Globals, RepoCmd, SyncCmd, BridgeCmd)
+    repo_new.go          RepoNewCmd
+    repo_ci.go           RepoCiCmd
+    repo_co.go           RepoCoCmd
+    repo_ls.go           RepoLsCmd
+    repo_timeline.go     RepoTimelineCmd
+    repo_cat.go          RepoCatCmd
+    repo_info.go         RepoInfoCmd
+    sync_start.go        SyncStartCmd
+    sync_now.go          SyncNowCmd
+    bridge_serve.go      BridgeServeCmd
+```
+
+One file per command. Each command struct is small (20-60 lines) and delegates to go-libfossil packages.
+
+### Struct Tree
+
+```go
+type CLI struct {
+    Globals
+
+    Repo    RepoCmd    `cmd:"" help:"Repository operations"`
+    Sync    SyncCmd    `cmd:"" help:"Leaf agent sync"`
+    Bridge  BridgeCmd  `cmd:"" help:"NATS-to-Fossil bridge"`
+}
+
+type Globals struct {
+    Repo     string `short:"R" help:"Path to repository file" type:"path"`
+    Checkout string `short:"C" help:"Path to checkout directory" type:"path"`
+    Verbose  bool   `short:"v" help:"Verbose output"`
+}
+
+type RepoCmd struct {
+    New      RepoNewCmd      `cmd:"" help:"Create a new repository"`
+    Ci       RepoCiCmd       `cmd:"" help:"Checkin file changes"`
+    Co       RepoCoCmd       `cmd:"" help:"Checkout a version"`
+    Ls       RepoLsCmd       `cmd:"" help:"List files in a version"`
+    Timeline RepoTimelineCmd `cmd:"" help:"Show repository history"`
+    Cat      RepoCatCmd      `cmd:"" help:"Output artifact content"`
+    Info     RepoInfoCmd     `cmd:"" help:"Repository statistics"`
+}
+
+type SyncCmd struct {
+    Start SyncStartCmd `cmd:"" help:"Start leaf agent daemon"`
+    Now   SyncNowCmd   `cmd:"" help:"Trigger immediate sync"`
+}
+
+type BridgeCmd struct {
+    Serve BridgeServeCmd `cmd:"" help:"Start NATS-to-Fossil bridge"`
+}
+```
+
+## Shared Helpers
+
+### resolveRID
+
+Multiple commands accept a version string (UUID, UUID prefix, or symbolic name) but the go-libfossil APIs take `libfossil.FslID` (integer rid). A shared helper resolves this:
+
+```go
+// resolveRID resolves a version string to an rid.
+// Accepts: full UUID, UUID prefix (minimum 4 chars), or empty string (tip).
+func resolveRID(r *repo.Repo, version string) (libfossil.FslID, error) {
+    if version == "" {
+        // Resolve tip: most recent checkin
+        var rid int64
+        err := r.DB().QueryRow(
+            "SELECT objid FROM event WHERE type='ci' ORDER BY mtime DESC LIMIT 1",
+        ).Scan(&rid)
+        if err != nil {
+            return 0, fmt.Errorf("no checkins found")
+        }
+        return libfossil.FslID(rid), nil
+    }
+    // UUID or prefix lookup
+    var rid int64
+    err := r.DB().QueryRow(
+        "SELECT rid FROM blob WHERE uuid LIKE ?", version+"%",
+    ).Scan(&rid)
+    if err != nil {
+        return 0, fmt.Errorf("artifact %q not found", version)
+    }
+    return libfossil.FslID(rid), nil
+}
+```
+
+Used by: `repo ls`, `repo co`, `repo cat`, `repo timeline`.
+
+### openRepo
+
+Opens a repo from the `-R` flag. All go-libfossil query APIs (`content.Expand`, `blob.Load`, `blob.Exists`, `manifest.ListFiles`, `manifest.Log`) take `db.Querier` or `*repo.Repo`. The querier is obtained via `r.DB()`.
+
+```go
+func openRepo(globals *Globals) (*repo.Repo, error) {
+    if globals.Repo == "" {
+        return nil, fmt.Errorf("no repository specified (use -R)")
+    }
+    return repo.Open(globals.Repo)
+}
+```
+
+## Command Specifications
+
+### repo new
+
+```go
+type RepoNewCmd struct {
+    Path string `arg:"" help:"Path for new repository file"`
+    User string `help:"Default user name" default:""`
+}
+```
+
+Creates a new Fossil repository via `repo.Create(path, user, simio.CryptoRand{})`. If user is empty, uses the OS username.
+
+### repo ci
+
+```go
+type RepoCiCmd struct {
+    Message string   `short:"m" required:"" help:"Checkin comment"`
+    Files   []string `arg:"" required:"" help:"Files to checkin"`
+    User    string   `help:"Checkin user (default: repo's default user)"`
+    Parent  string   `help:"Parent version UUID (default: tip)"`
+}
+```
+
+The `Run()` implementation:
+1. Opens repo via `openRepo()`
+2. Resolves parent rid via `resolveRID()` (defaults to tip if not specified)
+3. Reads each file path from disk into `manifest.File{Name, Content, Perm}` structs
+4. Calls `manifest.Checkin(r, manifest.CheckinOpts{Files, Comment, User, Parent, Time: time.Now()})`
+
+**Note:** `--branch` and `--tag` flags are deferred to Phase 2. The current `manifest.Checkin` API hardcodes "trunk" for initial checkins and does not support custom branch/tag cards. These require extending the manifest package first.
+
+### repo co
+
+```go
+type RepoCoCmd struct {
+    Version string `arg:"" optional:"" help:"Version to checkout (default: tip)"`
+    Force   bool   `help:"Overwrite modified files"`
+}
+```
+
+Resolves version via `resolveRID()`, reads the manifest via `manifest.GetManifest(r, rid)`, iterates files, extracts each via `content.Expand(r.DB(), fileRid)`, writes to checkout directory (from `-C` flag or CWD).
+
+### repo ls
+
+```go
+type RepoLsCmd struct {
+    Version string `arg:"" optional:"" help:"Version to list (default: tip)"`
+    Long    bool   `short:"l" help:"Show sizes and hashes"`
+}
+```
+
+Resolves version via `resolveRID()`, calls `manifest.ListFiles(r, rid)`. Long format shows UUID and size per file.
+
+### repo timeline
+
+```go
+type RepoTimelineCmd struct {
+    Limit int `short:"n" default:"20" help:"Number of entries"`
+}
+```
+
+Resolves tip rid via `resolveRID(r, "")`, calls `manifest.Log(r, manifest.LogOpts{Start: tipRid, Limit: n})`. Formats each entry with UUID (first 10 chars), user, date, and comment.
+
+### repo cat
+
+```go
+type RepoCatCmd struct {
+    Artifact string `arg:"" help:"Artifact UUID or prefix"`
+    Raw      bool   `help:"Output raw blob (no delta expansion)"`
+}
+```
+
+Resolves UUID via `resolveRID()`. Raw mode calls `blob.Load(r.DB(), rid)`, normal mode calls `content.Expand(r.DB(), rid)`. Output to stdout.
+
+### repo info
+
+```go
+type RepoInfoCmd struct{}
+```
+
+Queries repo stats: blob count, total uncompressed size, delta count, phantom count, project-code, server-code. Pure SQL against `blob`, `delta`, `phantom`, `config` tables.
+
+### sync start
+
+```go
+type SyncStartCmd struct {
+    NATSUrl      string        `help:"NATS server URL" default:"nats://localhost:4222"`
+    PollInterval time.Duration `help:"Sync poll interval" default:"5s"`
+    Push         bool          `help:"Enable push" default:"true" negatable:""`
+    Pull         bool          `help:"Enable pull" default:"true" negatable:""`
+}
+```
+
+Creates `agent.New()` with `agent.Config{RepoPath: globals.Repo, NATSUrl, PollInterval, Push, Pull}`, calls `Start()`, blocks on signal (SIGINT/SIGTERM).
+
+**Note:** `agent.Config.applyDefaults()` flips both Push and Pull to true when both are false. The `Run()` implementation should pass Push/Pull directly to the config without relying on defaulting — kong handles the defaults via struct tags.
+
+This is the first real entry point using `agent.New()` (the existing `cmd/leaf/main.go` is a stub).
+
+### sync now
+
+```go
+type SyncNowCmd struct {
+    PID int `help:"PID of running agent to signal"`
+}
+```
+
+Sends SIGUSR1 to the running agent process to trigger an immediate sync cycle.
+
+### bridge serve
+
+```go
+type BridgeServeCmd struct {
+    NATSUrl   string `help:"NATS server URL" default:"nats://localhost:4222"`
+    FossilURL string `required:"" help:"Fossil server HTTP URL"`
+    Project   string `required:"" help:"Project code for NATS subject"`
+}
+```
+
+Creates `bridge.New()` with `bridge.Config{NATSUrl, FossilURL, ProjectCode: Project}`, calls `Start()`, blocks on signal (SIGINT/SIGTERM).
+
+Note: maps `BridgeServeCmd.Project` to `bridge.Config.ProjectCode`. This is the first real entry point using `bridge.New()` (the existing `cmd/bridge/main.go` is a stub).
+
+## Global Flags
+
+`-R <path>` — explicitly specify repository file. If omitted, search upward from CWD for `.fslckout` or `_FOSSIL_` (matching fossil's convention).
+
+`-C <path>` — specify checkout directory. Defaults to CWD.
+
+`-v` — verbose output (log sync rounds, SQL queries, etc).
+
+## Repo Discovery
+
+When `-R` is not provided, the CLI searches for the repo:
+1. Look for `.fslckout` or `_FOSSIL_` in CWD
+2. Walk parent directories until found or root reached
+3. If found, read the repo path from the checkout DB
+4. If not found, error with "no repository found (use -R to specify)"
+
+This is the same algorithm fossil uses.
+
+## Dependencies
+
+- `github.com/alecthomas/kong` — CLI framework
+- Existing go-libfossil packages (repo, manifest, content, blob, hash, db)
+- Existing leaf/agent and bridge/bridge packages
+
+## Backward Compatibility
+
+`cmd/leaf/main.go` and `cmd/bridge/main.go` remain as-is. `cmd/edgesync/` is a new binary that wraps them. Eventually the old entry points can be deprecated.
+
+## Build
+
+```bash
+go build ./cmd/edgesync/
+# Produces: ./edgesync
+
+# Usage:
+./edgesync repo new myrepo.fossil
+./edgesync -R myrepo.fossil repo ls
+./edgesync -R myrepo.fossil repo timeline -n 5
+./edgesync sync start -R myrepo.fossil --nats-url nats://localhost:4222
+./edgesync bridge serve --fossil-url http://localhost:8080 --project abc123
+```

--- a/docs/superpowers/specs/2026-03-16-merge-design.md
+++ b/docs/superpowers/specs/2026-03-16-merge-design.md
@@ -17,15 +17,13 @@ When a leaf node is offline and both it and another node modify the same file, s
 
 ## Design Principles
 
-**No custom conflict table.** Fossil does not store merge conflict metadata in the repo DB. We follow the same approach:
+**Idiomatic Fossil storage.** All database writes follow Fossil's conventions: INTEGER PRIMARY KEY, REFERENCES blob for rids, julianday for timestamps — the same patterns used by plink, event, tagxref, and other Fossil tables.
 
-- Conflict markers go in the working file (`<<<<<<<`/`=======`/`>>>>>>>`)
-- Sidecar files for the three versions: `file.LOCAL`, `file.BASELINE`, `file.MERGE`
-- `vfile.chnged=5` in the checkout DB flags conflicted files
-- `repo conflicts` scans vfile for `chnged=5` rather than querying a custom table
-- `fossil` CLI can open our repos and understand the conflict state natively
+**Strategy-dependent conflict storage:**
 
-This ensures full round-trip compatibility with Fossil.
+- **Most strategies** (three-way, last-writer-wins, binary) use Fossil's native conflict handling: `vfile.chnged=5` in the checkout DB, sidecar files (`.LOCAL`, `.BASELINE`, `.MERGE`), conflict markers in working files. The `fossil` CLI sees these conflicts natively.
+
+- **The conflict-fork strategy** (offline-first, keep all versions until resolved) uses a `conflict` table in the repo DB. This table follows Fossil's conventions and is only created/written when the conflict-fork strategy is active. It preserves all divergent versions as blob references so nothing is lost during extended offline periods with multiple writers. The `fossil` CLI ignores this table (Fossil skips unknown tables).
 
 ## Package Structure
 
@@ -35,6 +33,7 @@ go-libfossil/merge/
     threeway.go     ThreeWayText — Myers diff + line-level 3-way merge
     lastwriter.go   LastWriterWins — pick newer version by timestamp
     binary.go       Binary — always conflict, never auto-merge
+    fork.go         ConflictFork — offline-first, preserve all versions in conflict table
     ancestor.go     FindCommonAncestor — BFS on plink table
     detect.go       DetectForks — find divergent leaves in plink DAG
     resolve.go      Resolver — read .edgesync-merge + config, match patterns to strategies
@@ -184,6 +183,29 @@ Compare event.mtime for the two divergent checkins. Return the content from whic
 
 Always returns a conflict. Cannot auto-merge binary files. Writes sidecar files so user can pick manually.
 
+### ConflictFork (offline-first)
+
+The strategy for extended offline scenarios with multiple writers. Instead of merging immediately, preserves all divergent versions as blob references in a `conflict` table. Nothing is lost — the user resolves when convenient.
+
+The `conflict` table follows Fossil's conventions:
+
+```sql
+CREATE TABLE IF NOT EXISTS conflict(
+    cid INTEGER PRIMARY KEY,                  -- conflict ID
+    filename TEXT NOT NULL,                    -- file path
+    base_rid INTEGER REFERENCES blob,         -- common ancestor blob
+    local_rid INTEGER REFERENCES blob,        -- local version blob
+    remote_rid INTEGER REFERENCES blob,       -- remote version blob
+    mtime REAL NOT NULL                       -- julianday timestamp
+);
+```
+
+This matches Fossil's patterns: `REFERENCES blob` for rid foreign keys (like plink.pid, plink.cid), `REAL` julianday for timestamps (like event.mtime, plink.mtime), `INTEGER PRIMARY KEY` for the row ID.
+
+The table is only created when the conflict-fork strategy is first used. It is only written to by the conflict-fork strategy — other strategies never touch it.
+
+When the user resolves a conflict-fork entry, the row is deleted (not flagged — Fossil deletes resolved state rather than marking it, as seen in the phantom table pattern where resolved phantoms are removed).
+
 ### Built-in Strategy Registry
 
 ```go
@@ -191,6 +213,7 @@ var strategies = map[string]Strategy{
     "three-way":        &ThreeWayText{},
     "last-writer-wins": &LastWriterWins{},
     "binary":           &Binary{},
+    "conflict-fork":    &ConflictFork{},
 }
 ```
 
@@ -213,27 +236,38 @@ Merge a divergent version into the current checkout:
 
 ### repo conflicts
 
-Scan checkout DB for conflicted files:
+Checks both conflict sources:
+
+1. Checkout DB `vfile.chnged=5` — standard merge conflicts (three-way, binary)
+2. Repo DB `conflict` table — conflict-fork entries (if table exists)
 
 ```sql
+-- Standard conflicts (from three-way/binary strategies)
 SELECT pathname FROM vfile WHERE chnged=5 AND vid=?
+
+-- Conflict-fork entries (from conflict-fork strategy)
+SELECT filename, base_rid, local_rid, remote_rid FROM conflict
 ```
 
 Output:
 ```
-CONFLICT  config.yaml
-CONFLICT  main.go
+CONFLICT  config.yaml  (three-way, 2 conflict regions)
+FORK      data.json    (conflict-fork, 3 versions preserved)
 ```
 
-Compatible with `fossil changes` which shows the same `chnged=5` state.
+Standard conflicts are also visible via `fossil changes`.
 
 ### repo merge resolve \<file\>
 
-Mark a conflict as resolved:
+Mark a conflict as resolved. Handles both conflict types:
 
-1. Verify the file exists in vfile with `chnged=5`
-2. Update `vfile SET chnged=1` (modified, no longer conflicted)
-3. Delete sidecar files: `file.LOCAL`, `file.BASELINE`, `file.MERGE`
+**Standard conflicts** (vfile.chnged=5):
+1. Update `vfile SET chnged=1` (modified, no longer conflicted)
+2. Delete sidecar files: `file.LOCAL`, `file.BASELINE`, `file.MERGE`
+
+**Conflict-fork entries** (conflict table):
+1. Delete the row from the `conflict` table (Fossil convention: delete resolved state, like phantom table)
+2. The chosen version is already in the working directory
 
 ## Sync Integration
 

--- a/docs/superpowers/specs/2026-03-16-merge-design.md
+++ b/docs/superpowers/specs/2026-03-16-merge-design.md
@@ -1,0 +1,275 @@
+# 3-Way Merge with Swappable Strategies
+
+**Date:** 2026-03-16
+**Status:** Draft
+**Scope:** `go-libfossil/merge/` package, CLI commands, sync integration
+
+## Problem
+
+When a leaf node is offline and both it and another node modify the same file, sync delivers both versions but there's no way to reconcile them. The offline-first architecture (edge config, personal sync, disconnected ops) makes this a common scenario, not an edge case.
+
+## Goals
+
+1. Detect divergent checkins by walking the plink DAG
+2. Provide swappable merge strategies (3-way text, last-writer-wins, binary)
+3. Support per-file-pattern strategy assignment via version-controlled config
+4. Handle conflicts the way Fossil does — no custom tables, idiomatic storage
+
+## Design Principles
+
+**No custom conflict table.** Fossil does not store merge conflict metadata in the repo DB. We follow the same approach:
+
+- Conflict markers go in the working file (`<<<<<<<`/`=======`/`>>>>>>>`)
+- Sidecar files for the three versions: `file.LOCAL`, `file.BASELINE`, `file.MERGE`
+- `vfile.chnged=5` in the checkout DB flags conflicted files
+- `repo conflicts` scans vfile for `chnged=5` rather than querying a custom table
+- `fossil` CLI can open our repos and understand the conflict state natively
+
+This ensures full round-trip compatibility with Fossil.
+
+## Package Structure
+
+```
+go-libfossil/merge/
+    strategy.go     Strategy interface, Result, Conflict types
+    threeway.go     ThreeWayText — Myers diff + line-level 3-way merge
+    lastwriter.go   LastWriterWins — pick newer version by timestamp
+    binary.go       Binary — always conflict, never auto-merge
+    ancestor.go     FindCommonAncestor — BFS on plink table
+    detect.go       DetectForks — find divergent leaves in plink DAG
+    resolve.go      Resolver — read .edgesync-merge + config, match patterns to strategies
+```
+
+## Core Types
+
+```go
+// Strategy merges three versions of content.
+type Strategy interface {
+    Name() string
+    Merge(base, local, remote []byte) (*Result, error)
+}
+
+type Result struct {
+    Content   []byte      // merged output (with conflict markers if any)
+    Conflicts []Conflict  // conflict regions (for reporting)
+    Clean     bool        // true if no unresolved conflicts
+}
+
+type Conflict struct {
+    StartLine int
+    EndLine   int
+    Local     []byte
+    Remote    []byte
+    Base      []byte
+}
+
+// Fork represents two divergent checkins sharing a common ancestor.
+type Fork struct {
+    Ancestor libfossil.FslID
+    LocalTip libfossil.FslID
+    RemoteTip libfossil.FslID
+}
+```
+
+No `ConflictRecord` type — conflicts are tracked via Fossil's native `vfile.chnged=5` mechanism.
+
+## Fork Detection
+
+`DetectForks(r *repo.Repo) ([]Fork, error)` finds divergent history:
+
+1. Query the `leaf` table for all leaf checkins (Fossil already maintains this table — checkins with no children)
+2. If only one leaf, no fork — repo is linear
+3. If multiple leaves, find common ancestor for each pair via BFS on plink
+4. Return Fork structs with ancestor + both tips
+
+`FindCommonAncestor(r *repo.Repo, ridA, ridB libfossil.FslID) (libfossil.FslID, error)` walks plink backwards from both nodes via BFS. First rid appearing in both visited sets is the ancestor.
+
+Detection is SQL-only — no file content is read.
+
+## Conflict Handling (Fossil-Idiomatic)
+
+When a file has unresolvable conflicts during merge:
+
+### 1. Write conflict markers into the working file
+
+```
+<<<<<<< LOCAL
+your changes here
+=======
+their changes here
+>>>>>>> REMOTE
+```
+
+### 2. Write sidecar files
+
+For a conflicted `config.yaml`:
+- `config.yaml` — merged content with conflict markers
+- `config.yaml.LOCAL` — the local (checkout) version
+- `config.yaml.BASELINE` — the common ancestor version
+- `config.yaml.MERGE` — the incoming (remote) version
+
+### 3. Flag in checkout DB
+
+```sql
+UPDATE vfile SET chnged=5 WHERE pathname='config.yaml' AND vid=?
+```
+
+`chnged=5` is Fossil's code for "merge conflict". This is readable by both `edgesync repo conflicts` and `fossil changes`.
+
+### 4. Resolution
+
+When the user edits the file to resolve conflicts and runs `edgesync repo merge resolve <file>`:
+- Reset `vfile.chnged` to 1 (modified, not conflicted)
+- Delete the sidecar files (`.LOCAL`, `.BASELINE`, `.MERGE`)
+
+## Strategy Resolution
+
+Three sources, checked in priority order:
+
+1. **CLI flag** — `--strategy <name>` overrides everything
+2. **`.edgesync-merge` file** — version-controlled, checked into repo, syncs across nodes
+3. **Config table** — `merge-strategy` key as default fallback (default: `three-way`)
+
+### .edgesync-merge file format
+
+```
+# pattern      strategy
+*.yaml         last-writer-wins
+*.json         last-writer-wins
+*.go           three-way
+*.md           three-way
+*.png          binary
+*              three-way
+```
+
+Glob matching, first match wins, processed top to bottom.
+
+```go
+type Resolver struct {
+    patterns []PatternRule
+    default_ string
+}
+
+type PatternRule struct {
+    Glob     string
+    Strategy string
+}
+
+func LoadResolver(r *repo.Repo, tipRid libfossil.FslID) (*Resolver, error)
+func (res *Resolver) Resolve(filename string) string
+func StrategyByName(name string) (Strategy, error)
+```
+
+## Strategy Implementations
+
+### ThreeWayText
+
+The core merge algorithm using `gotextdiff/myers`:
+
+1. Split base, local, remote into lines
+2. Diff base→local (edits A) and base→remote (edits B)
+3. Walk base line by line:
+   - Neither changed: copy from base
+   - Only A changed: take A's version
+   - Only B changed: take B's version
+   - Both changed identically: take either
+   - Both changed differently: emit conflict markers
+4. Return Result with merged content + conflict list
+
+### LastWriterWins
+
+Compare event.mtime for the two divergent checkins. Return the content from whichever is newer. Always clean — no conflicts possible.
+
+### Binary
+
+Always returns a conflict. Cannot auto-merge binary files. Writes sidecar files so user can pick manually.
+
+### Built-in Strategy Registry
+
+```go
+var strategies = map[string]Strategy{
+    "three-way":        &ThreeWayText{},
+    "last-writer-wins": &LastWriterWins{},
+    "binary":           &Binary{},
+}
+```
+
+## CLI Commands
+
+### repo merge \<version\>
+
+Merge a divergent version into the current checkout:
+
+1. Open repo + checkout DB, resolve version to rid
+2. Find common ancestor via `FindCommonAncestor`
+3. Load `.edgesync-merge` file + config for strategy resolution
+4. For each file differing between the two versions:
+   - Pick strategy via resolver
+   - Load base, local, remote content via `content.Expand()`
+   - Call `strategy.Merge(base, local, remote)`
+   - If clean: write merged content to checkout, set `vfile.chnged=1`
+   - If conflicts: write merged content with markers + sidecar files, set `vfile.chnged=5`
+5. Report summary: N files merged, M conflicts
+
+### repo conflicts
+
+Scan checkout DB for conflicted files:
+
+```sql
+SELECT pathname FROM vfile WHERE chnged=5 AND vid=?
+```
+
+Output:
+```
+CONFLICT  config.yaml
+CONFLICT  main.go
+```
+
+Compatible with `fossil changes` which shows the same `chnged=5` state.
+
+### repo merge resolve \<file\>
+
+Mark a conflict as resolved:
+
+1. Verify the file exists in vfile with `chnged=5`
+2. Update `vfile SET chnged=1` (modified, no longer conflicted)
+3. Delete sidecar files: `file.LOCAL`, `file.BASELINE`, `file.MERGE`
+
+## Sync Integration
+
+After a successful sync cycle, the leaf agent can optionally detect forks:
+
+```go
+forks, _ := merge.DetectForks(r)
+if len(forks) > 0 {
+    log.Printf("sync: %d divergent branches detected — run 'edgesync repo merge' to resolve", len(forks))
+}
+```
+
+Advisory only — logs a message. No automatic merging. The user decides when to merge.
+
+## Testing
+
+1. **Unit tests for ThreeWayText**: non-overlapping edits, overlapping same, overlapping different (conflict), empty files, single-line files
+2. **Unit tests for LastWriterWins**: newer local wins, newer remote wins
+3. **Unit tests for FindCommonAncestor**: linear history, branched history, no common ancestor
+4. **Unit tests for DetectForks**: single leaf (no fork), multiple leaves (fork found)
+5. **Unit tests for Resolver**: glob matching, file fallback, config fallback
+6. **Integration test**: create repo, make divergent checkins, run merge, verify markers + sidecar files + vfile.chnged=5
+7. **Fossil compat test**: after merge with conflicts, run `fossil changes` and verify it sees the conflicts
+
+## Dependencies
+
+- `github.com/hexops/gotextdiff` (already added for repo diff)
+- Existing go-libfossil packages: repo, blob, content, manifest, db
+
+## Implementation Order
+
+1. Core types + Strategy interface (`strategy.go`)
+2. FindCommonAncestor (`ancestor.go`)
+3. DetectForks (`detect.go`)
+4. ThreeWayText (`threeway.go`) — the hard part
+5. LastWriterWins + Binary (`lastwriter.go`, `binary.go`)
+6. Resolver (`resolve.go`)
+7. CLI: `repo merge`, `repo conflicts`, `repo merge resolve`
+8. Sync integration (advisory fork detection logging)

--- a/go-libfossil/merge/ancestor.go
+++ b/go-libfossil/merge/ancestor.go
@@ -1,0 +1,82 @@
+package merge
+
+import (
+	"fmt"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// FindCommonAncestor walks the plink DAG backwards from two checkin rids
+// to find their most recent common ancestor via bidirectional BFS.
+func FindCommonAncestor(r *repo.Repo, ridA, ridB libfossil.FslID) (libfossil.FslID, error) {
+	if ridA == ridB {
+		return ridA, nil
+	}
+
+	visitedA := map[libfossil.FslID]bool{ridA: true}
+	visitedB := map[libfossil.FslID]bool{ridB: true}
+	queueA := []libfossil.FslID{ridA}
+	queueB := []libfossil.FslID{ridB}
+
+	for len(queueA) > 0 || len(queueB) > 0 {
+		if len(queueA) > 0 {
+			current := queueA[0]
+			queueA = queueA[1:]
+			if visitedB[current] {
+				return current, nil
+			}
+			parents, err := getParents(r, current)
+			if err != nil {
+				return 0, err
+			}
+			for _, pid := range parents {
+				if !visitedA[pid] {
+					visitedA[pid] = true
+					if visitedB[pid] {
+						return pid, nil
+					}
+					queueA = append(queueA, pid)
+				}
+			}
+		}
+
+		if len(queueB) > 0 {
+			current := queueB[0]
+			queueB = queueB[1:]
+			if visitedA[current] {
+				return current, nil
+			}
+			parents, err := getParents(r, current)
+			if err != nil {
+				return 0, err
+			}
+			for _, pid := range parents {
+				if !visitedB[pid] {
+					visitedB[pid] = true
+					if visitedA[pid] {
+						return pid, nil
+					}
+					queueB = append(queueB, pid)
+				}
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("no common ancestor for rid %d and %d", ridA, ridB)
+}
+
+func getParents(r *repo.Repo, rid libfossil.FslID) ([]libfossil.FslID, error) {
+	rows, err := r.DB().Query("SELECT pid FROM plink WHERE cid=?", rid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var parents []libfossil.FslID
+	for rows.Next() {
+		var pid int64
+		rows.Scan(&pid)
+		parents = append(parents, libfossil.FslID(pid))
+	}
+	return parents, rows.Err()
+}

--- a/go-libfossil/merge/binary.go
+++ b/go-libfossil/merge/binary.go
@@ -1,0 +1,20 @@
+package merge
+
+func init() { Register(&Binary{}) }
+
+// Binary always returns a conflict. Binary files cannot be auto-merged.
+type Binary struct{}
+
+func (b *Binary) Name() string { return "binary" }
+
+func (b *Binary) Merge(base, local, remote []byte) (*Result, error) {
+	return &Result{
+		Content: local,
+		Clean:   false,
+		Conflicts: []Conflict{{
+			Local:  local,
+			Remote: remote,
+			Base:   base,
+		}},
+	}, nil
+}

--- a/go-libfossil/merge/detect.go
+++ b/go-libfossil/merge/detect.go
@@ -1,0 +1,50 @@
+package merge
+
+import (
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// DetectForks finds divergent branches by querying the leaf table
+// (maintained by Fossil/manifest.Checkin) for checkins with no children.
+func DetectForks(r *repo.Repo) ([]Fork, error) {
+	rows, err := r.DB().Query(`
+		SELECT l.rid FROM leaf l
+		JOIN event e ON e.objid=l.rid
+		WHERE e.type='ci'
+		ORDER BY e.mtime DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var leaves []libfossil.FslID
+	for rows.Next() {
+		var rid int64
+		rows.Scan(&rid)
+		leaves = append(leaves, libfossil.FslID(rid))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(leaves) <= 1 {
+		return nil, nil
+	}
+
+	var forks []Fork
+	for i := 0; i < len(leaves); i++ {
+		for j := i + 1; j < len(leaves); j++ {
+			ancestor, err := FindCommonAncestor(r, leaves[i], leaves[j])
+			if err != nil {
+				continue
+			}
+			forks = append(forks, Fork{
+				Ancestor:  ancestor,
+				LocalTip:  leaves[i],
+				RemoteTip: leaves[j],
+			})
+		}
+	}
+	return forks, nil
+}

--- a/go-libfossil/merge/fork.go
+++ b/go-libfossil/merge/fork.go
@@ -1,0 +1,77 @@
+package merge
+
+import "github.com/dmestas/edgesync/go-libfossil/repo"
+
+func init() { Register(&ConflictFork{}) }
+
+// ConflictFork preserves all divergent versions without merging.
+// Used for offline-first scenarios where conflicts accumulate.
+// Stores references in a conflict table (Fossil-idiomatic schema).
+type ConflictFork struct{}
+
+func (c *ConflictFork) Name() string { return "conflict-fork" }
+
+func (c *ConflictFork) Merge(base, local, remote []byte) (*Result, error) {
+	// Don't merge — preserve all versions. The CLI writes to the conflict table.
+	return &Result{
+		Content: local,
+		Clean:   false,
+		Conflicts: []Conflict{{
+			Local:  local,
+			Remote: remote,
+			Base:   base,
+		}},
+	}, nil
+}
+
+// EnsureConflictTable creates the conflict table if it doesn't exist.
+// Follows Fossil conventions: REFERENCES blob for rids, julianday REAL for timestamps.
+func EnsureConflictTable(r *repo.Repo) error {
+	_, err := r.DB().Exec(`CREATE TABLE IF NOT EXISTS conflict(
+		cid INTEGER PRIMARY KEY,
+		filename TEXT NOT NULL,
+		base_rid INTEGER REFERENCES blob,
+		local_rid INTEGER REFERENCES blob,
+		remote_rid INTEGER REFERENCES blob,
+		mtime REAL NOT NULL
+	)`)
+	return err
+}
+
+// RecordConflictFork inserts a conflict-fork entry.
+func RecordConflictFork(r *repo.Repo, filename string, baseRID, localRID, remoteRID int64) error {
+	_, err := r.DB().Exec(
+		"INSERT INTO conflict(filename, base_rid, local_rid, remote_rid, mtime) VALUES(?, ?, ?, ?, julianday('now'))",
+		filename, baseRID, localRID, remoteRID,
+	)
+	return err
+}
+
+// ResolveConflictFork deletes a resolved entry (Fossil convention: delete, don't flag).
+func ResolveConflictFork(r *repo.Repo, filename string) error {
+	_, err := r.DB().Exec("DELETE FROM conflict WHERE filename=?", filename)
+	return err
+}
+
+// ListConflictForks returns all unresolved conflict-fork entries.
+func ListConflictForks(r *repo.Repo) ([]string, error) {
+	// Check if conflict table exists.
+	var count int
+	err := r.DB().QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='conflict'").Scan(&count)
+	if err != nil || count == 0 {
+		return nil, nil
+	}
+
+	rows, err := r.DB().Query("SELECT filename FROM conflict ORDER BY mtime DESC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		rows.Scan(&name)
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}

--- a/go-libfossil/merge/lastwriter.go
+++ b/go-libfossil/merge/lastwriter.go
@@ -1,0 +1,13 @@
+package merge
+
+func init() { Register(&LastWriterWins{}) }
+
+// LastWriterWins picks the newer version. The caller passes the newer
+// content as remote. Always clean — no conflicts possible.
+type LastWriterWins struct{}
+
+func (l *LastWriterWins) Name() string { return "last-writer-wins" }
+
+func (l *LastWriterWins) Merge(base, local, remote []byte) (*Result, error) {
+	return &Result{Content: remote, Clean: true}, nil
+}

--- a/go-libfossil/merge/merge_test.go
+++ b/go-libfossil/merge/merge_test.go
@@ -1,0 +1,438 @@
+package merge
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+)
+
+func hasFossil() bool {
+	_, err := exec.LookPath("fossil")
+	return err == nil
+}
+
+// createDivergentRepo creates a repo with:
+//   - Initial checkin: file.txt = baseContent
+//   - Branch A checkin: file.txt = localContent (child of initial)
+//   - Branch B checkin: file.txt = remoteContent (child of initial)
+//
+// Returns the repo, initial rid, branch A rid, branch B rid.
+func createDivergentRepo(t *testing.T, baseContent, localContent, remoteContent string) (*repo.Repo, libfossil.FslID, libfossil.FslID, libfossil.FslID) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	r, err := repo.Create(path, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+
+	// Initial checkin.
+	baseRid, _, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: []byte(baseContent)}},
+		Comment: "initial",
+		User:    "testuser",
+		Time:    time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("checkin base: %v", err)
+	}
+
+	// Branch A (local): child of initial.
+	localRid, _, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: []byte(localContent)}},
+		Comment: "branch A",
+		User:    "testuser",
+		Parent:  baseRid,
+		Time:    time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("checkin local: %v", err)
+	}
+
+	// Branch B (remote): also child of initial (creates a fork).
+	remoteRid, _, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: []byte(remoteContent)}},
+		Comment: "branch B",
+		User:    "testuser",
+		Parent:  baseRid,
+		Time:    time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("checkin remote: %v", err)
+	}
+
+	return r, baseRid, localRid, remoteRid
+}
+
+// expandFileFromCheckin reads file.txt content from a checkin manifest.
+func expandFileFromCheckin(t *testing.T, r *repo.Repo, rid libfossil.FslID) []byte {
+	t.Helper()
+	files, err := manifest.ListFiles(r, rid)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+	for _, f := range files {
+		if f.Name == "file.txt" {
+			frid, ok := blob.Exists(r.DB(), f.UUID)
+			if !ok {
+				t.Fatalf("blob %s not found", f.UUID)
+			}
+			data, err := content.Expand(r.DB(), frid)
+			if err != nil {
+				t.Fatalf("Expand: %v", err)
+			}
+			return data
+		}
+	}
+	t.Fatal("file.txt not found in checkin")
+	return nil
+}
+
+func TestFindCommonAncestorLinear(t *testing.T) {
+	r, baseRid, localRid, _ := createDivergentRepo(t, "base\n", "local\n", "remote\n")
+	defer r.Close()
+
+	ancestor, err := FindCommonAncestor(r, localRid, baseRid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// localRid's parent is baseRid, so ancestor should be baseRid.
+	if ancestor != baseRid {
+		t.Fatalf("ancestor=%d, want %d (base)", ancestor, baseRid)
+	}
+}
+
+func TestFindCommonAncestorForked(t *testing.T) {
+	r, baseRid, localRid, remoteRid := createDivergentRepo(t, "base\n", "local\n", "remote\n")
+	defer r.Close()
+
+	ancestor, err := FindCommonAncestor(r, localRid, remoteRid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ancestor != baseRid {
+		t.Fatalf("ancestor=%d, want %d (base)", ancestor, baseRid)
+	}
+}
+
+func TestDetectForksFindsTwo(t *testing.T) {
+	r, _, _, _ := createDivergentRepo(t, "base\n", "local\n", "remote\n")
+	defer r.Close()
+
+	forks, err := DetectForks(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(forks) == 0 {
+		t.Fatal("expected at least one fork")
+	}
+	t.Logf("found %d fork(s): ancestor=%d local=%d remote=%d",
+		len(forks), forks[0].Ancestor, forks[0].LocalTip, forks[0].RemoteTip)
+}
+
+func TestDetectForksLinear(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "linear.fossil")
+	r, err := repo.Create(path, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	rid1, _, _ := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "a.txt", Content: []byte("v1\n")}},
+		Comment: "first",
+		User:    "testuser",
+		Time:    time.Now().UTC(),
+	})
+	manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "a.txt", Content: []byte("v2\n")}},
+		Comment: "second",
+		User:    "testuser",
+		Parent:  rid1,
+		Time:    time.Now().UTC(),
+	})
+
+	forks, err := DetectForks(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(forks) != 0 {
+		t.Fatalf("expected no forks in linear history, got %d", len(forks))
+	}
+}
+
+// --- Strategy tests with Fossil validation ---
+
+func TestThreeWayStrategyWithFossilValidation(t *testing.T) {
+	if !hasFossil() {
+		t.Skip("fossil binary not found")
+	}
+
+	// Non-overlapping edits: local changes line 1, remote changes line 3.
+	base := "line1\nline2\nline3\n"
+	local := "LOCAL1\nline2\nline3\n"
+	remote := "line1\nline2\nREMOTE3\n"
+
+	r, baseRid, localRid, remoteRid := createDivergentRepo(t, base, local, remote)
+
+	// Verify ancestor.
+	ancestor, err := FindCommonAncestor(r, localRid, remoteRid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ancestor != baseRid {
+		t.Fatalf("ancestor=%d, want %d", ancestor, baseRid)
+	}
+
+	// Load content.
+	baseContent := expandFileFromCheckin(t, r, baseRid)
+	localContent := expandFileFromCheckin(t, r, localRid)
+	remoteContent := expandFileFromCheckin(t, r, remoteRid)
+
+	// Merge with three-way.
+	strat := &ThreeWayText{}
+	result, err := strat.Merge(baseContent, localContent, remoteContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Clean {
+		t.Fatalf("expected clean merge, got %d conflicts", len(result.Conflicts))
+	}
+	expected := "LOCAL1\nline2\nREMOTE3\n"
+	if string(result.Content) != expected {
+		t.Fatalf("merged content = %q, want %q", result.Content, expected)
+	}
+
+	// Commit the merge result and verify with Fossil.
+	mergeRid, _, err := manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: result.Content}},
+		Comment: "merge of A and B",
+		User:    "testuser",
+		Parent:  localRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("checkin merge result: %v", err)
+	}
+	_ = mergeRid
+	r.Close()
+
+	// Fossil rebuild — validates repo integrity.
+	cmd := exec.Command("fossil", "rebuild", r.Path())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild failed: %v\n%s", err, out)
+	}
+	t.Logf("fossil rebuild: %s", strings.TrimSpace(string(out)))
+
+	// Fossil artifact — read the merged content back.
+	r2, _ := repo.Open(r.Path())
+	defer r2.Close()
+	mergedContent := expandFileFromCheckin(t, r2, mergeRid)
+	if string(mergedContent) != expected {
+		t.Fatalf("fossil-validated content = %q, want %q", mergedContent, expected)
+	}
+	t.Log("three-way merge: Fossil validation PASSED")
+}
+
+func TestLastWriterWinsWithFossilValidation(t *testing.T) {
+	if !hasFossil() {
+		t.Skip("fossil binary not found")
+	}
+
+	base := "original content\n"
+	local := "local edit\n"
+	remote := "remote edit (newer)\n"
+
+	r, _, localRid, _ := createDivergentRepo(t, base, local, remote)
+
+	baseContent := []byte(base)
+	localContent := []byte(local)
+	remoteContent := []byte(remote)
+
+	strat := &LastWriterWins{}
+	result, err := strat.Merge(baseContent, localContent, remoteContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Clean {
+		t.Fatal("last-writer-wins should always be clean")
+	}
+	// Remote wins (passed as remote).
+	if string(result.Content) != "remote edit (newer)\n" {
+		t.Fatalf("content = %q", result.Content)
+	}
+
+	// Commit and validate.
+	_, _, err = manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: result.Content}},
+		Comment: "last-writer-wins merge",
+		User:    "testuser",
+		Parent:  localRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("checkin: %v", err)
+	}
+	r.Close()
+
+	cmd := exec.Command("fossil", "rebuild", r.Path())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild: %v\n%s", err, out)
+	}
+	t.Logf("fossil rebuild: %s", strings.TrimSpace(string(out)))
+	t.Log("last-writer-wins: Fossil validation PASSED")
+}
+
+func TestBinaryStrategyWithFossilValidation(t *testing.T) {
+	if !hasFossil() {
+		t.Skip("fossil binary not found")
+	}
+
+	base := "binary\x00base\xff"
+	local := "binary\x00local\xff"
+	remote := "binary\x00remote\xff"
+
+	r, _, localRid, _ := createDivergentRepo(t, base, local, remote)
+
+	strat := &Binary{}
+	result, err := strat.Merge([]byte(base), []byte(local), []byte(remote))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Clean {
+		t.Fatal("binary should always conflict")
+	}
+	if len(result.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(result.Conflicts))
+	}
+
+	// User picks local version to resolve. Commit it.
+	_, _, err = manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: []byte(local)}},
+		Comment: "binary conflict resolved (kept local)",
+		User:    "testuser",
+		Parent:  localRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("checkin: %v", err)
+	}
+	r.Close()
+
+	cmd := exec.Command("fossil", "rebuild", r.Path())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild: %v\n%s", err, out)
+	}
+	t.Logf("fossil rebuild: %s", strings.TrimSpace(string(out)))
+	t.Log("binary strategy: Fossil validation PASSED")
+}
+
+func TestConflictForkWithFossilValidation(t *testing.T) {
+	if !hasFossil() {
+		t.Skip("fossil binary not found")
+	}
+
+	base := "config: v1\n"
+	local := "config: v2-local\n"
+	remote := "config: v2-remote\n"
+
+	r, baseRid, localRid, remoteRid := createDivergentRepo(t, base, local, remote)
+
+	strat := &ConflictFork{}
+	result, err := strat.Merge([]byte(base), []byte(local), []byte(remote))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Clean {
+		t.Fatal("conflict-fork should never be clean")
+	}
+
+	// Record in conflict table.
+	if err := EnsureConflictTable(r); err != nil {
+		t.Fatalf("EnsureConflictTable: %v", err)
+	}
+	if err := RecordConflictFork(r, "file.txt", int64(baseRid), int64(localRid), int64(remoteRid)); err != nil {
+		t.Fatalf("RecordConflictFork: %v", err)
+	}
+
+	// Verify conflict table has the entry.
+	forks, err := ListConflictForks(r)
+	if err != nil {
+		t.Fatalf("ListConflictForks: %v", err)
+	}
+	if len(forks) != 1 || forks[0] != "file.txt" {
+		t.Fatalf("expected 1 fork for file.txt, got %v", forks)
+	}
+
+	// Resolve: user picks remote version.
+	_, _, err = manifest.Checkin(r, manifest.CheckinOpts{
+		Files:   []manifest.File{{Name: "file.txt", Content: []byte(remote)}},
+		Comment: "conflict-fork resolved (picked remote)",
+		User:    "testuser",
+		Parent:  localRid,
+		Time:    time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("checkin: %v", err)
+	}
+	if err := ResolveConflictFork(r, "file.txt"); err != nil {
+		t.Fatalf("ResolveConflictFork: %v", err)
+	}
+
+	// Verify fork is resolved.
+	forks, _ = ListConflictForks(r)
+	if len(forks) != 0 {
+		t.Fatalf("expected 0 forks after resolve, got %v", forks)
+	}
+
+	r.Close()
+
+	cmd := exec.Command("fossil", "rebuild", r.Path())
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild: %v\n%s", err, out)
+	}
+	t.Logf("fossil rebuild: %s", strings.TrimSpace(string(out)))
+
+	// Verify Fossil ignores the conflict table (it should rebuild fine).
+	t.Log("conflict-fork: Fossil validation PASSED (conflict table ignored by fossil)")
+}
+
+func TestResolverPatternMatching(t *testing.T) {
+	res := &Resolver{
+		patterns: []PatternRule{
+			{Glob: "*.yaml", Strategy: "last-writer-wins"},
+			{Glob: "*.png", Strategy: "binary"},
+			{Glob: "*.go", Strategy: "three-way"},
+		},
+		fallback: "three-way",
+	}
+
+	tests := []struct {
+		file     string
+		expected string
+	}{
+		{"config.yaml", "last-writer-wins"},
+		{"image.png", "binary"},
+		{"main.go", "three-way"},
+		{"readme.txt", "three-way"}, // fallback
+	}
+
+	for _, tt := range tests {
+		got := res.Resolve(tt.file)
+		if got != tt.expected {
+			t.Errorf("Resolve(%q) = %q, want %q", tt.file, got, tt.expected)
+		}
+	}
+}

--- a/go-libfossil/merge/resolve.go
+++ b/go-libfossil/merge/resolve.go
@@ -1,0 +1,83 @@
+package merge
+
+import (
+	"bufio"
+	"path/filepath"
+	"strings"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// PatternRule maps a glob pattern to a strategy name.
+type PatternRule struct {
+	Glob     string
+	Strategy string
+}
+
+// Resolver picks the merge strategy for a given filename.
+type Resolver struct {
+	patterns []PatternRule
+	fallback string
+}
+
+// LoadResolver reads the .edgesync-merge file from the repo at the given
+// version, plus the merge-strategy config key as fallback.
+func LoadResolver(r *repo.Repo, tipRid libfossil.FslID) *Resolver {
+	res := &Resolver{fallback: "three-way"}
+
+	var cfgDefault string
+	if r.DB().QueryRow("SELECT value FROM config WHERE name='merge-strategy'").Scan(&cfgDefault) == nil && cfgDefault != "" {
+		res.fallback = cfgDefault
+	}
+
+	if tipRid > 0 {
+		files, err := manifest.ListFiles(r, tipRid)
+		if err == nil {
+			for _, f := range files {
+				if f.Name == ".edgesync-merge" {
+					rid, ok := blob.Exists(r.DB(), f.UUID)
+					if ok {
+						data, err := content.Expand(r.DB(), rid)
+						if err == nil {
+							res.patterns = parseMergeFile(data)
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	return res
+}
+
+// Resolve returns the strategy name for a filename.
+func (res *Resolver) Resolve(filename string) string {
+	for _, p := range res.patterns {
+		matched, _ := filepath.Match(p.Glob, filepath.Base(filename))
+		if matched {
+			return p.Strategy
+		}
+	}
+	return res.fallback
+}
+
+func parseMergeFile(data []byte) []PatternRule {
+	var rules []PatternRule
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			rules = append(rules, PatternRule{Glob: parts[0], Strategy: parts[1]})
+		}
+	}
+	return rules
+}

--- a/go-libfossil/merge/strategy.go
+++ b/go-libfossil/merge/strategy.go
@@ -1,0 +1,45 @@
+package merge
+
+import libfossil "github.com/dmestas/edgesync/go-libfossil"
+
+// Strategy merges three versions of content.
+type Strategy interface {
+	Name() string
+	Merge(base, local, remote []byte) (*Result, error)
+}
+
+// Result of a merge operation.
+type Result struct {
+	Content   []byte     // merged output (may contain conflict markers)
+	Conflicts []Conflict // unresolved conflict regions
+	Clean     bool       // true if no conflicts
+}
+
+// Conflict describes one conflicting region.
+type Conflict struct {
+	StartLine int
+	EndLine   int
+	Local     []byte
+	Remote    []byte
+	Base      []byte
+}
+
+// Fork represents two divergent checkins sharing a common ancestor.
+type Fork struct {
+	Ancestor  libfossil.FslID
+	LocalTip  libfossil.FslID
+	RemoteTip libfossil.FslID
+}
+
+// StrategyByName returns a strategy implementation by name.
+func StrategyByName(name string) (Strategy, bool) {
+	s, ok := strategies[name]
+	return s, ok
+}
+
+var strategies = map[string]Strategy{}
+
+// Register adds a strategy to the registry.
+func Register(s Strategy) {
+	strategies[s.Name()] = s
+}

--- a/go-libfossil/merge/threeway.go
+++ b/go-libfossil/merge/threeway.go
@@ -1,0 +1,265 @@
+package merge
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+func init() { Register(&ThreeWayText{}) }
+
+// ThreeWayText implements line-level 3-way merge.
+type ThreeWayText struct{}
+
+func (t *ThreeWayText) Name() string { return "three-way" }
+
+func (t *ThreeWayText) Merge(base, local, remote []byte) (*Result, error) {
+	// Fast paths.
+	if bytes.Equal(local, remote) {
+		return &Result{Content: local, Clean: true}, nil
+	}
+	if bytes.Equal(base, local) {
+		return &Result{Content: remote, Clean: true}, nil
+	}
+	if bytes.Equal(base, remote) {
+		return &Result{Content: local, Clean: true}, nil
+	}
+
+	baseLines := splitLines(base)
+	localLines := splitLines(local)
+	remoteLines := splitLines(remote)
+
+	// Compute LCS-based diff hunks for base→local and base→remote.
+	localDiff := diffLines(baseLines, localLines)
+	remoteDiff := diffLines(baseLines, remoteLines)
+
+	// Merge the two diffs against the base.
+	merged, conflicts := merge3(baseLines, localLines, remoteLines, localDiff, remoteDiff)
+
+	var buf bytes.Buffer
+	for _, line := range merged {
+		buf.WriteString(line)
+	}
+
+	return &Result{
+		Content:   buf.Bytes(),
+		Conflicts: conflicts,
+		Clean:     len(conflicts) == 0,
+	}, nil
+}
+
+// hunk represents a change region: replace base[baseStart:baseEnd] with lines.
+type hunk struct {
+	baseStart int // first base line affected (0-indexed)
+	baseEnd   int // one past last base line affected
+	lines     []string
+}
+
+// diffLines computes a list of hunks that transform base into modified.
+func diffLines(base, modified []string) []hunk {
+	lcs := longestCommonSubseq(base, modified)
+
+	var hunks []hunk
+	bi, mi := 0, 0
+
+	for _, match := range lcs {
+		if bi < match.baseIdx || mi < match.modIdx {
+			hunks = append(hunks, hunk{
+				baseStart: bi,
+				baseEnd:   match.baseIdx,
+				lines:     modified[mi:match.modIdx],
+			})
+		}
+		bi = match.baseIdx + 1
+		mi = match.modIdx + 1
+	}
+	// Trailing changes after last match.
+	if bi < len(base) || mi < len(modified) {
+		hunks = append(hunks, hunk{
+			baseStart: bi,
+			baseEnd:   len(base),
+			lines:     modified[mi:],
+		})
+	}
+	return hunks
+}
+
+type lcsMatch struct {
+	baseIdx int
+	modIdx  int
+}
+
+// longestCommonSubseq finds matching lines between base and modified.
+func longestCommonSubseq(a, b []string) []lcsMatch {
+	m, n := len(a), len(b)
+	// DP table.
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := m - 1; i >= 0; i-- {
+		for j := n - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				dp[i][j] = dp[i+1][j+1] + 1
+			} else if dp[i+1][j] >= dp[i][j+1] {
+				dp[i][j] = dp[i+1][j]
+			} else {
+				dp[i][j] = dp[i][j+1]
+			}
+		}
+	}
+	// Backtrack to find matches.
+	var matches []lcsMatch
+	i, j := 0, 0
+	for i < m && j < n {
+		if a[i] == b[j] {
+			matches = append(matches, lcsMatch{i, j})
+			i++
+			j++
+		} else if dp[i+1][j] >= dp[i][j+1] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return matches
+}
+
+// merge3 combines two sets of hunks against a common base.
+func merge3(base, local, remote []string, localHunks, remoteHunks []hunk) ([]string, []Conflict) {
+	var result []string
+	var conflicts []Conflict
+
+	li, ri := 0, 0 // hunk indices
+	bi := 0         // base line index
+
+	for bi <= len(base) {
+		var lh, rh *hunk
+		if li < len(localHunks) {
+			lh = &localHunks[li]
+		}
+		if ri < len(remoteHunks) {
+			rh = &remoteHunks[ri]
+		}
+
+		// No more hunks — copy remaining base.
+		if lh == nil && rh == nil {
+			if bi < len(base) {
+				result = append(result, base[bi:]...)
+			}
+			break
+		}
+
+		// Find the next hunk start.
+		nextStart := len(base)
+		if lh != nil && lh.baseStart < nextStart {
+			nextStart = lh.baseStart
+		}
+		if rh != nil && rh.baseStart < nextStart {
+			nextStart = rh.baseStart
+		}
+
+		// Copy base lines before the next hunk.
+		if bi < nextStart {
+			result = append(result, base[bi:nextStart]...)
+			bi = nextStart
+		}
+
+		// Determine if hunks overlap.
+		if lh != nil && rh != nil && hunksOverlap(lh, rh) {
+			// Both sides changed an overlapping region.
+			if sameHunkContent(lh, rh) {
+				// Same change — take one copy.
+				result = append(result, lh.lines...)
+			} else {
+				// Conflict.
+				conflict := Conflict{
+					StartLine: bi + 1,
+					Local:     []byte(strings.Join(lh.lines, "")),
+					Remote:    []byte(strings.Join(rh.lines, "")),
+				}
+				// Find the base region covered by both hunks.
+				start := min(lh.baseStart, rh.baseStart)
+				end := max(lh.baseEnd, rh.baseEnd)
+				if start < end {
+					conflict.Base = []byte(strings.Join(base[start:end], ""))
+				}
+				conflict.EndLine = bi + max(lh.baseEnd, rh.baseEnd) - bi
+
+				result = append(result, "<<<<<<< LOCAL\n")
+				result = append(result, lh.lines...)
+				if len(lh.lines) > 0 && !strings.HasSuffix(lh.lines[len(lh.lines)-1], "\n") {
+					result = append(result, "\n")
+				}
+				result = append(result, "=======\n")
+				result = append(result, rh.lines...)
+				if len(rh.lines) > 0 && !strings.HasSuffix(rh.lines[len(rh.lines)-1], "\n") {
+					result = append(result, "\n")
+				}
+				result = append(result, ">>>>>>> REMOTE\n")
+				conflicts = append(conflicts, conflict)
+			}
+			bi = max(lh.baseEnd, rh.baseEnd)
+			li++
+			ri++
+			continue
+		}
+
+		// Non-overlapping: apply whichever hunk starts first.
+		if lh != nil && (rh == nil || lh.baseStart <= rh.baseStart) {
+			result = append(result, lh.lines...)
+			bi = lh.baseEnd
+			li++
+		} else if rh != nil {
+			result = append(result, rh.lines...)
+			bi = rh.baseEnd
+			ri++
+		}
+	}
+
+	return result, conflicts
+}
+
+func hunksOverlap(a, b *hunk) bool {
+	return a.baseStart < b.baseEnd && b.baseStart < a.baseEnd
+}
+
+func sameHunkContent(a, b *hunk) bool {
+	if len(a.lines) != len(b.lines) {
+		return false
+	}
+	for i := range a.lines {
+		if a.lines[i] != b.lines[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func splitLines(data []byte) []string {
+	if len(data) == 0 {
+		return nil
+	}
+	lines := strings.SplitAfter(string(data), "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// Ensure fmt is available for error formatting if needed.
+var _ = fmt.Sprintf

--- a/go-libfossil/merge/threeway_test.go
+++ b/go-libfossil/merge/threeway_test.go
@@ -1,0 +1,176 @@
+package merge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestThreeWayIdentical(t *testing.T) {
+	base := []byte("same\n")
+	r, err := (&ThreeWayText{}).Merge(base, base, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatal("expected clean merge")
+	}
+	if string(r.Content) != "same\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayOnlyLocalChanged(t *testing.T) {
+	base := []byte("line1\nline2\nline3\n")
+	local := []byte("line1\nMODIFIED\nline3\n")
+	remote := []byte("line1\nline2\nline3\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatal("expected clean merge")
+	}
+	if string(r.Content) != "line1\nMODIFIED\nline3\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayOnlyRemoteChanged(t *testing.T) {
+	base := []byte("line1\nline2\nline3\n")
+	local := []byte("line1\nline2\nline3\n")
+	remote := []byte("line1\nline2\nREMOTE\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatal("expected clean merge")
+	}
+	if string(r.Content) != "line1\nline2\nREMOTE\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayBothChangedSame(t *testing.T) {
+	base := []byte("old\n")
+	local := []byte("new\n")
+	remote := []byte("new\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatal("expected clean merge (both made same change)")
+	}
+}
+
+func TestThreeWayNonOverlapping(t *testing.T) {
+	base := []byte("aaa\nbbb\nccc\n")
+	local := []byte("AAA\nbbb\nccc\n")
+	remote := []byte("aaa\nbbb\nCCC\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatalf("expected clean merge, got %d conflicts", len(r.Conflicts))
+	}
+	if string(r.Content) != "AAA\nbbb\nCCC\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayConflict(t *testing.T) {
+	base := []byte("original\n")
+	local := []byte("local version\n")
+	remote := []byte("remote version\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Clean {
+		t.Fatal("expected conflict")
+	}
+	if len(r.Conflicts) == 0 {
+		t.Fatal("expected at least one conflict")
+	}
+	if !strings.Contains(string(r.Content), "<<<<<<< LOCAL") {
+		t.Fatalf("expected conflict markers, got %q", r.Content)
+	}
+	if !strings.Contains(string(r.Content), "local version") {
+		t.Fatalf("expected local content in markers")
+	}
+	if !strings.Contains(string(r.Content), "remote version") {
+		t.Fatalf("expected remote content in markers")
+	}
+}
+
+func TestThreeWayLocalAddsLines(t *testing.T) {
+	base := []byte("a\nc\n")
+	local := []byte("a\nb\nc\n")
+	remote := []byte("a\nc\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatalf("expected clean merge, got %d conflicts", len(r.Conflicts))
+	}
+	if string(r.Content) != "a\nb\nc\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayRemoteAddsLines(t *testing.T) {
+	base := []byte("a\nc\n")
+	local := []byte("a\nc\n")
+	remote := []byte("a\nb\nc\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatal("expected clean merge")
+	}
+	if string(r.Content) != "a\nb\nc\n" {
+		t.Fatalf("got %q", r.Content)
+	}
+}
+
+func TestThreeWayEmptyBase(t *testing.T) {
+	base := []byte("")
+	local := []byte("same line\n")
+	remote := []byte("different line\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both added different content to empty base — conflict.
+	// (Both sides insert at position 0, overlapping hunk.)
+	if r.Clean {
+		// If the algorithm treats both as non-overlapping inserts, that's
+		// also acceptable for empty base — just verify both are present.
+		if !strings.Contains(string(r.Content), "same line") || !strings.Contains(string(r.Content), "different line") {
+			t.Fatalf("expected both additions, got %q", r.Content)
+		}
+	}
+}
+
+func TestThreeWayBothAddDifferentRegions(t *testing.T) {
+	base := []byte("line1\nline2\nline3\nline4\nline5\n")
+	local := []byte("LOCAL\nline1\nline2\nline3\nline4\nline5\n")
+	remote := []byte("line1\nline2\nline3\nline4\nline5\nREMOTE\n")
+	r, err := (&ThreeWayText{}).Merge(base, local, remote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Clean {
+		t.Fatalf("expected clean merge (additions in different regions), got %d conflicts", len(r.Conflicts))
+	}
+	if !strings.Contains(string(r.Content), "LOCAL") {
+		t.Fatal("missing local addition")
+	}
+	if !strings.Contains(string(r.Content), "REMOTE") {
+		t.Fatal("missing remote addition")
+	}
+}

--- a/go-libfossil/sync/integration_test.go
+++ b/go-libfossil/sync/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 
 // startFossilServer starts a fossil server on a free port and returns the URL
 // and a cleanup function.
-func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func()) {
+func startFossilServer(t *testing.T, repoPath string) string {
 	t.Helper()
 
 	bin := testutil.FossilBinary()
@@ -59,10 +60,22 @@ func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func(
 
 ready:
 	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	return serverURL, func() {
+	// Register cleanup via t.Cleanup so it runs before TempDir removal (LIFO).
+	t.Cleanup(func() {
 		cmd.Process.Kill()
 		cmd.Wait()
-	}
+		// Remove WAL/SHM files that fossil processes leave behind,
+		// so t.TempDir() cleanup doesn't fail with "directory not empty".
+		dir := filepath.Dir(repoPath)
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			name := e.Name()
+			if strings.HasSuffix(name, "-wal") || strings.HasSuffix(name, "-shm") || strings.HasSuffix(name, "-journal") {
+				os.Remove(filepath.Join(dir, name))
+			}
+		}
+	})
+	return serverURL
 }
 
 // getProjectCode reads the project-code from a fossil repo.
@@ -107,7 +120,11 @@ func TestIntegrationPushToFossilServer(t *testing.T) {
 	}
 	bin := testutil.FossilBinary()
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "TestIntegrationPush*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
 	// 1. Create a Go-managed local repo with a checkin
 	localPath := filepath.Join(dir, "local.fossil")
@@ -152,8 +169,7 @@ func TestIntegrationPushToFossilServer(t *testing.T) {
 	}
 
 	// 4. Start fossil server on the remote
-	serverURL, serverCleanup := startFossilServer(t, remotePath)
-	defer serverCleanup()
+	serverURL := startFossilServer(t, remotePath)
 
 	// 5. Re-open local repo and push via our sync engine
 	r2, err := repo.Open(localPath)
@@ -198,7 +214,11 @@ func TestIntegrationPullFromFossilServer(t *testing.T) {
 	}
 	bin := testutil.FossilBinary()
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "TestIntegrationPull*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
 	// 1. Create a remote repo with fossil new
 	remotePath := filepath.Join(dir, "remote.fossil")
@@ -209,8 +229,7 @@ func TestIntegrationPullFromFossilServer(t *testing.T) {
 	}
 
 	// 2. Start fossil server on the remote
-	serverURL, cleanup := startFossilServer(t, remotePath)
-	defer cleanup()
+	serverURL := startFossilServer(t, remotePath)
 
 	// 3. Clone it to local with fossil clone (so project/server codes match)
 	localPath := filepath.Join(dir, "local.fossil")

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/dmestas/edgesync
 
 go 1.23
 
-require github.com/alecthomas/kong v1.14.0 // indirect
+require (
+	github.com/alecthomas/kong v1.14.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/dmestas/edgesync
 
 go 1.23
+
+require github.com/alecthomas/kong v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=
+github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=
 github.com/alecthomas/kong v1.14.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=

--- a/leaf/agent/integration_test.go
+++ b/leaf/agent/integration_test.go
@@ -22,7 +22,7 @@ import (
 
 // startFossilServer starts a fossil server on a free port and returns the URL
 // and a cleanup function. The server is shut down when the test ends.
-func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func()) {
+func startFossilServer(t *testing.T, repoPath string) string {
 	t.Helper()
 
 	bin := testutil.FossilBinary()
@@ -61,10 +61,13 @@ func startFossilServer(t *testing.T, repoPath string) (url string, cleanup func(
 
 ready:
 	serverURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	return serverURL, func() {
+	t.Cleanup(func() {
 		cmd.Process.Kill()
 		cmd.Wait()
-	}
+		os.Remove(repoPath + "-wal")
+		os.Remove(repoPath + "-shm")
+	})
+	return serverURL
 }
 
 // startTestBridge subscribes to NATS subject fossil.<projectCode>.sync and
@@ -146,8 +149,7 @@ func TestIntegrationLeafPush(t *testing.T) {
 	}
 
 	// 3. Start fossil server on the remote.
-	fossilURL, fossilCleanup := startFossilServer(t, remotePath)
-	defer fossilCleanup()
+	fossilURL := startFossilServer(t, remotePath)
 
 	// 4. Start embedded NATS.
 	natsURL := startEmbeddedNATS(t)


### PR DESCRIPTION
## Summary

Single `edgesync` binary with 35 kong-based commands across 3 groups: repo operations (30), sync agent (2), bridge (1). All libfossil f-apps covered except annotate.

## Commands

```
# Repo lifecycle
edgesync repo new / ci / co / ls / timeline / cat / info

# Inspection & utilities
edgesync repo hash / delta create|apply / config ls|get|set / query / verify / resolve / extract

# Checkout operations
edgesync repo open / status / add / rm / rename / revert / diff

# Wiki & tags
edgesync repo wiki ls|export / tag ls|add

# Merge system (swappable strategies)
edgesync repo merge <version> [--strategy three-way|last-writer-wins|binary|conflict-fork]
edgesync repo conflicts [ls|show|pick|merge|extract]
edgesync repo mark-resolved <file>

# Sync & bridge
edgesync sync start / now
edgesync bridge serve
```

## Merge System (`go-libfossil/merge/`)

4 swappable strategies via `Strategy` interface:
- **ThreeWayText**: LCS-based line merge with conflict markers
- **LastWriterWins**: pick newer version by timestamp
- **Binary**: always conflict (can't auto-merge)
- **ConflictFork**: offline-first, preserve all versions in Fossil-idiomatic conflict table

Per-file strategy via `.edgesync-merge` config file (syncs across nodes).

Conflict recovery workflow: `conflicts show` → `conflicts pick`/`conflicts merge`/`conflicts extract` → `mark-resolved`

## Also included

- SQLite driver adapter: build-tag selection for modernc/ncruces/mattn
- DST driver matrix in CI
- Fix: NATS subscription race in bridge.Start()
- Fix: TempDir cleanup in integration tests

## Test results

- 14 go-libfossil packages: all pass
- 19 merge tests (10 algorithm + 4 Fossil-validated + 5 DAG/resolver): all pass
- 36 DST tests: all pass
- leaf/agent + bridge: all pass
- 35 CLI commands: validated end-to-end
- `fossil rebuild`: 100% complete on all strategy outputs

## Binary sizes

| Driver | Stripped | Notes |
|--------|---------|-------|
| modernc (default) | 13M | Pure Go, compiles everywhere |
| ncruces | 17M | WASM-capable |
| mattn | 14M | CGo, best database/sql perf |

Generated with [Claude Code](https://claude.com/claude-code)