### PR TITLE
Integrate Crosslink into sync.Clone path

### DIFF
--- a/go-libfossil/sync/clone.go
+++ b/go-libfossil/sync/clone.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
 	"github.com/dmestas/edgesync/go-libfossil/xfer"
@@ -94,6 +95,14 @@ func Clone(ctx context.Context, path string, t Transport, opts CloneOpts) (r *re
 		err = cloneErr
 		return
 	}
+
+	// Crosslink: parse received manifests into event/plink/leaf/mlink tables.
+	linked, xlinkErr := manifest.Crosslink(r)
+	if xlinkErr != nil {
+		err = fmt.Errorf("sync.Clone: crosslink: %w", xlinkErr)
+		return
+	}
+	cloneResult.CheckinsLinked = linked
 
 	return r, cloneResult, nil
 }

--- a/go-libfossil/sync/clone_test.go
+++ b/go-libfossil/sync/clone_test.go
@@ -2,11 +2,14 @@ package sync_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/deck"
 	"github.com/dmestas/edgesync/go-libfossil/delta"
 	"github.com/dmestas/edgesync/go-libfossil/hash"
 	"github.com/dmestas/edgesync/go-libfossil/sync"
@@ -335,4 +338,102 @@ func TestCloneWithPhantoms(t *testing.T) {
 	}
 
 	t.Logf("Clone with phantoms: rounds=%d blobs=%d", result.Rounds, result.BlobsRecvd)
+}
+
+// TestCloneCrosslinksManifests verifies that Clone automatically populates the
+// event/plink/leaf tables by crosslinking received manifest blobs.
+func TestCloneCrosslinksManifests(t *testing.T) {
+	// Build a file blob.
+	fileContent := []byte("hello from crosslink test")
+	fileUUID := hash.SHA1(fileContent)
+
+	// Build a checkin manifest referencing the file.
+	d := &deck.Deck{
+		Type: deck.Checkin,
+		C:    "test checkin",
+		D:    time.Date(2026, 3, 21, 12, 0, 0, 0, time.UTC),
+		F:    []deck.FileCard{{Name: "hello.txt", UUID: fileUUID}},
+		U:    "tester",
+		T: []deck.TagCard{
+			{Type: deck.TagPropagating, Name: "branch", UUID: "*", Value: "trunk"},
+			{Type: deck.TagSingleton, Name: "sym-trunk", UUID: "*"},
+		},
+	}
+
+	// Compute R-card.
+	rHash, err := d.ComputeR(func(uuid string) ([]byte, error) {
+		if uuid == fileUUID {
+			return fileContent, nil
+		}
+		return nil, fmt.Errorf("unknown uuid: %s", uuid)
+	})
+	if err != nil {
+		t.Fatalf("ComputeR: %v", err)
+	}
+	d.R = rHash
+
+	manifestBytes, err := d.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	manifestUUID := hash.SHA1(manifestBytes)
+
+	transport := &mockCloneTransport{
+		handler: func(round int, req *xfer.Message) *xfer.Message {
+			if round == 0 {
+				return &xfer.Message{Cards: []xfer.Card{
+					&xfer.PushCard{ServerCode: "srv1", ProjectCode: "proj1"},
+					&xfer.FileCard{UUID: fileUUID, Content: fileContent},
+					&xfer.FileCard{UUID: manifestUUID, Content: manifestBytes},
+					&xfer.CloneSeqNoCard{SeqNo: 0},
+				}}
+			}
+			return &xfer.Message{Cards: []xfer.Card{
+				&xfer.CloneSeqNoCard{SeqNo: 0},
+			}}
+		},
+	}
+
+	tmpDir := t.TempDir()
+	repoPath := filepath.Join(tmpDir, "crosslink.fossil")
+
+	r, result, err := sync.Clone(context.Background(), repoPath, transport, sync.CloneOpts{})
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+	defer r.Close()
+
+	// Verify blobs received.
+	if result.BlobsRecvd != 2 {
+		t.Errorf("BlobsRecvd = %d, want 2", result.BlobsRecvd)
+	}
+
+	// Verify crosslink populated the event table.
+	if result.CheckinsLinked != 1 {
+		t.Errorf("CheckinsLinked = %d, want 1", result.CheckinsLinked)
+	}
+
+	var eventCount int
+	if err := r.DB().QueryRow("SELECT count(*) FROM event WHERE type='ci'").Scan(&eventCount); err != nil {
+		t.Fatalf("query event: %v", err)
+	}
+	if eventCount != 1 {
+		t.Errorf("event count = %d, want 1", eventCount)
+	}
+
+	// Verify leaf table has the manifest.
+	var leafCount int
+	if err := r.DB().QueryRow("SELECT count(*) FROM leaf").Scan(&leafCount); err != nil {
+		t.Fatalf("query leaf: %v", err)
+	}
+	if leafCount != 1 {
+		t.Errorf("leaf count = %d, want 1", leafCount)
+	}
+
+	// Verify manifest blob exists.
+	if _, ok := blob.Exists(r.DB(), manifestUUID); !ok {
+		t.Error("manifest blob not found")
+	}
+
+	t.Logf("Clone crosslink: rounds=%d blobs=%d checkins=%d", result.Rounds, result.BlobsRecvd, result.CheckinsLinked)
 }

--- a/go-libfossil/sync/stubs.go
+++ b/go-libfossil/sync/stubs.go
@@ -13,9 +13,10 @@ type CloneOpts struct {
 
 // CloneResult reports what happened during a clone.
 type CloneResult struct {
-	Rounds      int
-	BlobsRecvd  int
-	ProjectCode string
-	ServerCode  string
-	Messages    []string // Informational messages from server
+	Rounds         int
+	BlobsRecvd     int
+	CheckinsLinked int      // Manifests crosslinked into event table
+	ProjectCode    string
+	ServerCode     string
+	Messages       []string // Informational messages from server
 }


### PR DESCRIPTION
## Summary
- `sync.Clone` now automatically crosslinks received manifest blobs into `event`/`plink`/`leaf`/`mlink` tables after blob transfer
- New `CloneResult.CheckinsLinked` field reports how many manifests were crosslinked
- New `TestCloneCrosslinksManifests` builds a real checkin manifest, clones it, and verifies event/leaf tables

Closes CDG-144.

## Test plan
- [x] All 8 clone tests pass (including new crosslink test)
- [x] All pre-commit tests pass (unit + DST + sim serve)
- [x] `TestCloneCrosslinksManifests`: 2 blobs received, 1 checkin crosslinked, event count=1, leaf count=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clone operation now processes and crosslinks manifests into repository tables during synchronization.
  * CloneResult now includes a new field tracking the number of checkins linked during clone operations.

* **Tests**
  * Added test coverage for manifest crosslinking functionality including blob storage verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->