### PR TITLE
Fix: process file cards before igot in HandleSync

### DIFF
--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -93,10 +93,26 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 		h.handleControlCard(card)
 	}
 
-	// Second pass: handle data cards.
+	// Second pass: handle file cards first (so blobs are stored before
+	// igot cards check existence — prevents spurious gimmes for blobs
+	// received in the same request).
 	for _, card := range req.Cards {
-		if err := h.handleDataCard(card); err != nil {
-			return nil, err
+		switch card.(type) {
+		case *xfer.FileCard, *xfer.CFileCard:
+			if err := h.handleDataCard(card); err != nil {
+				return nil, err
+			}
+		}
+	}
+	// Third pass: handle remaining data cards.
+	for _, card := range req.Cards {
+		switch card.(type) {
+		case *xfer.FileCard, *xfer.CFileCard:
+			continue // already handled
+		default:
+			if err := h.handleDataCard(card); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix infinite sync loop when pushing new commits via NATS (or any HandleSync-based transport)
- Root cause: HandleSync processed IGotCard before FileCard in the same request, causing spurious GimmeCards for blobs being delivered in the same message
- Fix: split data card processing into two passes — files first, then igot/gimme/etc.

Fixes CDG-149.

## Test plan
- [x] All pre-commit tests pass (unit + DST + sim serve)
- [x] Native NATS push test: clone → commit → sync via NATS → converges in 2 rounds (was: exceeded 100 rounds)
- [x] Existing sync/handler tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization reliability by implementing a two-phase approach to data processing. File data is now processed first, followed by other data types, preventing conflicts during synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->