### PR TITLE
Fix: process file cards before igot in HandleSync (v2)

### DIFF
--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -93,10 +93,27 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 		h.handleControlCard(card)
 	}
 
-	// Second pass: handle data cards in wire order (matches Fossil's page_xfer).
+	// Second pass: handle file cards first so blobs are stored before
+	// IGotCard checks blob.Exists. Without this, a request containing
+	// both IGotCard and FileCard for the same blob produces a spurious
+	// GimmeCard — the IGotCard runs before the FileCard stores it.
 	for _, card := range req.Cards {
-		if err := h.handleDataCard(card); err != nil {
-			return nil, err
+		switch card.(type) {
+		case *xfer.FileCard, *xfer.CFileCard:
+			if err := h.handleDataCard(card); err != nil {
+				return nil, err
+			}
+		}
+	}
+	// Third pass: handle remaining data cards (igot, gimme, etc.).
+	for _, card := range req.Cards {
+		switch card.(type) {
+		case *xfer.FileCard, *xfer.CFileCard:
+			continue // Already handled above.
+		default:
+			if err := h.handleDataCard(card); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -403,3 +403,64 @@ func TestHandleReqConfigMissing(t *testing.T) {
 		t.Fatal("should not return config for nonexistent key")
 	}
 }
+
+// TestHandleSyncNoSpuriousGimmeForReceivedFile verifies that HandleSync
+// does NOT emit a GimmeCard for a blob that was delivered as a FileCard
+// in the same request. Regression test for the igot-before-file bug:
+// if IGotCard is processed before FileCard, blob.Exists returns false
+// and a spurious GimmeCard is emitted, causing infinite sync loops.
+func TestHandleSyncNoSpuriousGimmeForReceivedFile(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	defer r.Close()
+
+	// Create a blob to push to the handler.
+	content := []byte("test content for spurious gimme check")
+	uuid := hash.SHA1(content)
+
+	// Build a request with BOTH IGotCard and FileCard for the same blob.
+	// This mimics what a sync client sends when pushing a new blob:
+	// it announces via igot AND delivers the file in the same round.
+	req := &xfer.Message{
+		Cards: []xfer.Card{
+			&xfer.PushCard{
+				ServerCode:  "test-server",
+				ProjectCode: "test-project",
+			},
+			&xfer.PullCard{
+				ServerCode:  "test-server",
+				ProjectCode: "test-project",
+			},
+			&xfer.IGotCard{UUID: uuid},
+			&xfer.FileCard{UUID: uuid, Content: content},
+		},
+	}
+
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Check response for spurious gimme.
+	for _, card := range resp.Cards {
+		if g, ok := card.(*xfer.GimmeCard); ok && g.UUID == uuid {
+			t.Errorf("HandleSync emitted GimmeCard for %s which was delivered as FileCard in the same request — this causes infinite sync loops", uuid[:12])
+		}
+	}
+
+	// Verify the blob was actually stored.
+	if _, exists := blob.Exists(r.DB(), uuid); !exists {
+		t.Errorf("blob %s was not stored by HandleSync", uuid[:12])
+	}
+
+	// Verify the server acknowledges it via igot in the response.
+	found := false
+	for _, card := range resp.Cards {
+		if ig, ok := card.(*xfer.IGotCard); ok && ig.UUID == uuid {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("HandleSync did not emit IGotCard for %s in response", uuid[:12])
+	}
+}


### PR DESCRIPTION
## Summary
Re-apply the file-before-igot fix that was reverted in PR#21.

**Bug:** HandleSync processes data cards in wire order. When a client sends IGotCard and FileCard for the same blob in one request, `handleIGot` calls `blob.Exists` before `handleFile` stores it → spurious GimmeCard → infinite sync loop (exceeded 100 rounds).

**Fix:** Split data card processing into two passes: FileCard/CFileCard first, then remaining cards.

**Regression test:** `TestHandleSyncNoSpuriousGimmeForReceivedFile`
- Sends IGotCard + FileCard for same blob in one request
- Asserts no GimmeCard in response (FAILS without fix, PASSES with fix)
- Asserts blob stored and acknowledged via IGotCard

## Why this was reverted
PR#21 reverted to single-pass "wire order" to match Fossil's `page_xfer`. However, Fossil's C implementation processes file cards inline (stores immediately), and the igot handler checks after storage. Our Go implementation processes all cards sequentially, so the ordering matters.

## Test plan
- [x] New test fails without fix, passes with fix
- [x] All existing tests pass
- [x] Full make test passes (unit + DST + sim serve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a synchronization issue where file processing order could cause unnecessary data requests and create infinite sync loops.

* **Tests**
  * Added test case to prevent regression in file handling during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->