### PR TITLE
leaf/wsdialer: add browser WebSocket dialer for NATS

### DIFF
--- a/leaf/wsdialer/conn.go
+++ b/leaf/wsdialer/conn.go
@@ -1,0 +1,157 @@
+//go:build js
+
+package wsdialer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"syscall/js"
+	"time"
+)
+
+// wsConn wraps a browser WebSocket as a net.Conn.
+// Messages from the WebSocket are buffered in a channel; Read() drains
+// them through a bytes.Reader to provide stream semantics.
+//
+// Note: js.FuncOf callbacks are not released — acceptable for spike scope.
+// Production code should store them on the struct and Release() in Close().
+type wsConn struct {
+	ws     js.Value
+	msgCh  chan []byte
+	reader *bytes.Reader
+
+	mu     sync.Mutex
+	closed bool
+
+	openCh chan struct{}
+	errCh  chan error
+}
+
+func newWSConn(url string) *wsConn {
+	c := &wsConn{
+		msgCh:  make(chan []byte, 256),
+		reader: bytes.NewReader(nil),
+		openCh: make(chan struct{}),
+		errCh:  make(chan error, 1),
+	}
+
+	ws := js.Global().Get("WebSocket").New(url)
+	ws.Set("binaryType", "arraybuffer")
+	c.ws = ws
+
+	ws.Call("addEventListener", "open", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		close(c.openCh)
+		return nil
+	}))
+
+	ws.Call("addEventListener", "error", js.FuncOf(func(_ js.Value, args []js.Value) any {
+		select {
+		case c.errCh <- fmt.Errorf("websocket error"):
+		default:
+		}
+		return nil
+	}))
+
+	ws.Call("addEventListener", "close", js.FuncOf(func(_ js.Value, _ []js.Value) any {
+		c.mu.Lock()
+		c.closed = true
+		c.mu.Unlock()
+		// Unblock any pending Read.
+		select {
+		case c.msgCh <- nil:
+		default:
+		}
+		return nil
+	}))
+
+	ws.Call("addEventListener", "message", js.FuncOf(func(_ js.Value, args []js.Value) any {
+		arrayBuf := args[0].Get("data")
+		buf := make([]byte, arrayBuf.Get("byteLength").Int())
+		js.CopyBytesToGo(buf, js.Global().Get("Uint8Array").New(arrayBuf))
+		// Drop-newest if buffer full.
+		select {
+		case c.msgCh <- buf:
+		default:
+		}
+		return nil
+	}))
+
+	return c
+}
+
+// waitOpen blocks until the WebSocket is open or fails.
+func (c *wsConn) waitOpen() error {
+	select {
+	case <-c.openCh:
+		return nil
+	case err := <-c.errCh:
+		return err
+	case <-time.After(5 * time.Second):
+		return errors.New("websocket open timeout (5s)")
+	}
+}
+
+// Read implements net.Conn. Uses an internal bytes.Reader to bridge
+// WebSocket message framing to stream semantics.
+func (c *wsConn) Read(p []byte) (int, error) {
+	// Drain leftover bytes from the previous message first.
+	if c.reader.Len() > 0 {
+		return c.reader.Read(p)
+	}
+
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return 0, net.ErrClosed
+	}
+
+	msg, ok := <-c.msgCh
+	if !ok || msg == nil {
+		return 0, net.ErrClosed
+	}
+	c.reader.Reset(msg)
+	return c.reader.Read(p)
+}
+
+// Write implements net.Conn. Sends binary data via WebSocket.
+func (c *wsConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return 0, net.ErrClosed
+	}
+
+	buf := js.Global().Get("Uint8Array").New(len(p))
+	js.CopyBytesToJS(buf, p)
+	c.ws.Call("send", buf.Get("buffer"))
+	return len(p), nil
+}
+
+// Close implements net.Conn.
+func (c *wsConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	c.ws.Call("close")
+	return nil
+}
+
+// Stubs — nats.go uses its own ping/pong timeouts, not net.Conn deadlines.
+func (c *wsConn) LocalAddr() net.Addr                { return wsAddr{} }
+func (c *wsConn) RemoteAddr() net.Addr               { return wsAddr{} }
+func (c *wsConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *wsConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *wsConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+type wsAddr struct{}
+
+func (wsAddr) Network() string { return "websocket" }
+func (wsAddr) String() string  { return "websocket" }

--- a/leaf/wsdialer/dialer.go
+++ b/leaf/wsdialer/dialer.go
@@ -1,0 +1,31 @@
+//go:build js
+
+package wsdialer
+
+import (
+	"fmt"
+	"net"
+)
+
+// WSDialer implements nats.CustomDialer using the browser's WebSocket API.
+// The URL field is the ws:// address of the NATS server's WebSocket port.
+//
+// Usage:
+//
+//	nats.Connect(url, nats.SetCustomDialer(&wsdialer.WSDialer{URL: "ws://localhost:8080"}))
+type WSDialer struct {
+	URL string
+}
+
+// Dial creates a new WebSocket connection. The network and address parameters
+// are ignored — the dialer always connects to the configured URL.
+func (d *WSDialer) Dial(network, address string) (net.Conn, error) {
+	if d.URL == "" {
+		panic("wsdialer: URL must not be empty")
+	}
+	conn := newWSConn(d.URL)
+	if err := conn.waitOpen(); err != nil {
+		return nil, fmt.Errorf("wsdialer: %w", err)
+	}
+	return conn, nil
+}


### PR DESCRIPTION
## Summary

- Adds `leaf/wsdialer/` package (~190 LOC) that implements `nats.CustomDialer` using `syscall/js` to wrap the browser's native WebSocket API as a `net.Conn`
- Enables NATS client connectivity from browser WASM (`GOOS=js GOARCH=wasm`)
- Build-tagged `//go:build js` — zero impact on native builds

## Components

- **`conn.go`** — `wsConn` wraps browser WebSocket as `net.Conn`. Buffered channel (256 msgs, drop-newest) + `bytes.Reader` for stream semantics over WebSocket message framing.
- **`dialer.go`** — `WSDialer` implements `nats.CustomDialer`. Creates `wsConn` and waits for WebSocket open.

## Spike Results

Proven on `spike/nats-wasm-leaf` branch with 15/15 tests passing:

| Capability | Status |
|-----------|--------|
| Pub/Sub | PASS |
| Request/Reply | PASS |
| Queue Groups | PASS |
| Wildcard Subscriptions | PASS |
| Large Payloads (512KB) | PASS |
| Concurrent Operations (10x) | PASS |
| WASM as Responder | PASS |

Performance: avg 3.4ms latency, 111K msg/s throughput, 10MB binary.

## Key Finding

Must use `nats://` scheme (not `ws://`) with `nats.SetCustomDialer()`. The `ws://` scheme triggers nats.go's own WebSocket upgrade, conflicting with the custom dialer.

## Test plan

- [x] `GOOS=js GOARCH=wasm go build ./leaf/wsdialer/` compiles clean
- [x] `go build ./leaf/...` native build unaffected
- [x] Pre-commit hooks pass (~8s)
- [x] 15/15 manual browser tests on spike branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket connectivity for browser-based applications, enabling secure network connections with automatic connection handling and error recovery.
  * Supports standard network interfaces for seamless integration with existing protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->