### PR TITLE
fix: UV sync convergence — clear stale uvToSend when hashes match

### DIFF
--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -432,7 +432,13 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 		return false, nil
 	}
 	if s.opts.UV && len(s.uvToSend) > 0 {
-		return false, nil
+		if !s.uvPushOK {
+			// Server did not grant uv-push-ok — UV hashes match,
+			// nothing to push. Clear stale uvToSend from prior rounds.
+			s.uvToSend = nil
+		} else {
+			return false, nil
+		}
 	}
 	if s.opts.UV && s.uvGimmes != nil && len(s.uvGimmes) > 0 {
 		return false, nil


### PR DESCRIPTION
## Summary
- Fix UV sync convergence failure where `uvToSend` never drained after initial sync
- `make dst` was timing out on all seeds (pre-existing on main)
- Root cause: `uvToSend` accumulated entries from `handleUVIGotCard` but server didn't send `uv-push-ok` (hashes matched), so entries were never sent or cleared
- Fix: clear `uvToSend` when `uvPushOK` is false — server's matching UV hash means nothing to push

## Impact
- `make dst` now passes all 8 seeds in ~3s each (was timing out at 30s)
- All sync/UV tests continue to pass

## Test plan
- [x] `make dst` — all 8 seeds pass
- [x] `make test` — full CI suite passes
- [x] Pre-commit hook passes

Fixes CDG-150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization handling to properly clear stale pending updates when the server does not support certain update features, preventing potential sync inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->