### PR TITLE
fix(sync): HandleSync emits PushCard and clone completion signal

### DIFF
--- a/go-libfossil/search/search_test.go
+++ b/go-libfossil/search/search_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/search"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
+
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/ncruces"
 )
 
 func newTestRepo(t *testing.T) *repo.Repo {

--- a/go-libfossil/sync/clone_test.go
+++ b/go-libfossil/sync/clone_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/dmestas/edgesync/go-libfossil/deck"
 	"github.com/dmestas/edgesync/go-libfossil/delta"
 	"github.com/dmestas/edgesync/go-libfossil/hash"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
 	"github.com/dmestas/edgesync/go-libfossil/sync"
 	"github.com/dmestas/edgesync/go-libfossil/xfer"
 )
@@ -436,4 +439,163 @@ func TestCloneCrosslinksManifests(t *testing.T) {
 	}
 
 	t.Logf("Clone crosslink: rounds=%d blobs=%d checkins=%d", result.Rounds, result.BlobsRecvd, result.CheckinsLinked)
+}
+
+// TestCloneViaHandler wires Clone() against HandleSync() with a real repo.
+// This is the integration test that catches protocol mismatches between
+// client and server — missing PushCard, missing completion signal, etc.
+func TestCloneViaHandler(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create source repo with a real checkin.
+	srcPath := filepath.Join(dir, "source.fossil")
+	srcRepo, err := repo.Create(srcPath, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+	defer srcRepo.Close()
+
+	_, _, err = manifest.Checkin(srcRepo, manifest.CheckinOpts{
+		Comment: "initial commit",
+		User:    "testuser",
+		Files: []manifest.File{
+			{Name: "README.md", Content: []byte("# Test repo\n")},
+			{Name: "hello.txt", Content: []byte("hello world\n")},
+			{Name: "src/main.go", Content: []byte("package main\n")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Checkin: %v", err)
+	}
+
+	// Read source project-code for verification.
+	var srcProjectCode string
+	srcRepo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&srcProjectCode)
+
+	// Wire Clone() against HandleSync() via MockTransport.
+	transport := &sync.MockTransport{
+		Handler: func(req *xfer.Message) *xfer.Message {
+			resp, err := sync.HandleSync(context.Background(), srcRepo, req)
+			if err != nil {
+				t.Fatalf("HandleSync: %v", err)
+			}
+			return resp
+		},
+	}
+
+	clonePath := filepath.Join(dir, "clone.fossil")
+	cloneRepo, result, err := sync.Clone(context.Background(), clonePath, transport, sync.CloneOpts{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer cloneRepo.Close()
+
+	// Verify blobs received (3 file blobs + 1 manifest).
+	if result.BlobsRecvd < 4 {
+		t.Errorf("BlobsRecvd = %d, want >= 4", result.BlobsRecvd)
+	}
+
+	// Verify crosslink produced a checkin.
+	if result.CheckinsLinked != 1 {
+		t.Errorf("CheckinsLinked = %d, want 1", result.CheckinsLinked)
+	}
+
+	// Verify project-code propagated.
+	if result.ProjectCode != srcProjectCode {
+		t.Errorf("ProjectCode = %q, want %q", result.ProjectCode, srcProjectCode)
+	}
+
+	// Verify tipRID query works (leaf + event tables populated).
+	var tipRID int64
+	err = cloneRepo.DB().QueryRow(`
+		SELECT l.rid FROM leaf l
+		JOIN event e ON e.objid=l.rid
+		WHERE e.type='ci'
+		ORDER BY e.mtime DESC LIMIT 1
+	`).Scan(&tipRID)
+	if err != nil {
+		t.Fatalf("tipRID query: %v", err)
+	}
+	if tipRID <= 0 {
+		t.Errorf("tipRID = %d, want > 0", tipRID)
+	}
+}
+
+// TestCloneViaHandlerMultipleCheckins verifies clone with parent-child checkins.
+func TestCloneViaHandlerMultipleCheckins(t *testing.T) {
+	dir := t.TempDir()
+
+	srcPath := filepath.Join(dir, "source.fossil")
+	srcRepo, err := repo.Create(srcPath, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+	defer srcRepo.Close()
+
+	// First checkin.
+	rid1, _, err := manifest.Checkin(srcRepo, manifest.CheckinOpts{
+		Comment: "first",
+		User:    "testuser",
+		Files:   []manifest.File{{Name: "a.txt", Content: []byte("v1")}},
+	})
+	if err != nil {
+		t.Fatalf("Checkin 1: %v", err)
+	}
+
+	// Second checkin (child of first).
+	rid2, _, err := manifest.Checkin(srcRepo, manifest.CheckinOpts{
+		Comment: "second",
+		User:    "testuser",
+		Parent:  rid1,
+		Files:   []manifest.File{{Name: "a.txt", Content: []byte("v2")}, {Name: "b.txt", Content: []byte("new")}},
+	})
+	if err != nil {
+		t.Fatalf("Checkin 2: %v", err)
+	}
+
+	// Third checkin (child of second).
+	_, _, err = manifest.Checkin(srcRepo, manifest.CheckinOpts{
+		Comment: "third",
+		User:    "testuser",
+		Parent:  rid2,
+		Files:   []manifest.File{{Name: "a.txt", Content: []byte("v3")}, {Name: "b.txt", Content: []byte("new")}},
+	})
+	if err != nil {
+		t.Fatalf("Checkin 3: %v", err)
+	}
+
+	transport := &sync.MockTransport{
+		Handler: func(req *xfer.Message) *xfer.Message {
+			resp, err := sync.HandleSync(context.Background(), srcRepo, req)
+			if err != nil {
+				t.Fatalf("HandleSync: %v", err)
+			}
+			return resp
+		},
+	}
+
+	clonePath := filepath.Join(dir, "clone.fossil")
+	cloneRepo, result, err := sync.Clone(context.Background(), clonePath, transport, sync.CloneOpts{})
+	if err != nil {
+		t.Fatalf("Clone: %v", err)
+	}
+	defer cloneRepo.Close()
+
+	if result.CheckinsLinked != 3 {
+		t.Errorf("CheckinsLinked = %d, want 3", result.CheckinsLinked)
+	}
+
+	// Verify plink has 2 parent-child links.
+	var plinkCount int
+	cloneRepo.DB().QueryRow("SELECT count(*) FROM plink").Scan(&plinkCount)
+	if plinkCount != 2 {
+		t.Errorf("plink count = %d, want 2", plinkCount)
+	}
+
+	// Verify 3 events.
+	var eventCount int
+	cloneRepo.DB().QueryRow("SELECT count(*) FROM event WHERE type='ci'").Scan(&eventCount)
+	if eventCount != 3 {
+		t.Errorf("event count = %d, want 3", eventCount)
+	}
 }

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -93,6 +93,21 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 		h.handleControlCard(card)
 	}
 
+	// Emit PushCard with project-code/server-code so the clone client can
+	// identify the repo. Only in clone mode — sync clients already have
+	// codes, and real Fossil treats server-sent "push" as unknown during sync.
+	if h.cloneMode {
+		var projectCode, serverCode string
+		_ = h.repo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode)
+		_ = h.repo.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&serverCode)
+		if projectCode != "" {
+			h.resp = append(h.resp, &xfer.PushCard{
+				ProjectCode: projectCode,
+				ServerCode:  serverCode,
+			})
+		}
+	}
+
 	// Second pass: handle file cards first so blobs are stored before
 	// IGotCard checks blob.Exists. Without this, a request containing
 	// both IGotCard and FileCard for the same blob produces a spurious
@@ -336,5 +351,10 @@ func (h *handler) emitCloneBatch() error {
 		lastRID = rid
 		count++
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	// All blobs sent — signal completion so the client stops requesting.
+	h.resp = append(h.resp, &xfer.CloneSeqNoCard{SeqNo: 0})
+	return nil
 }

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -251,8 +251,8 @@ func TestHandleClonePagination(t *testing.T) {
 	}
 
 	seqnos2 := findCards[*xfer.CloneSeqNoCard](resp2)
-	if len(seqnos2) > 0 {
-		t.Fatal("page 2: should not have clone_seqno (all blobs served)")
+	if len(seqnos2) != 1 || seqnos2[0].SeqNo != 0 {
+		t.Fatalf("page 2: expected clone_seqno 0 (completion), got %v", seqnos2)
 	}
 }
 
@@ -462,5 +462,51 @@ func TestHandleSyncNoSpuriousGimmeForReceivedFile(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("HandleSync did not emit IGotCard for %s in response", uuid[:12])
+	}
+}
+
+func TestHandlerEmitsPushCardOnClone(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	var projectCode, serverCode string
+	r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode)
+	r.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&serverCode)
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.CloneCard{Version: 1},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	pushCards := findCards[*xfer.PushCard](resp)
+	if len(pushCards) != 1 {
+		t.Fatalf("PushCard count = %d, want 1", len(pushCards))
+	}
+	if pushCards[0].ProjectCode != projectCode {
+		t.Errorf("ProjectCode = %q, want %q", pushCards[0].ProjectCode, projectCode)
+	}
+	if pushCards[0].ServerCode != serverCode {
+		t.Errorf("ServerCode = %q, want %q", pushCards[0].ServerCode, serverCode)
+	}
+}
+
+func TestHandlerNoPushCardOnPull(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Server must NOT emit PushCard on sync/pull — real Fossil treats
+	// server-sent "push" as unknown command during sync.
+	pushCards := findCards[*xfer.PushCard](resp)
+	if len(pushCards) != 0 {
+		t.Fatalf("PushCard count = %d, want 0 (push is clone-only)", len(pushCards))
 	}
 }


### PR DESCRIPTION
## Summary

- HandleSync now emits `PushCard` with project-code/server-code during clone (required for clone convergence)
- `emitCloneBatch` sends `CloneSeqNoCard{SeqNo: 0}` when all blobs are sent (signals transfer complete)
- PushCard only emitted in clone mode — not during sync/pull, where real Fossil treats server-sent "push" as unknown
- Fixed missing driver import in `search_test.go`

## What was broken

No test ever wired `Clone()` client against `HandleSync()` server. Each side was tested independently with mocks that hand-crafted the "right" responses. Three protocol gaps:

1. **No PushCard** — client never received project-code/server-code, clone looped forever
2. **No completion signal** — no `CloneSeqNoCard{SeqNo: 0}` when all blobs sent, client never knew transfer was done
3. **Missing integration test** — clone tests used mock handlers, handler tests never tested clone flow

## New tests

- `TestCloneViaHandler` — single checkin, Clone() against HandleSync() end-to-end
- `TestCloneViaHandlerMultipleCheckins` — 3 parent-child checkins, verifies plink/event tables
- `TestHandlerEmitsPushCardOnClone` — verifies PushCard with correct codes on clone
- `TestHandlerNoPushCardOnPull` — verifies no PushCard on sync/pull (Fossil compat)

## Test plan

- [x] `go test ./go-libfossil/sync/ -count=1` — all pass
- [x] `go test ./sim/ -run "TestServeHTTP|TestLeafToLeaf|TestAgentServe"` — all pass
- [x] Pre-commit hook passes (unit + DST + sim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)