### PR TITLE
feat(auth): user auth, capabilities, and invite tokens

### DIFF
--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -57,6 +57,8 @@ type RepoCmd struct {
 	Blame        RepoBlameCmd        `cmd:"" help:"Alias for annotate"`
 	Branch       RepoBranchCmd       `cmd:"" help:"Branch operations"`
 	UV           RepoUVCmd           `cmd:"" name:"uv" help:"Unversioned file operations"`
+	User         RepoUserCmd         `cmd:"" help:"User management"`
+	Invite       RepoInviteCmd       `cmd:"" help:"Generate invite token for a user"`
 }
 
 type SyncCmd struct {

--- a/cmd/edgesync/invite.go
+++ b/cmd/edgesync/invite.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/auth"
+)
+
+type RepoInviteCmd struct {
+	Login string        `arg:"" help:"Username for the invitee"`
+	Cap   string        `help:"Capability string (e.g. oi)" required:""`
+	URL   string        `help:"Sync URL to embed in token" default:""`
+	TTL   time.Duration `help:"Token time-to-live (e.g. 24h)" default:"0"`
+}
+
+func (c *RepoInviteCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.CreateUser(r.DB(), pc, c.Login, password, c.Cap); err != nil {
+		return err
+	}
+
+	if c.TTL > 0 {
+		expiry := time.Now().Add(c.TTL).Format("2006-01-02 15:04:05")
+		if _, err := r.DB().Exec("UPDATE user SET cexpire=? WHERE login=?", expiry, c.Login); err != nil {
+			return fmt.Errorf("setting expiry: %w", err)
+		}
+	}
+
+	url := c.URL
+	if url == "" {
+		r.DB().QueryRow("SELECT value FROM config WHERE name='last-sync-url'").Scan(&url)
+	}
+
+	tok := auth.InviteToken{
+		URL:      url,
+		Login:    c.Login,
+		Password: password,
+		Caps:     c.Cap,
+	}
+
+	encoded := tok.Encode()
+
+	fmt.Printf("Invite for %q (capabilities: %s", c.Login, c.Cap)
+	if c.TTL > 0 {
+		fmt.Printf(", expires: %s", time.Now().Add(c.TTL).Format(time.RFC3339))
+	}
+	fmt.Println("):")
+	fmt.Println()
+	fmt.Printf("  edgesync repo clone --invite %s\n", encoded)
+	fmt.Println()
+	fmt.Println("Share this command with the recipient. It contains credentials - treat it like a password.")
+	return nil
+}

--- a/cmd/edgesync/repo_clone.go
+++ b/cmd/edgesync/repo_clone.go
@@ -5,17 +5,41 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/sync"
 )
 
 type RepoCloneCmd struct {
-	URL  string `arg:"" help:"Remote Fossil server URL"`
-	Path string `arg:"" help:"Local path for new repository file"`
-	User string `short:"u" help:"Username for clone auth"`
-	Pass string `short:"p" help:"Password for clone auth"`
+	URL    string `arg:"" optional:"" help:"Remote Fossil server URL"`
+	Path   string `arg:"" optional:"" help:"Local path for new repository file"`
+	User   string `short:"u" help:"Username for clone auth"`
+	Pass   string `short:"p" help:"Password for clone auth"`
+	Invite string `help:"Invite token (from edgesync invite)"`
 }
 
 func (c *RepoCloneCmd) Run(g *Globals) error {
+	if c.Invite != "" {
+		token, err := auth.DecodeInviteToken(c.Invite)
+		if err != nil {
+			return fmt.Errorf("invalid invite token: %w", err)
+		}
+		if c.URL == "" {
+			c.URL = token.URL
+		}
+		if c.User == "" {
+			c.User = token.Login
+		}
+		if c.Pass == "" {
+			c.Pass = token.Password
+		}
+	}
+	if c.URL == "" {
+		return fmt.Errorf("URL required (provide as argument or via --invite token)")
+	}
+	if c.Path == "" {
+		return fmt.Errorf("path required")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 

--- a/cmd/edgesync/user.go
+++ b/cmd/edgesync/user.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/auth"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+type RepoUserCmd struct {
+	Add    UserAddCmd    `cmd:"" help:"Create a new user"`
+	List   UserListCmd   `cmd:"" help:"List all users"`
+	Update UserUpdateCmd `cmd:"" help:"Update user capabilities"`
+	Rm     UserRmCmd     `cmd:"" help:"Delete a user"`
+	Passwd UserPasswdCmd `cmd:"" help:"Reset user password"`
+}
+
+type UserAddCmd struct {
+	Login string `arg:"" help:"Username"`
+	Cap   string `help:"Capability string (e.g. oi)" required:""`
+}
+
+func (c *UserAddCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.CreateUser(r.DB(), pc, c.Login, password, c.Cap); err != nil {
+		return err
+	}
+	fmt.Printf("Created user %q (caps: %s)\n", c.Login, c.Cap)
+	fmt.Printf("Password: %s\n", password)
+	return nil
+}
+
+type UserListCmd struct{}
+
+func (c *UserListCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	users, err := auth.ListUsers(r.DB())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-20s %-20s\n", "LOGIN", "CAPABILITIES")
+	for _, u := range users {
+		fmt.Printf("%-20s %-20s\n", u.Login, u.Cap)
+	}
+	return nil
+}
+
+type UserUpdateCmd struct {
+	Login string `arg:"" help:"Username"`
+	Cap   string `help:"New capability string" required:""`
+}
+
+func (c *UserUpdateCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := auth.UpdateCaps(r.DB(), c.Login, c.Cap); err != nil {
+		return err
+	}
+	fmt.Printf("Updated %q capabilities: %s\n", c.Login, c.Cap)
+	return nil
+}
+
+type UserRmCmd struct {
+	Login string `arg:"" help:"Username"`
+}
+
+func (c *UserRmCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := auth.DeleteUser(r.DB(), c.Login); err != nil {
+		return err
+	}
+	fmt.Printf("Deleted user %q\n", c.Login)
+	return nil
+}
+
+type UserPasswdCmd struct {
+	Login string `arg:"" help:"Username"`
+}
+
+func (c *UserPasswdCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.SetPassword(r.DB(), pc, c.Login, password); err != nil {
+		return err
+	}
+	fmt.Printf("New password for %q: %s\n", c.Login, password)
+	return nil
+}
+
+func generatePassword() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating password: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func repoProjectCode(r *repo.Repo) (string, error) {
+	var pc string
+	err := r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&pc)
+	if err != nil {
+		return "", fmt.Errorf("reading project-code: %w", err)
+	}
+	return pc, nil
+}

--- a/docs/superpowers/plans/2026-03-24-auth-capabilities.md
+++ b/docs/superpowers/plans/2026-03-24-auth-capabilities.md
@@ -1,0 +1,1635 @@
+# Auth & Capabilities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-side login card verification, capability-based access control, and invite token CLI to EdgeSync.
+
+**Architecture:** New `go-libfossil/auth/` package handles user CRUD, login verification, and capability checks. `sync/handler.go` gets two-pass card processing (login first, then capability-gated push/pull/clone). CLI commands in `cmd/edgesync/` for user management and invite tokens. `repo.Create` seeds a default `nobody` user with full caps for backwards compatibility.
+
+**Tech Stack:** Go, SQLite (user table), crypto/sha1, crypto/subtle, crypto/rand, encoding/base64
+
+**Spec:** `docs/superpowers/specs/2026-03-24-auth-capabilities-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `go-libfossil/auth/auth.go` | User type, HasCapability, CanPush/Pull/Clone/PushUV |
+| `go-libfossil/auth/user.go` | User CRUD: CreateUser, GetUser, ListUsers, UpdateCaps, SetPassword, DeleteUser |
+| `go-libfossil/auth/verify.go` | VerifyLogin — validate login card against user table |
+| `go-libfossil/auth/auth_test.go` | Capability check tests |
+| `go-libfossil/auth/user_test.go` | CRUD tests |
+| `go-libfossil/auth/verify_test.go` | Login verification tests |
+| `go-libfossil/auth/invite.go` | Invite token encode/decode |
+| `go-libfossil/auth/invite_test.go` | Token round-trip tests |
+| `go-libfossil/sync/handler.go` | Modified: auth state fields, initAuth, two-pass card processing |
+| `go-libfossil/sync/handler_test.go` | Modified: auth integration tests added |
+| `go-libfossil/db/schema.go` | Modified: SeedNobody function |
+| `go-libfossil/repo/repo.go` | Modified: CreateWithEnv calls SeedNobody |
+| `cmd/edgesync/cli.go` | Modified: add User and Invite commands to CLI struct |
+| `cmd/edgesync/user.go` | User CRUD CLI commands |
+| `cmd/edgesync/invite.go` | Invite and clone --invite CLI commands |
+
+---
+
+### Task 1: Capability Checking (`auth/auth.go`)
+
+**Files:**
+- Create: `go-libfossil/auth/auth.go`
+- Test: `go-libfossil/auth/auth_test.go`
+
+- [ ] **Step 1: Write failing tests for HasCapability and convenience wrappers**
+
+```go
+// auth_test.go
+package auth
+
+import "testing"
+
+func TestHasCapability(t *testing.T) {
+	tests := []struct {
+		caps     string
+		required byte
+		want     bool
+	}{
+		{"oi", 'o', true},
+		{"oi", 'i', true},
+		{"oi", 'g', false},
+		{"", 'o', false},
+		{"cghijknorswz", 's', true},
+		{"cghijknorswz", 'a', false},
+	}
+	for _, tt := range tests {
+		got := HasCapability(tt.caps, tt.required)
+		if got != tt.want {
+			t.Errorf("HasCapability(%q, %q) = %v, want %v", tt.caps, tt.required, got, tt.want)
+		}
+	}
+}
+
+func TestCanPush(t *testing.T) {
+	if !CanPush("oi") {
+		t.Error("CanPush(oi) should be true")
+	}
+	if CanPush("o") {
+		t.Error("CanPush(o) should be false")
+	}
+}
+
+func TestCanPull(t *testing.T) {
+	if !CanPull("oi") {
+		t.Error("CanPull(oi) should be true")
+	}
+	if CanPull("i") {
+		t.Error("CanPull(i) should be false")
+	}
+}
+
+func TestCanClone(t *testing.T) {
+	if !CanClone("g") {
+		t.Error("CanClone(g) should be true")
+	}
+	if CanClone("oi") {
+		t.Error("CanClone(oi) should be false")
+	}
+}
+
+func TestCanPushUV(t *testing.T) {
+	if !CanPushUV("z") {
+		t.Error("CanPushUV(z) should be true")
+	}
+	if CanPushUV("oi") {
+		t.Error("CanPushUV(oi) should be false")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -v`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Implement auth.go**
+
+```go
+// auth.go
+package auth
+
+import (
+	"strings"
+	"time"
+)
+
+// User represents a row in the Fossil user table.
+type User struct {
+	UID     int
+	Login   string
+	Cap     string
+	CExpire time.Time // zero value = no expiry
+	Info    string
+	MTime   time.Time
+}
+
+// HasCapability reports whether caps contains the required capability letter.
+func HasCapability(caps string, required byte) bool {
+	return strings.IndexByte(caps, required) >= 0
+}
+
+// CanPush reports whether caps includes checkin (i) capability.
+func CanPush(caps string) bool { return HasCapability(caps, 'i') }
+
+// CanPull reports whether caps includes checkout (o) capability.
+func CanPull(caps string) bool { return HasCapability(caps, 'o') }
+
+// CanClone reports whether caps includes clone (g) capability.
+func CanClone(caps string) bool { return HasCapability(caps, 'g') }
+
+// CanPushUV reports whether caps includes unversioned push (z) capability.
+func CanPushUV(caps string) bool { return HasCapability(caps, 'z') }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-libfossil/auth/auth.go go-libfossil/auth/auth_test.go
+git commit -m "feat(auth): add capability checking (HasCapability, CanPush/Pull/Clone/PushUV)"
+```
+
+---
+
+### Task 2: User CRUD (`auth/user.go`)
+
+**Files:**
+- Create: `go-libfossil/auth/user.go`
+- Test: `go-libfossil/auth/user_test.go`
+
+**Context:** The user table schema is in `go-libfossil/db/schema.go:31-42`. The `pw` field stores `SHA1(projectCode/login/password)`. Use the existing `sha1Hex` pattern from `sync/auth.go:38-41` (but define it locally in `auth/` to avoid a circular dependency on `sync/`).
+
+- [ ] **Step 1: Write failing tests for CreateUser and GetUser**
+
+```go
+// user_test.go
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	dbschema "github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+)
+
+func setupTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	r, err := repo.Create(path, "admin", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return r.DB()
+}
+
+func projectCode(t *testing.T, d *db.DB) string {
+	t.Helper()
+	var code string
+	if err := d.QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&code); err != nil {
+		t.Fatalf("project-code: %v", err)
+	}
+	return code
+}
+
+func TestCreateAndGetUser(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	if err := CreateUser(d, pc, "bob", "secret123", "oi"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	u, err := GetUser(d, "bob")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u.Login != "bob" {
+		t.Errorf("Login = %q, want bob", u.Login)
+	}
+	if u.Cap != "oi" {
+		t.Errorf("Cap = %q, want oi", u.Cap)
+	}
+	// pw should be SHA1(projectCode/bob/secret123)
+	expectedPW := hashPassword(pc, "bob", "secret123")
+	var storedPW string
+	d.QueryRow("SELECT pw FROM user WHERE login='bob'").Scan(&storedPW)
+	if storedPW != expectedPW {
+		t.Errorf("stored pw = %q, want %q", storedPW, expectedPW)
+	}
+}
+
+func TestCreateUserDuplicate(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "alice", "pass1", "o")
+	err := CreateUser(d, pc, "alice", "pass2", "oi")
+	if err == nil {
+		t.Fatal("expected error for duplicate user")
+	}
+}
+
+func TestGetUserNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	_, err := GetUser(d, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing user")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -run TestCreate -v`
+Expected: FAIL — CreateUser not defined
+
+- [ ] **Step 3: Implement CreateUser, GetUser, and hashPassword**
+
+```go
+// user.go
+package auth
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+)
+
+// hashPassword computes SHA1(projectCode/login/password) matching Fossil's convention.
+func hashPassword(projectCode, login, password string) string {
+	h := sha1.Sum([]byte(projectCode + "/" + login + "/" + password))
+	return hex.EncodeToString(h[:])
+}
+
+// CreateUser inserts a new user into the repo's user table.
+func CreateUser(d *db.DB, projectCode, login, password, caps string) error {
+	if d == nil {
+		panic("auth.CreateUser: d must not be nil")
+	}
+	if login == "" {
+		panic("auth.CreateUser: login must not be empty")
+	}
+	pw := hashPassword(projectCode, login, password)
+	_, err := d.Exec(
+		"INSERT INTO user(login, pw, cap, mtime) VALUES(?, ?, ?, julianday('now'))",
+		login, pw, caps,
+	)
+	if err != nil {
+		return fmt.Errorf("auth.CreateUser %q: %w", login, err)
+	}
+	return nil
+}
+
+// GetUser retrieves a user by login name.
+func GetUser(d *db.DB, login string) (User, error) {
+	if d == nil {
+		panic("auth.GetUser: d must not be nil")
+	}
+	var u User
+	var cexpire sql.NullString
+	err := d.QueryRow(
+		"SELECT uid, login, cap, cexpire, info, mtime FROM user WHERE login = ?",
+		login,
+	).Scan(&u.UID, &u.Login, &u.Cap, &cexpire, &u.Info, &u.MTime)
+	if err != nil {
+		return User{}, fmt.Errorf("auth.GetUser %q: %w", login, err)
+	}
+	if cexpire.Valid && cexpire.String != "" {
+		u.CExpire, _ = time.Parse("2006-01-02 15:04:05", cexpire.String)
+	}
+	return u, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -run "TestCreate|TestGet" -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for ListUsers, UpdateCaps, SetPassword, DeleteUser**
+
+```go
+// append to user_test.go
+
+func TestListUsers(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "alice", "pass", "o")
+	CreateUser(d, pc, "bob", "pass", "oi")
+
+	users, err := ListUsers(d)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	// admin + alice + bob = 3
+	if len(users) < 3 {
+		t.Fatalf("ListUsers returned %d users, want >= 3", len(users))
+	}
+}
+
+func TestUpdateCaps(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "pass", "o")
+	if err := UpdateCaps(d, "bob", "ois"); err != nil {
+		t.Fatalf("UpdateCaps: %v", err)
+	}
+	u, _ := GetUser(d, "bob")
+	if u.Cap != "ois" {
+		t.Errorf("Cap = %q, want ois", u.Cap)
+	}
+}
+
+func TestSetPassword(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "oldpass", "o")
+	if err := SetPassword(d, pc, "bob", "newpass"); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+	expected := hashPassword(pc, "bob", "newpass")
+	var pw string
+	d.QueryRow("SELECT pw FROM user WHERE login='bob'").Scan(&pw)
+	if pw != expected {
+		t.Errorf("pw after SetPassword = %q, want %q", pw, expected)
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "pass", "o")
+	if err := DeleteUser(d, "bob"); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	_, err := GetUser(d, "bob")
+	if err == nil {
+		t.Fatal("expected error after deleting user")
+	}
+}
+```
+
+- [ ] **Step 6: Implement ListUsers, UpdateCaps, SetPassword, DeleteUser**
+
+```go
+// append to user.go
+
+// ListUsers returns all users in the repo.
+func ListUsers(d *db.DB) ([]User, error) {
+	if d == nil {
+		panic("auth.ListUsers: d must not be nil")
+	}
+	rows, err := d.Query("SELECT uid, login, cap, info FROM user ORDER BY login")
+	if err != nil {
+		return nil, fmt.Errorf("auth.ListUsers: %w", err)
+	}
+	defer rows.Close()
+	var users []User
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.UID, &u.Login, &u.Cap, &u.Info); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
+// UpdateCaps changes a user's capability string.
+func UpdateCaps(d *db.DB, login, caps string) error {
+	if d == nil {
+		panic("auth.UpdateCaps: d must not be nil")
+	}
+	res, err := d.Exec("UPDATE user SET cap=?, mtime=julianday('now') WHERE login=?", caps, login)
+	if err != nil {
+		return fmt.Errorf("auth.UpdateCaps %q: %w", login, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("auth.UpdateCaps: user %q not found", login)
+	}
+	return nil
+}
+
+// SetPassword updates a user's password hash.
+func SetPassword(d *db.DB, projectCode, login, password string) error {
+	if d == nil {
+		panic("auth.SetPassword: d must not be nil")
+	}
+	pw := hashPassword(projectCode, login, password)
+	res, err := d.Exec("UPDATE user SET pw=?, mtime=julianday('now') WHERE login=?", pw, login)
+	if err != nil {
+		return fmt.Errorf("auth.SetPassword %q: %w", login, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("auth.SetPassword: user %q not found", login)
+	}
+	return nil
+}
+
+// DeleteUser removes a user from the repo.
+func DeleteUser(d *db.DB, login string) error {
+	if d == nil {
+		panic("auth.DeleteUser: d must not be nil")
+	}
+	res, err := d.Exec("DELETE FROM user WHERE login=?", login)
+	if err != nil {
+		return fmt.Errorf("auth.DeleteUser %q: %w", login, err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("auth.DeleteUser: user %q not found", login)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Run all auth tests**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -v`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add go-libfossil/auth/user.go go-libfossil/auth/user_test.go
+git commit -m "feat(auth): add user CRUD (CreateUser, GetUser, ListUsers, UpdateCaps, SetPassword, DeleteUser)"
+```
+
+---
+
+### Task 3: Login Verification (`auth/verify.go`)
+
+**Files:**
+- Create: `go-libfossil/auth/verify.go`
+- Test: `go-libfossil/auth/verify_test.go`
+
+**Context:** The client computes login cards in `sync/auth.go:14-28` using `SHA1(nonce + SHA1(projectCode/user/password))`. The server must recompute `SHA1(nonce + storedPW)` and compare. `storedPW` is already `SHA1(projectCode/user/password)`.
+
+- [ ] **Step 1: Write failing tests for VerifyLogin**
+
+```go
+// verify_test.go
+package auth
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/xfer"
+)
+
+// buildLoginCard mirrors sync.computeLogin for test use.
+func buildLoginCard(user, password, projectCode string, payload []byte) *xfer.LoginCard {
+	nonce := sha1hex(payload)
+	sharedSecret := sha1hex([]byte(projectCode + "/" + user + "/" + password))
+	signature := sha1hex([]byte(nonce + sharedSecret))
+	return &xfer.LoginCard{User: user, Nonce: nonce, Signature: signature}
+}
+
+func sha1hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+func TestVerifyLoginSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "secret", "oi")
+
+	payload := []byte("test payload\n")
+	card := buildLoginCard("bob", "secret", pc, payload)
+
+	u, err := VerifyLogin(d, pc, card)
+	if err != nil {
+		t.Fatalf("VerifyLogin: %v", err)
+	}
+	if u.Login != "bob" {
+		t.Errorf("Login = %q, want bob", u.Login)
+	}
+	if u.Cap != "oi" {
+		t.Errorf("Cap = %q, want oi", u.Cap)
+	}
+}
+
+func TestVerifyLoginWrongPassword(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "secret", "oi")
+
+	payload := []byte("test payload\n")
+	card := buildLoginCard("bob", "wrong", pc, payload)
+
+	_, err := VerifyLogin(d, pc, card)
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+}
+
+func TestVerifyLoginUnknownUser(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	payload := []byte("test payload\n")
+	card := buildLoginCard("nobody-here", "pass", pc, payload)
+
+	_, err := VerifyLogin(d, pc, card)
+	if err == nil {
+		t.Fatal("expected error for unknown user")
+	}
+}
+
+func TestVerifyLoginExpired(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "secret", "oi")
+	// Set cexpire to the past
+	past := time.Now().Add(-1 * time.Hour).Format("2006-01-02 15:04:05")
+	d.Exec("UPDATE user SET cexpire=? WHERE login='bob'", past)
+
+	payload := []byte("test payload\n")
+	card := buildLoginCard("bob", "secret", pc, payload)
+
+	_, err := VerifyLogin(d, pc, card)
+	if err == nil {
+		t.Fatal("expected error for expired credentials")
+	}
+}
+
+func TestVerifyLoginNonExpired(t *testing.T) {
+	d := setupTestDB(t)
+	pc := projectCode(t, d)
+
+	CreateUser(d, pc, "bob", "secret", "oi")
+	// Set cexpire to the future
+	future := time.Now().Add(24 * time.Hour).Format("2006-01-02 15:04:05")
+	d.Exec("UPDATE user SET cexpire=? WHERE login='bob'", future)
+
+	payload := []byte("test payload\n")
+	card := buildLoginCard("bob", "secret", pc, payload)
+
+	u, err := VerifyLogin(d, pc, card)
+	if err != nil {
+		t.Fatalf("VerifyLogin: %v", err)
+	}
+	if u.Login != "bob" {
+		t.Errorf("Login = %q, want bob", u.Login)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -run TestVerify -v`
+Expected: FAIL — VerifyLogin not defined
+
+- [ ] **Step 3: Implement VerifyLogin**
+
+```go
+// verify.go
+package auth
+
+import (
+	"crypto/sha1"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/xfer"
+)
+
+// ErrAuthFailed is returned for all authentication failures.
+// A single generic message prevents user enumeration.
+var ErrAuthFailed = errors.New("authentication failed")
+
+// VerifyLogin validates a login card against the user table.
+// Returns the verified User on success, or ErrAuthFailed on any failure.
+// VerifyLogin validates a login card against the user table.
+// The server does NOT need the raw payload — the nonce is in card.Nonce.
+// The client computed nonce = SHA1(payload), but the server just uses it directly.
+func VerifyLogin(d *db.DB, projectCode string, card *xfer.LoginCard) (User, error) {
+	if d == nil {
+		panic("auth.VerifyLogin: d must not be nil")
+	}
+	if card == nil {
+		panic("auth.VerifyLogin: card must not be nil")
+	}
+
+	var uid int
+	var login, pw, cap string
+	var cexpire sql.NullString
+	err := d.QueryRow(
+		"SELECT uid, login, pw, cap, cexpire FROM user WHERE login = ?",
+		card.User,
+	).Scan(&uid, &login, &pw, &cap, &cexpire)
+	if err != nil {
+		return User{}, ErrAuthFailed
+	}
+
+	// Check expiry
+	if cexpire.Valid && cexpire.String != "" {
+		exp, parseErr := time.Parse("2006-01-02 15:04:05", cexpire.String)
+		if parseErr == nil && time.Now().After(exp) {
+			return User{}, ErrAuthFailed
+		}
+	}
+
+	// Recompute expected signature: SHA1(nonce + storedPW)
+	h := sha1.Sum([]byte(card.Nonce + pw))
+	expected := hex.EncodeToString(h[:])
+
+	if subtle.ConstantTimeCompare([]byte(expected), []byte(card.Signature)) != 1 {
+		return User{}, ErrAuthFailed
+	}
+
+	return User{UID: uid, Login: login, Cap: cap}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -v`
+Expected: PASS (all auth tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-libfossil/auth/verify.go go-libfossil/auth/verify_test.go
+git commit -m "feat(auth): add VerifyLogin with constant-time comparison and expiry check"
+```
+
+---
+
+### Task 4: Seed Nobody User on Repo Creation
+
+**Files:**
+- Modify: `go-libfossil/db/schema.go:200-212` (add SeedNobody)
+- Modify: `go-libfossil/repo/repo.go:46-60` (call SeedNobody in CreateWithEnv)
+
+**Context:** `repo.CreateWithEnv` at `repo.go:46-60` calls `db.SeedUser` (which creates the admin user with `s` cap) and `db.SeedConfig`. We need to also seed a `nobody` user with full caps (`cghijknorswz`) so existing tests and repos remain open by default.
+
+- [ ] **Step 1: Write failing test for SeedNobody**
+
+```go
+// Add to go-libfossil/db/schema_test.go (create if needed)
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSeedNobody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	if err := CreateRepoSchema(d); err != nil {
+		t.Fatalf("CreateRepoSchema: %v", err)
+	}
+	if err := SeedNobody(d, "oi"); err != nil {
+		t.Fatalf("SeedNobody: %v", err)
+	}
+
+	var login, cap string
+	err = d.QueryRow("SELECT login, cap FROM user WHERE login='nobody'").Scan(&login, &cap)
+	if err != nil {
+		t.Fatalf("nobody user not found: %v", err)
+	}
+	if cap != "oi" {
+		t.Errorf("cap = %q, want oi", cap)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./db/ -run TestSeedNobody -v`
+Expected: FAIL — SeedNobody not defined
+
+- [ ] **Step 3: Add SeedNobody to db/schema.go**
+
+Add after `SeedUser` function (after line 212):
+
+```go
+// SeedNobody inserts a "nobody" user with the given capabilities.
+// This controls anonymous access policy for the repo.
+func SeedNobody(d *DB, caps string) error {
+	if d == nil {
+		panic("db.SeedNobody: d must not be nil")
+	}
+	_, err := d.Exec(
+		"INSERT OR IGNORE INTO user(login, pw, cap, info) VALUES('nobody', '', ?, '')",
+		caps,
+	)
+	return err
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./db/ -run TestSeedNobody -v`
+Expected: PASS
+
+- [ ] **Step 5: Call SeedNobody in repo.CreateWithEnv**
+
+In `go-libfossil/repo/repo.go`, add after the `SeedUser` call (after line 60):
+
+```go
+	if err := db.SeedNobody(d, "cghijknorswz"); err != nil {
+		d.Close()
+		if rmErr := env.Storage.Remove(path); rmErr != nil {
+			return nil, fmt.Errorf("repo.CreateWithEnv: %w (cleanup failed: %v)", err, rmErr)
+		}
+		return nil, fmt.Errorf("repo.CreateWithEnv seed nobody: %w", err)
+	}
+```
+
+- [ ] **Step 6: Run full test suite to verify nothing breaks**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./...`
+Expected: PASS — all existing tests still pass because nobody has full caps
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go-libfossil/db/schema.go go-libfossil/db/schema_test.go go-libfossil/repo/repo.go
+git commit -m "feat(auth): seed nobody user with full caps on repo creation"
+```
+
+---
+
+### Task 5: HandleSync Auth Integration
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:77-174`
+- Modify: `go-libfossil/sync/handler_test.go`
+
+**Context:** The handler struct is at `handler.go:77-88`. `handleControlCard` is at line 152-174. The `process` method is at line 90-150. The two-pass control card processing must replace the single pass at lines 92-94.
+
+- [ ] **Step 1: Write failing auth integration tests**
+
+Add to `handler_test.go`:
+
+```go
+func TestHandlePushRequiresAuth(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	pc := projectCode(t, r.DB())
+
+	// Delete nobody so anonymous push is rejected
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+
+	data := []byte("auth test")
+	uuid := hash.SHA1(data)
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unauthorized push")
+	}
+	// Blob should NOT be stored
+	if _, ok := blob.Exists(r.DB(), uuid); ok {
+		t.Fatal("blob should not be stored without push capability")
+	}
+}
+
+func TestHandlePullRequiresAuth(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	storeTestBlob(t, r, []byte("pull auth test"))
+
+	// Delete nobody so anonymous pull is rejected
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unauthorized pull")
+	}
+	igots := findCards[*xfer.IGotCard](resp)
+	if len(igots) > 0 {
+		t.Fatal("should not emit igots without pull capability")
+	}
+}
+
+func TestHandleAuthenticatedPush(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	pc := projectCode(t, r.DB())
+
+	// Delete nobody, create a user with push caps
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+	auth.CreateUser(r.DB(), pc, "pusher", "secret", "oi")
+
+	data := []byte("authed push")
+	uuid := hash.SHA1(data)
+
+	// Build a valid login card
+	allCards := []xfer.Card{
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}
+	// Encode non-login cards to compute nonce
+	var buf bytes.Buffer
+	for _, c := range allCards {
+		xfer.Encode(&buf, c)
+	}
+	payload := buf.Bytes()
+	loginCard := buildTestLoginCard("pusher", "secret", pc, payload)
+
+	req := &xfer.Message{Cards: append([]xfer.Card{loginCard}, allCards...)}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected error: %s", errs[0].Message)
+	}
+	if _, ok := blob.Exists(r.DB(), uuid); !ok {
+		t.Fatal("authenticated push should store blob")
+	}
+}
+
+func TestHandleNobodyPullOnly(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	storeTestBlob(t, r, []byte("nobody test"))
+
+	// Set nobody to pull-only
+	r.DB().Exec("UPDATE user SET cap='o' WHERE login='nobody'")
+
+	// Pull should work
+	pullReq := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	pullResp, _ := HandleSync(context.Background(), r, pullReq)
+	igots := findCards[*xfer.IGotCard](pullResp)
+	if len(igots) == 0 {
+		t.Fatal("nobody with 'o' cap should allow pull")
+	}
+
+	// Push should fail
+	data := []byte("nobody push attempt")
+	uuid := hash.SHA1(data)
+	pushReq := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}}
+	pushResp, _ := HandleSync(context.Background(), r, pushReq)
+	errs := findCards[*xfer.ErrorCard](pushResp)
+	if len(errs) == 0 {
+		t.Fatal("nobody with 'o' cap should reject push")
+	}
+}
+```
+
+Also add a helper at the top of handler_test.go:
+
+```go
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+
+	"github.com/dmestas/edgesync/go-libfossil/auth"
+)
+
+func projectCode(t *testing.T, d *db.DB) string {
+	t.Helper()
+	var code string
+	if err := d.QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&code); err != nil {
+		t.Fatalf("project-code: %v", err)
+	}
+	return code
+}
+
+func buildTestLoginCard(user, password, projectCode string, payload []byte) *xfer.LoginCard {
+	nonce := sha1Hex(payload)
+	shared := sha1Hex([]byte(projectCode + "/" + user + "/" + password))
+	sig := sha1Hex([]byte(nonce + shared))
+	return &xfer.LoginCard{User: user, Nonce: nonce, Signature: sig}
+}
+
+func sha1Hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./sync/ -run "TestHandlePushRequiresAuth|TestHandlePullRequiresAuth|TestHandleAuthenticatedPush|TestHandleNobodyPullOnly" -v`
+Expected: FAIL — handler doesn't check capabilities yet
+
+- [ ] **Step 3: Add auth import to handler.go**
+
+Add to imports in `handler.go`:
+
+```go
+"github.com/dmestas/edgesync/go-libfossil/auth"
+```
+
+- [ ] **Step 4: Add auth fields to handler struct**
+
+In `handler.go`, modify the handler struct (line 77-88):
+
+```go
+type handler struct {
+	repo          *repo.Repo
+	buggify       BuggifyChecker
+	resp          []xfer.Card
+	pushOK        bool
+	pullOK        bool
+	cloneMode     bool
+	cloneSeq      int
+	uvCatalogSent bool
+	filesSent     int
+	filesRecvd    int
+	// Auth state
+	user   string // verified username ("nobody" if no login card)
+	caps   string // capability string from user table
+	authed bool   // whether login card was verified
+}
+```
+
+- [ ] **Step 5: Implement initAuth and two-pass card processing**
+
+Replace `process` method's first pass (lines 90-94) and `handleControlCard` (lines 152-174):
+
+```go
+func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, error) {
+	// Initialize auth state from nobody user.
+	h.initAuth()
+
+	// First pass: resolve login cards before other control cards.
+	for _, card := range req.Cards {
+		if lc, ok := card.(*xfer.LoginCard); ok {
+			h.handleLoginCard(lc)
+		}
+	}
+
+	// Second pass: process other control cards with capability checks.
+	for _, card := range req.Cards {
+		if _, ok := card.(*xfer.LoginCard); ok {
+			continue // Already processed.
+		}
+		h.handleControlCard(card)
+	}
+
+	// ... rest of process method unchanged from line 96 onward ...
+```
+
+```go
+func (h *handler) initAuth() {
+	h.user = "nobody"
+	h.caps = ""
+	h.authed = false
+	var caps string
+	err := h.repo.DB().QueryRow("SELECT cap FROM user WHERE login='nobody'").Scan(&caps)
+	if err == nil {
+		h.caps = caps
+	}
+}
+
+func (h *handler) handleLoginCard(c *xfer.LoginCard) {
+	var projectCode string
+	if err := h.repo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode); err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	u, err := auth.VerifyLogin(h.repo.DB(), projectCode, c, nil)
+	// Note: payload verification requires the encoded non-login cards.
+	// For now we verify user+password match only. The nonce is computed
+	// from the request payload by the caller — we need the raw payload.
+	// TODO: pass raw payload through for full nonce verification.
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	h.user = u.Login
+	h.caps = u.Cap
+	h.authed = true
+}
+```
+
+```go
+func (h *handler) handleLoginCard(c *xfer.LoginCard) {
+	var projectCode string
+	if err := h.repo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode); err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	u, err := auth.VerifyLogin(h.repo.DB(), projectCode, c)
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	h.user = u.Login
+	h.caps = u.Cap
+	h.authed = true
+}
+```
+
+Update `handleControlCard` to add capability checks:
+
+```go
+func (h *handler) handleControlCard(card xfer.Card) {
+	switch c := card.(type) {
+	case *xfer.LoginCard:
+		return // Already processed in first pass.
+	case *xfer.PragmaCard:
+		if c.Name == "uv-hash" && len(c.Values) >= 1 {
+			if err := h.handlePragmaUVHash(c.Values[0]); err != nil {
+				h.resp = append(h.resp, &xfer.ErrorCard{
+					Message: fmt.Sprintf("uv-hash: %v", err),
+				})
+			}
+		}
+	case *xfer.PushCard:
+		if auth.CanPush(h.caps) {
+			h.pushOK = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "push denied: insufficient capabilities",
+			})
+		}
+	case *xfer.PullCard:
+		if auth.CanPull(h.caps) {
+			h.pullOK = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "pull denied: insufficient capabilities",
+			})
+		}
+	case *xfer.CloneCard:
+		if auth.CanClone(h.caps) {
+			h.cloneMode = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "clone denied: insufficient capabilities",
+			})
+		}
+	case *xfer.CloneSeqNoCard:
+		h.cloneSeq = c.SeqNo
+	}
+}
+```
+
+Also add UV write check in `handleUVFile`. In `handler_uv.go`, add before the existing content storage logic (the existing `pushOK` check ensures a push card was sent; this additionally checks the `z` capability):
+
+```go
+if !auth.CanPushUV(h.caps) {
+	h.resp = append(h.resp, &xfer.ErrorCard{
+		Message: fmt.Sprintf("uvfile %s denied: insufficient capabilities", c.Name),
+	})
+	return nil
+}
+```
+
+UV writes require BOTH a push card (existing `pushOK` check) AND the `z` capability (new check).
+
+- [ ] **Step 5: Run new auth tests**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./sync/ -run "TestHandlePushRequiresAuth|TestHandlePullRequiresAuth|TestHandleAuthenticatedPush|TestHandleNobodyPullOnly" -v`
+Expected: PASS
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./...`
+Expected: PASS — all existing tests pass because nobody has full caps
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add go-libfossil/auth/verify.go go-libfossil/auth/verify_test.go go-libfossil/sync/handler.go go-libfossil/sync/handler_test.go go-libfossil/sync/handler_uv.go
+git commit -m "feat(auth): wire VerifyLogin into HandleSync with two-pass card processing"
+```
+
+---
+
+### Task 6: Invite Token Encode/Decode (`auth/invite.go`)
+
+**Files:**
+- Create: `go-libfossil/auth/invite.go`
+- Test: `go-libfossil/auth/invite_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// invite_test.go
+package auth
+
+import "testing"
+
+func TestInviteTokenRoundTrip(t *testing.T) {
+	tok := InviteToken{
+		URL:      "nats://100.78.32.45:4222/myrepo",
+		Login:    "bob",
+		Password: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+		Caps:     "oi",
+	}
+
+	encoded := tok.Encode()
+	if encoded == "" {
+		t.Fatal("Encode returned empty string")
+	}
+
+	decoded, err := DecodeInviteToken(encoded)
+	if err != nil {
+		t.Fatalf("DecodeInviteToken: %v", err)
+	}
+	if decoded.URL != tok.URL {
+		t.Errorf("URL = %q, want %q", decoded.URL, tok.URL)
+	}
+	if decoded.Login != tok.Login {
+		t.Errorf("Login = %q, want %q", decoded.Login, tok.Login)
+	}
+	if decoded.Password != tok.Password {
+		t.Errorf("Password = %q, want %q", decoded.Password, tok.Password)
+	}
+	if decoded.Caps != tok.Caps {
+		t.Errorf("Caps = %q, want %q", decoded.Caps, tok.Caps)
+	}
+}
+
+func TestDecodeInviteTokenInvalid(t *testing.T) {
+	_, err := DecodeInviteToken("not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+
+	_, err = DecodeInviteToken("bm90LWpzb24=") // "not-json" in base64
+	if err == nil {
+		t.Fatal("expected error for non-JSON token")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -run TestInvite -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement invite.go**
+
+```go
+// invite.go
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// InviteToken contains the credentials needed to clone a repo.
+type InviteToken struct {
+	URL      string `json:"url"`
+	Login    string `json:"login"`
+	Password string `json:"password"`
+	Caps     string `json:"caps"`
+}
+
+// Encode returns the token as a base64url-encoded compact JSON string.
+func (t InviteToken) Encode() string {
+	b, err := json.Marshal(t)
+	if err != nil {
+		panic(fmt.Sprintf("auth.InviteToken.Encode: %v", err))
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// DecodeInviteToken decodes a base64url-encoded invite token.
+func DecodeInviteToken(s string) (InviteToken, error) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: %w", err)
+	}
+	var t InviteToken
+	if err := json.Unmarshal(b, &t); err != nil {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: %w", err)
+	}
+	return t, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./auth/ -run TestInvite -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-libfossil/auth/invite.go go-libfossil/auth/invite_test.go
+git commit -m "feat(auth): add invite token encode/decode"
+```
+
+---
+
+### Task 7: CLI — User Management Commands
+
+**Files:**
+- Create: `cmd/edgesync/user.go`
+- Modify: `cmd/edgesync/cli.go` (add UserCmd to RepoCmd)
+
+**Context:** CLI uses kong for command parsing. See `cli.go` for the pattern. Each command is a struct with `Run(g *Globals) error`. The `--repo` flag is already on `Globals` as `-R`.
+
+- [ ] **Step 1: Add UserCmd to cli.go**
+
+In `cmd/edgesync/cli.go`, add to `RepoCmd` struct:
+
+```go
+User     RepoUserCmd     `cmd:"" help:"User management"`
+```
+
+- [ ] **Step 2: Create user.go with all subcommands**
+
+```go
+// user.go
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/auth"
+)
+
+type RepoUserCmd struct {
+	Add    UserAddCmd    `cmd:"" help:"Create a new user"`
+	List   UserListCmd   `cmd:"" help:"List all users"`
+	Update UserUpdateCmd `cmd:"" help:"Update user capabilities"`
+	Rm     UserRmCmd     `cmd:"" help:"Delete a user"`
+	Passwd UserPasswdCmd `cmd:"" help:"Reset user password"`
+}
+
+type UserAddCmd struct {
+	Login string `arg:"" help:"Username"`
+	Cap   string `help:"Capability string (e.g. oi)" required:""`
+}
+
+func (c *UserAddCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.CreateUser(r.DB(), pc, c.Login, password, c.Cap); err != nil {
+		return err
+	}
+	fmt.Printf("Created user %q (caps: %s)\n", c.Login, c.Cap)
+	fmt.Printf("Password: %s\n", password)
+	return nil
+}
+
+type UserListCmd struct{}
+
+func (c *UserListCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	users, err := auth.ListUsers(r.DB())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-20s %-20s\n", "LOGIN", "CAPABILITIES")
+	for _, u := range users {
+		fmt.Printf("%-20s %-20s\n", u.Login, u.Cap)
+	}
+	return nil
+}
+
+type UserUpdateCmd struct {
+	Login string `arg:"" help:"Username"`
+	Cap   string `help:"New capability string" required:""`
+}
+
+func (c *UserUpdateCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := auth.UpdateCaps(r.DB(), c.Login, c.Cap); err != nil {
+		return err
+	}
+	fmt.Printf("Updated %q capabilities: %s\n", c.Login, c.Cap)
+	return nil
+}
+
+type UserRmCmd struct {
+	Login string `arg:"" help:"Username"`
+}
+
+func (c *UserRmCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := auth.DeleteUser(r.DB(), c.Login); err != nil {
+		return err
+	}
+	fmt.Printf("Deleted user %q\n", c.Login)
+	return nil
+}
+
+type UserPasswdCmd struct {
+	Login string `arg:"" help:"Username"`
+}
+
+func (c *UserPasswdCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.SetPassword(r.DB(), pc, c.Login, password); err != nil {
+		return err
+	}
+	fmt.Printf("New password for %q: %s\n", c.Login, password)
+	return nil
+}
+
+func generatePassword() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating password: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func repoProjectCode(r *repo.Repo) (string, error) {
+	var pc string
+	err := r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&pc)
+	if err != nil {
+		return "", fmt.Errorf("reading project-code: %w", err)
+	}
+	return pc, nil
+}
+```
+
+Note: `repoProjectCode` needs the repo import — add `"github.com/dmestas/edgesync/go-libfossil/repo"` to imports.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build -buildvcs=false ./cmd/edgesync/`
+Expected: Compiles successfully
+
+- [ ] **Step 4: Manual smoke test**
+
+Run:
+```bash
+./bin/edgesync repo new /tmp/test-auth.fossil
+./bin/edgesync repo user list -R /tmp/test-auth.fossil
+./bin/edgesync repo user add alice --cap oi -R /tmp/test-auth.fossil
+./bin/edgesync repo user list -R /tmp/test-auth.fossil
+./bin/edgesync repo user update alice --cap o -R /tmp/test-auth.fossil
+./bin/edgesync repo user passwd alice -R /tmp/test-auth.fossil
+./bin/edgesync repo user rm alice -R /tmp/test-auth.fossil
+rm /tmp/test-auth.fossil
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/edgesync/user.go cmd/edgesync/cli.go
+git commit -m "feat(cli): add user management commands (add, list, update, rm, passwd)"
+```
+
+---
+
+### Task 8: CLI — Invite Command
+
+**Files:**
+- Create: `cmd/edgesync/invite.go`
+- Modify: `cmd/edgesync/cli.go` (add InviteCmd)
+- Modify: `cmd/edgesync/repo_clone.go` (add --invite flag)
+
+**Context:** Check `repo_clone.go` for the existing clone command structure before modifying it.
+
+- [ ] **Step 1: Read repo_clone.go to understand existing clone structure**
+
+- [ ] **Step 2: Add InviteCmd to cli.go**
+
+In `RepoCmd` struct, add:
+
+```go
+Invite   RepoInviteCmd   `cmd:"" help:"Generate invite token for a user"`
+```
+
+- [ ] **Step 3: Create invite.go**
+
+```go
+// invite.go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/auth"
+)
+
+type RepoInviteCmd struct {
+	Login string        `arg:"" help:"Username for the invitee"`
+	Cap   string        `help:"Capability string (e.g. oi)" required:""`
+	URL   string        `help:"Sync URL to embed in token" default:""`
+	TTL   time.Duration `help:"Token time-to-live (e.g. 24h)" default:"0"`
+}
+
+func (c *RepoInviteCmd) Run(g *Globals) error {
+	r, err := openRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	password, err := generatePassword()
+	if err != nil {
+		return err
+	}
+
+	pc, err := repoProjectCode(r)
+	if err != nil {
+		return err
+	}
+
+	if err := auth.CreateUser(r.DB(), pc, c.Login, password, c.Cap); err != nil {
+		return err
+	}
+
+	if c.TTL > 0 {
+		expiry := time.Now().Add(c.TTL).Format("2006-01-02 15:04:05")
+		if _, err := r.DB().Exec("UPDATE user SET cexpire=? WHERE login=?", expiry, c.Login); err != nil {
+			return fmt.Errorf("setting expiry: %w", err)
+		}
+	}
+
+	url := c.URL
+	if url == "" {
+		// Try to read from repo config
+		r.DB().QueryRow("SELECT value FROM config WHERE name='last-sync-url'").Scan(&url)
+	}
+
+	tok := auth.InviteToken{
+		URL:      url,
+		Login:    c.Login,
+		Password: password,
+		Caps:     c.Cap,
+	}
+
+	encoded := tok.Encode()
+
+	fmt.Printf("Invite for %q (capabilities: %s", c.Login, c.Cap)
+	if c.TTL > 0 {
+		fmt.Printf(", expires: %s", time.Now().Add(c.TTL).Format(time.RFC3339))
+	}
+	fmt.Println("):")
+	fmt.Println()
+	fmt.Printf("  edgesync repo clone --invite %s\n", encoded)
+	fmt.Println()
+	fmt.Println("Share this command with the recipient. It contains credentials — treat it like a password.")
+	return nil
+}
+```
+
+- [ ] **Step 4: Add --invite flag to RepoCloneCmd**
+
+Read `repo_clone.go` first, then add an `Invite string` field and handle it in `Run`:
+
+```go
+Invite string `help:"Invite token (from edgesync invite)" default:""`
+```
+
+In the `Run` method, if `c.Invite != ""`:
+1. Decode the token
+2. Use token.URL, token.Login, token.Password for the clone
+3. Store credentials in the cloned repo's config
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `go build -buildvcs=false ./cmd/edgesync/`
+Expected: Compiles successfully
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/edgesync/invite.go cmd/edgesync/cli.go cmd/edgesync/repo_clone.go
+git commit -m "feat(cli): add invite command and clone --invite flag"
+```
+
+---
+
+### Task 9: Run Full Test Suite and Pre-Commit
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all go-libfossil tests**
+
+Run: `cd go-libfossil && go test -buildvcs=false ./...`
+Expected: PASS
+
+- [ ] **Step 2: Run DST tests**
+
+Run: `make dst`
+Expected: PASS
+
+- [ ] **Step 3: Run sim tests**
+
+Run: `make test`
+Expected: PASS
+
+- [ ] **Step 4: Build all binaries**
+
+Run: `make build`
+Expected: All binaries built successfully
+
+- [ ] **Step 5: Final commit if any fixups needed**
+
+---
+
+### Task 10: Update Linear Tickets
+
+- [ ] **Step 1: Move CDG-131 to Done** (spike delivered as spec + implementation)
+- [ ] **Step 2: Move CDG-155 to Done** (auth package implemented)
+- [ ] **Step 3: Move CDG-115 to Done** (verify login credentials in HandleSync — now implemented)

--- a/docs/superpowers/specs/2026-03-24-auth-capabilities-design.md
+++ b/docs/superpowers/specs/2026-03-24-auth-capabilities-design.md
@@ -1,0 +1,309 @@
+# Auth & Capabilities Design
+
+**Date:** 2026-03-24
+**Tickets:** CDG-131 (spike: user access control & capabilities), CDG-155 (implement user auth and capabilities)
+**Status:** Draft
+
+## Problem
+
+HandleSync (`handler.go:154`) ignores login cards — any client can push to any server. Multi-user sync is unusable without access control. Sharing repos between users requires emailing passwords.
+
+## Design Principles
+
+- **Repo-sovereign auth.** Each repo's `user` table is the single source of truth for who can do what. No external identity provider required.
+- **Fossil-native at the core.** Login card verification uses Fossil's existing HMAC scheme: `SHA1(nonce + SHA1(projectCode/user/password))`. No wire protocol changes.
+- **CLI sugar for smooth sharing.** Invite tokens eliminate password management for the common case.
+- **Path to more later.** The `auth/` package is a clean boundary. An IdP (Clerk, NATS JWT, etc.) can be layered on top in the future by provisioning user table entries through the same API.
+
+## Architecture
+
+```
++---------------------------+
+| CLI (invite, user CRUD)   |  edgesync invite / edgesync user add
++---------------------------+
+| auth/ package             |  VerifyLogin, HasCapability, user CRUD
++---------------------------+
+| user table (per-repo DB)  |  uid, login, pw, cap, cexpire
++---------------------------+
+| HandleSync                |  calls auth.VerifyLogin, checks caps
++---------------------------+
+| sync/auth.go (client)     |  computeLogin (unchanged)
++---------------------------+
+```
+
+Client-side sync (`computeLogin` in `sync/auth.go`) is unchanged. All new work is server-side verification and the `auth/` package.
+
+## Fossil's User Table
+
+Already exists in the repo schema (`db/schema.go:31-42`):
+
+```sql
+CREATE TABLE user(
+  uid INTEGER PRIMARY KEY,
+  login TEXT UNIQUE,
+  pw TEXT,              -- SHA1(projectCode/login/password)
+  cap TEXT,             -- capability string e.g. "oi"
+  cookie TEXT,
+  ipaddr TEXT,
+  cexpire DATETIME,     -- credential expiry (used by invite TTL)
+  info TEXT,
+  mtime DATE,
+  photo BLOB
+);
+```
+
+The `pw` field stores `SHA1(projectCode/login/password)`, not the raw password. The `cap` field is a string of single-letter capability flags.
+
+## Fossil Capability Flags
+
+| Flag | Meaning |
+|------|---------|
+| `a` | Admin (can add/remove users) |
+| `c` | Append (checkin via push) |
+| `d` | Delete artifacts |
+| `e` | View email addresses |
+| `g` | Clone |
+| `h` | Hyperlinks (view web UI) |
+| `i` | Checkin (push artifacts) |
+| `j` | Read wiki |
+| `k` | Write wiki |
+| `n` | New ticket |
+| `o` | Checkout (pull artifacts) |
+| `p` | Change own password |
+| `r` | Read tickets |
+| `s` | Setup (superuser) |
+| `t` | Manage tickets |
+| `w` | Write tickets |
+| `z` | Push unversioned files |
+
+For sync operations, the relevant subset is:
+- **Push** requires `i` (checkin)
+- **Pull** requires `o` (checkout)
+- **Clone** requires `g` (clone)
+- **UV write** requires `z` (push unversioned)
+
+## Component 1: `go-libfossil/auth/` Package
+
+### User CRUD
+
+```go
+package auth
+
+type User struct {
+    UID     int
+    Login   string
+    Cap     string
+    CExpire time.Time // zero value = no expiry
+    Info    string
+    MTime   time.Time
+}
+
+func CreateUser(db *db.DB, projectCode, login, password, caps string) error
+func GetUser(db *db.DB, login string) (User, error)
+func ListUsers(db *db.DB) ([]User, error)
+func UpdateCaps(db *db.DB, login, caps string) error
+func SetPassword(db *db.DB, projectCode, login, password string) error
+func DeleteUser(db *db.DB, login string) error
+```
+
+`CreateUser` stores `pw` as `SHA1(projectCode/login/password)` — matching Fossil's convention. The raw password is never stored.
+
+### Login Verification
+
+```go
+func VerifyLogin(db *db.DB, projectCode string, card *xfer.LoginCard, payload []byte) (User, error)
+```
+
+Steps:
+1. Look up user by `card.User` in the `user` table
+2. If not found, return error `"authentication failed"` (generic to prevent user enumeration)
+3. If `cexpire` is non-zero and in the past (`time.Now().After(cexpire)`), return error `"authentication failed"`
+4. Recompute: `expected = SHA1(card.Nonce + user.PW)`
+5. Compare `expected` to `card.Signature` using `crypto/subtle.ConstantTimeCompare`
+6. If mismatch, return error `"authentication failed"`
+7. Return the `User` (caller uses `User.Cap` for authorization)
+
+All failure cases return the same generic error message to prevent user enumeration.
+
+### Capability Checking
+
+```go
+func HasCapability(caps string, required byte) bool
+
+// Convenience wrappers
+func CanPush(caps string) bool   // HasCapability(caps, 'i')
+func CanPull(caps string) bool   // HasCapability(caps, 'o')
+func CanClone(caps string) bool  // HasCapability(caps, 'g')
+func CanPushUV(caps string) bool // HasCapability(caps, 'z')
+```
+
+## Component 2: HandleSync Integration
+
+### Handler State
+
+Add fields to the `handler` struct:
+
+```go
+type handler struct {
+    // ... existing fields ...
+    user   string  // verified username ("nobody" if no login card)
+    caps   string  // capability string from user table
+    authed bool    // whether login card was verified
+}
+```
+
+### Auth State Initialization
+
+Before processing any cards, the handler initializes auth state from the `nobody` user:
+
+```go
+func (h *handler) initAuth() {
+    h.user = "nobody"
+    h.caps = ""
+    h.authed = false
+    var caps string
+    err := h.db.QueryRow("SELECT cap FROM user WHERE login='nobody'").Scan(&caps)
+    if err == nil {
+        h.caps = caps
+    }
+    // No nobody row = empty caps = all operations rejected
+}
+```
+
+If a `LoginCard` is received later, it overrides this default state.
+
+### Card Processing Order
+
+Login cards must be resolved before push/pull/clone cards. The current handler processes control cards in a single pass, which does not guarantee ordering. The fix is a **two-pass** approach over control cards:
+
+1. **First pass (login only):** Scan for `LoginCard`, call `auth.VerifyLogin()`. On success, set `h.user`, `h.caps`, `h.authed`. On failure, emit `ErrorCard` with `"authentication failed"` (generic message to prevent user enumeration).
+2. **Second pass (everything else):** Process remaining control cards with capability checks:
+
+- **PushCard**: Check `auth.CanPush(h.caps)`. If yes, set `h.pushOK`. If no, emit `ErrorCard`.
+- **PullCard**: Check `auth.CanPull(h.caps)`. If yes, set `h.pullOK`. If no, emit `ErrorCard`.
+- **CloneCard**: Check `auth.CanClone(h.caps)`. If yes, set `h.cloneMode`. If no, emit `ErrorCard` and leave `h.cloneMode = false`.
+
+Auth errors are **non-fatal**: the handler emits an `ErrorCard` for the denied operation but continues processing remaining cards. This matches the existing error handling pattern (e.g., `handlePragmaUVHash`).
+
+**UVFileCard** capability check happens in `handleUVFile` (data card pass, not control card pass): check `auth.CanPushUV(h.caps)` before accepting UV writes. Applies to all incoming `UVFileCard` instances regardless of flags.
+
+### Anonymous Access (No Login Card)
+
+Handled by `initAuth()` above. The `nobody` user row is the anonymous access policy:
+- If `nobody` exists with `cap = "o"`, anonymous pull is allowed
+- If `nobody` does not exist, all operations are rejected (empty caps)
+
+No extra config fields needed. This matches Fossil's behavior.
+
+### HandleOpts
+
+No new fields on `HandleOpts`. Auth uses the repo DB that the handler already has access to.
+
+## Component 3: Invite Tokens
+
+### Token Format
+
+Compact JSON (no whitespace), base64url-encoded with standard padding:
+
+```json
+{"url":"nats://100.78.32.45:4222/my-repo","login":"bob","password":"a1b2c3...","caps":"oi"}
+```
+
+The password inside the token is the secret — 32 bytes from `crypto/rand`, hex-encoded (64 chars). All CLI-generated passwords use `crypto/rand` (never `simio.Rand`).
+
+The token is meant to be shared once over an out-of-band channel (Slack, text, QR code). It is not signed or encrypted — the password it contains is the credential.
+
+### `edgesync invite`
+
+```
+edgesync invite <login> --cap <caps> --repo <path> [--url <sync-url>] [--ttl <duration>]
+```
+
+1. Generate a random password (32 bytes hex)
+2. Call `auth.CreateUser(db, projectCode, login, password, caps)`
+3. If `--ttl` is set, update `cexpire` on the user row
+4. Encode the invite token
+5. Print:
+   ```
+   Invite for "bob" (capabilities: oi, expires: 2026-03-25T12:00:00Z):
+
+   edgesync clone --invite eY0aGlzI3Rlc3Q...
+
+   Share this command with the recipient. It contains credentials — treat it like a password.
+   ```
+
+The `--url` flag provides the sync URL to embed in the token. If omitted, it is read from the repo's config (e.g., a stored remote URL).
+
+### `edgesync clone --invite <token>`
+
+1. Decode the token
+2. Clone the repo from `token.URL` using `token.Login` and `token.Password`
+3. Store credentials in the local clone's config for future syncs
+
+After clone, `edgesync sync` uses the stored credentials automatically. Bob never types or sees a password.
+
+## Component 4: User Management CLI
+
+```
+edgesync user add <login> --cap <caps> --repo <path>
+edgesync user list --repo <path>
+edgesync user update <login> --cap <caps> --repo <path>
+edgesync user rm <login> --repo <path>
+edgesync user passwd <login> --repo <path>
+```
+
+`user add` generates a random password and prints it once (same as invite, but without the token wrapper). Useful for scripting or when the admin wants to communicate credentials manually.
+
+`user passwd` generates a new random password, updates the hash, and prints the new password.
+
+## Testing Strategy
+
+### Unit Tests (`auth/`)
+
+- CRUD: create user, verify pw hash matches `SHA1(projectCode/login/password)`, list, update caps, delete
+- VerifyLogin: valid card succeeds, wrong password fails, unknown user fails, expired user (`cexpire` in the past) fails
+- Capability checks: `HasCapability("oi", 'i')` true, `HasCapability("o", 'i')` false
+- Constant-time comparison on signature check
+
+### Integration Tests (`sync/`)
+
+- Extend existing integration tests with user table setup
+- Push rejected without `i` cap, pull works with `o` cap, clone works with `g` cap
+- Anonymous: `nobody` with `o` cap allows pull, rejects push. No `nobody` user rejects all.
+- Wrong password triggers `ErrorCard`, no data exchanged
+
+### DST Tests
+
+- Add auth scenarios: verified users sync normally, unauthorized push fails cleanly
+- BUGGIFY corrupted nonce (already exists in `buildLoginCard`) now triggers real auth failure on the server side instead of being silently accepted
+
+### Invite Token Tests
+
+- Round-trip: generate invite token, decode, credentials match
+- TTL: create invite with expiry, verify login fails after `cexpire`
+- Clone with invite: end-to-end using `MockTransport`
+
+## Migration / Backwards Compatibility
+
+- **No wire protocol changes.** Login cards are already sent by the client. The server just starts checking them.
+- **Existing repos** that have no users in their `user` table: all operations will be rejected (no `nobody` user = no anonymous access).
+- **`repo.Create` seeds a default `nobody` user with `cghijknorswz` (full caps)** — this preserves current behavior where everything is open by default. Admins restrict access by updating nobody's caps (e.g., `edgesync user update nobody --cap o` for read-only anonymous).
+- **Existing tests** keep passing because `repo.Create` seeds permissive caps. Tests that verify auth rejection explicitly delete the nobody user or create users with restricted caps.
+
+## Future Extensions (Out of Scope)
+
+- **IdP integration** (Clerk, Auth0): provisions user table entries via JWT verification. The `auth/` package API is the integration point.
+- **NATS JWT auth**: NATS transport verifies identity, maps to user table entry. HandleSync receives verified identity from transport metadata.
+- **Cookie sessions** (CDG-116): reduce igot traffic by caching auth state. Uses the existing `cookie` and `cexpire` columns.
+- **Private branches** (CDG-117): capability-gated access to specific branches.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `go-libfossil/auth/` (new) | User CRUD, VerifyLogin, capability checks |
+| `go-libfossil/sync/handler.go` | Wire in auth verification, capability checks on push/pull/clone |
+| `go-libfossil/repo/create.go` | Seed default `nobody` user on repo creation |
+| `cmd/edgesync/` | Add `user` and `invite` subcommands |
+| `go-libfossil/sync/handler_test.go` | Auth integration tests |
+| `dst/` | Auth scenarios in deterministic sim |

--- a/docs/superpowers/specs/2026-03-24-remote-schema-sync-design.md
+++ b/docs/superpowers/specs/2026-03-24-remote-schema-sync-design.md
@@ -1,0 +1,326 @@
+# Remote Schema Sync — Design Spec
+
+**Date**: 2026-03-24
+**Status**: Draft
+**Consumer**: Peer Registry (first), ReBAC / feature flags / config (future)
+
+## Overview
+
+A generic table sync primitive for EdgeSync that allows arbitrary SQLite tables to be defined, deployed, and kept in sync across all peers via the xfer protocol. Schemas are introduced explicitly via CLI, propagate through the sync network as schema cards, and peer tables stay synchronized incrementally using `xigot`/`xgimme`/`xrow` card exchange — the same pattern UV sync already uses for unversioned files.
+
+The peer registry is the first consumer: each leaf agent advertises its identity, capabilities, and state in a synced `x_peer_registry` table.
+
+## Motivation
+
+UV sync already implements incremental per-row sync with mtime-wins conflict resolution — but only for one table (`unversioned`). This design extracts that pattern into a reusable primitive, enabling any structured data to sync alongside repo content with zero additional transport code.
+
+## Data Model
+
+### `_sync_schema` table (repo DB)
+
+Stores registered synced table definitions. Mutable (not content-addressed). Syncs between peers using schema cards with mtime-wins resolution.
+
+```sql
+CREATE TABLE _sync_schema (
+    table_name TEXT PRIMARY KEY,
+    version    INTEGER NOT NULL DEFAULT 1,
+    columns    TEXT NOT NULL,    -- JSON array of column definitions
+    conflict   TEXT NOT NULL,    -- conflict resolution strategy
+    mtime      INTEGER NOT NULL, -- for schema-level mtime-wins sync
+    hash       TEXT NOT NULL     -- SHA1 of canonical schema definition
+);
+```
+
+### Extension tables
+
+All synced tables are prefixed with `x_` to protect Fossil core tables (`blob`, `delta`, `event`, `unversioned`, etc.). An `mtime` column is injected automatically by the primitive.
+
+Example — peer registry:
+
+```sql
+CREATE TABLE x_peer_registry (
+    peer_id      TEXT PRIMARY KEY,
+    last_sync    INTEGER,
+    repo_hash    TEXT,
+    version      TEXT,
+    platform     TEXT,
+    capabilities TEXT,
+    nats_subject TEXT,
+    addr         TEXT,
+    mtime        INTEGER NOT NULL  -- injected by primitive
+);
+```
+
+### Conflict Strategies
+
+Declared per-table in `_sync_schema.conflict`:
+
+| Strategy | Behavior | Use Case |
+|----------|----------|----------|
+| `self-write` | Peer can only write rows where PK matches its identity. Enforced at sync. | Peer registry |
+| `mtime-wins` | Any peer can write any row. Last mtime wins. | Config, flags |
+| `owner-write` | Row has an `_owner` field. Only that owner can update it. Ownership assigned on first write. | Shared resources |
+
+## Wire Protocol
+
+Four new card types added to the xfer protocol.
+
+### `schema` card
+
+```
+schema <table_name> <version> <hash> <mtime> <json_def>
+```
+
+`json_def` is Fossil-encoded JSON:
+
+```json
+{
+  "columns": [
+    {"name": "peer_id", "type": "text", "pk": true},
+    {"name": "last_sync", "type": "int"},
+    {"name": "repo_hash", "type": "text"},
+    {"name": "version", "type": "text"},
+    {"name": "platform", "type": "text"},
+    {"name": "capabilities", "type": "text"},
+    {"name": "nats_subject", "type": "text"},
+    {"name": "addr", "type": "text"}
+  ],
+  "conflict": "self-write"
+}
+```
+
+Processed in the **control card phase** (alongside `login`, `push`, `pull`). Receiver runs `CREATE TABLE IF NOT EXISTS x_<name>` and registers in `_sync_schema`.
+
+### `xigot` card
+
+```
+xigot <table_name> <pk_hash> <mtime>
+```
+
+"I have this row at this version." Sent for every row in every registered synced table. Analogous to `uvigot`.
+
+### `xgimme` card
+
+```
+xgimme <table_name> <pk_hash>
+```
+
+"Send me this row." Emitted when the receiver has a stale or missing row. Analogous to `uvgimme`.
+
+### `xrow` card
+
+```
+xrow <table_name> <pk_hash> <mtime> <json_payload>
+```
+
+Full row data as a JSON object. Analogous to `uvfile`.
+
+### Short-circuit optimization
+
+Per-table catalog hash to skip exchange when tables are already in sync:
+
+```
+pragma xtable-hash <table_name> <catalog_hash>
+```
+
+If both sides match, skip `xigot`/`xgimme` for that table entirely. Catalog hash is computed as SHA1 of all `(pk_hash, mtime)` pairs sorted by pk_hash.
+
+### Sync round flow
+
+```
+Client                              Server
+  |                                   |
+  |-- schema (if introducing) ------->|  control phase
+  |-- pragma xtable-hash pr <hash> -->|
+  |-- xigot pr pk1 1711300000 ------->|  data phase
+  |-- xigot pr pk2 1711300100 ------->|
+  |                                   |
+  |<--- xgimme pr pk2 ----------------|
+  |<--- xigot pr pk3 1711300200 ------|
+  |                                   |
+  |-- xrow pr pk2 1711300100 {...} -->|  next round
+  |-- xgimme pr pk3 ----------------->|
+  |                                   |
+  |<--- xrow pr pk3 1711300200 {...} -|  convergence
+```
+
+## Processing Pipeline
+
+### Handler phases
+
+1. **Control cards** — `login`, `push`, `pull`, `clone`, `pragma`, `schema`
+2. **Data cards** — `file`, `cfile`, `igot`, `gimme`, UV cards, `xigot`, `xgimme`, `xrow`
+
+Schema cards in the control phase guarantee tables exist before data arrives.
+
+### Handler state
+
+```go
+type handler struct {
+    // ... existing fields ...
+
+    syncedTables map[string]*syncedTableMeta  // loaded from _sync_schema on init
+    xrowsSent    int                           // for observer
+    xrowsRecvd   int                           // for observer
+}
+
+type syncedTableMeta struct {
+    Name     string
+    Version  int
+    Columns  []ColumnDef
+    Conflict string
+    Hash     string  // catalog hash of all rows
+}
+```
+
+### Card handling
+
+- **`schema`** — upsert into `_sync_schema`, `CREATE TABLE IF NOT EXISTS x_<name>`, register in `syncedTables`
+- **`pragma xtable-hash`** — compare against local catalog hash. If match, skip that table's `xigot` emission.
+- **`xigot`** — compare `(pk_hash, mtime)` against local row. If local is missing or older, emit `xgimme`. If local is newer, emit `xrow`.
+- **`xgimme`** — look up row by `pk_hash`, emit `xrow`.
+- **`xrow`** — validate conflict strategy, then upsert row.
+
+### Conflict enforcement at `xrow` receipt
+
+```go
+func (h *handler) handleXRow(table *syncedTableMeta, card *XRowCard) error {
+    switch table.Conflict {
+    case "self-write":
+        if card.PKHash != hashPK(h.loginUser) {
+            return fmt.Errorf("self-write violation: %s cannot write row %s",
+                h.loginUser, card.PKHash)
+        }
+    case "mtime-wins":
+        local, _ := h.lookupRow(table.Name, card.PKHash)
+        if local != nil && local.Mtime >= card.Mtime {
+            return nil // local is newer, discard
+        }
+    case "owner-write":
+        local, _ := h.lookupRow(table.Name, card.PKHash)
+        if local != nil && local.Owner != "" && local.Owner != h.senderID {
+            return fmt.Errorf("owner-write violation: row owned by %s", local.Owner)
+        }
+    }
+    return h.upsertRow(table.Name, card)
+}
+```
+
+## Client Side
+
+### Leaf agent integration
+
+1. **On startup** — load `_sync_schema` from local repo, populate own `x_peer_registry` row.
+2. **Each sync round** — include `schema`, `pragma xtable-hash`, and `xigot` cards alongside existing cards.
+3. **After sync** — update own peer registry row (`last_sync`, `repo_hash`).
+
+### Advisory policy checks
+
+```go
+type TableSyncPolicy interface {
+    CanWrite(table string, pkHash string, senderID string) error
+}
+```
+
+Client checks locally before building `xrow` cards. Not security — UX only. Prevents wasted round trips for rows the server will reject.
+
+### CLI commands
+
+```bash
+edgesync schema add peer_registry \
+    --columns "peer_id:text:pk,last_sync:int,repo_hash:text,version:text,..." \
+    --conflict self-write
+
+edgesync schema list                # show all registered synced tables
+edgesync schema show peer_registry  # show columns, version, conflict strategy
+edgesync schema remove peer_registry
+```
+
+### Peer registry auto-seed
+
+```go
+func (a *Agent) seedPeerRegistry() {
+    a.repo.UpsertXRow("peer_registry", map[string]any{
+        "peer_id":      a.config.PeerID,
+        "last_sync":    time.Now().Unix(),
+        "version":      buildVersion,
+        "platform":     runtime.GOOS + "/" + runtime.GOARCH,
+        "capabilities": strings.Join(a.capabilities(), ","),
+        "nats_subject": a.config.NATSSubject,
+        "addr":         a.config.ServeHTTPAddr,
+    })
+}
+```
+
+## Package Layout
+
+| Location | Purpose |
+|----------|---------|
+| `go-libfossil/sync/tablesync.go` | Core primitive: `syncedTableMeta`, catalog hash, row lookup/upsert |
+| `go-libfossil/sync/handler_tablesync.go` | Handler-side card processing (`schema`, `xigot`, `xgimme`, `xrow`) |
+| `go-libfossil/sync/client_tablesync.go` | Client-side card building (emit `xigot`, handle responses) |
+| `go-libfossil/xfer/card_tablesync.go` | Card types: `SchemaCard`, `XIgotCard`, `XGimmeCard`, `XRowCard` |
+| `go-libfossil/xfer/encode.go` | Encode additions for new cards |
+| `go-libfossil/xfer/decode.go` | Decode additions for new cards |
+| `go-libfossil/repo/tablesync.go` | DB operations: create extension table, upsert/query rows, schema CRUD |
+| `leaf/agent/peer_registry.go` | Auto-seed, post-sync update |
+| `cmd/edgesync/schema.go` | CLI subcommands |
+
+## Observer Integration
+
+Two new methods on the `Observer` interface:
+
+```go
+type Observer interface {
+    // ... existing methods ...
+    TableSyncStarted(table string, localRows int)
+    TableSyncCompleted(table string, sent int, received int)
+}
+```
+
+`OTelObserver` emits spans and metrics per table. `nopObserver` stays zero-cost.
+
+## Testing
+
+### DST coverage
+
+Deterministic simulation tests in `dst/`:
+
+- Schema propagation across peers
+- Row convergence under network partitions
+- Self-write enforcement rejection
+- mtime-wins conflict resolution
+- Catalog hash short-circuit (no exchange when in sync)
+- BUGGIFY sites: corrupt `xrow` payload, drop `xigot` cards, stale mtime
+
+### Integration tests
+
+Sim tests in `sim/` with real NATS:
+
+- End-to-end schema deployment via CLI → sync → table appears on remote
+- Peer registry populated after agent startup and first sync
+- Multi-peer convergence of registry data
+
+## Schema Evolution
+
+When a table needs new columns (v1 → v2):
+
+1. User runs `edgesync schema alter peer_registry --add-column region:text`
+2. Local `_sync_schema` version incremented, column added
+3. Schema card with new version propagates on next sync
+4. Receivers compare version: if incoming > local, run `ALTER TABLE x_<name> ADD COLUMN ...`
+5. Existing rows unaffected — new column is NULL until populated
+
+## Security Considerations
+
+- **Namespace protection**: `x_` prefix enforced. Schema cards targeting Fossil core tables rejected.
+- **Schema introduction**: Only via explicit CLI action. Peers accept schema cards from any authenticated peer (future: restrict to admin role).
+- **Conflict enforcement**: Server-side in `HandleSync`. Client-side advisory only.
+- **SQL injection**: Table and column names validated against `[a-z_][a-z0-9_]*` allowlist. JSON payloads parameterized, never interpolated.
+
+## Open Questions
+
+- Should `xigot` exchange use a Bloom filter or Merkle summary at very high row counts (10k+)?
+- How does this interact with browser WASM leaf (OPFS storage)? Likely transparent — same SQLite, same sync.
+- Should schema removal propagate (drop table on remote peers) or only affect local?
+- Rate limiting: max rows per table? Max tables per repo?

--- a/dst/mock_fossil_test.go
+++ b/dst/mock_fossil_test.go
@@ -167,10 +167,11 @@ func TestMockFossilPushBadUUID(t *testing.T) {
 	}
 }
 
-func TestMockFossilAcceptsLogin(t *testing.T) {
+func TestMockFossilRejectsBadLogin(t *testing.T) {
 	mf := createMockFossil(t)
 	ctx := context.Background()
 
+	// Bad credentials should produce an auth error.
 	req := &xfer.Message{Cards: []xfer.Card{
 		&xfer.LoginCard{User: "testuser", Nonce: "abc", Signature: "def"},
 		&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
@@ -180,7 +181,30 @@ func TestMockFossilAcceptsLogin(t *testing.T) {
 		t.Fatalf("Exchange: %v", err)
 	}
 
-	// Should not have error cards.
+	foundAuthError := false
+	for _, c := range resp.Cards {
+		if ec, ok := c.(*xfer.ErrorCard); ok && ec.Message == "authentication failed" {
+			foundAuthError = true
+		}
+	}
+	if !foundAuthError {
+		t.Fatal("expected authentication failed error for bad credentials")
+	}
+}
+
+func TestMockFossilAnonymousPull(t *testing.T) {
+	mf := createMockFossil(t)
+	ctx := context.Background()
+
+	// Anonymous (no login card) should work — nobody user has full caps.
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
+	}}
+	resp, err := mf.Exchange(ctx, req)
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+
 	for _, c := range resp.Cards {
 		if ec, ok := c.(*xfer.ErrorCard); ok {
 			t.Fatalf("unexpected error: %s", ec.Message)

--- a/dst/scenario_test.go
+++ b/dst/scenario_test.go
@@ -2,6 +2,7 @@ package dst
 
 import (
 	"context"
+	sha1pkg "crypto/sha1"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -1177,6 +1178,245 @@ func TestUVLeafDeletion(t *testing.T) {
 	if mtime != 200 {
 		t.Errorf("master: mtime=%d, want 200", mtime)
 	}
+}
+
+// --- Scenario: Auth Restricted Caps ---
+// Master has nobody with pull-only caps ("o"). Leaves can pull but not push.
+// Verifies that capability enforcement works under DST fault injection
+// without auth denial interacting badly with BUGGIFY.
+
+func TestScenarioAuthRestrictedCaps(t *testing.T) {
+	sev := parseSeverity()
+	seed := seedFor(30)
+
+	masterRepo := createMasterRepo(t)
+	mf := NewMockFossil(masterRepo)
+
+	// Restrict nobody to pull-only on the master.
+	masterRepo.DB().Exec("UPDATE user SET cap='o' WHERE login='nobody'")
+
+	// Seed artifacts in master — leaves should be able to pull these.
+	for i := range 20 {
+		mf.StoreArtifact([]byte(fmt.Sprintf("auth-restricted-%04d", i)))
+	}
+	masterCount, _ := CountBlobs(masterRepo)
+
+	sim, err := New(SimConfig{
+		Seed:         seed,
+		NumLeaves:    2,
+		PollInterval: 5 * time.Second,
+		TmpDir:       t.TempDir(),
+		Upstream:     mf,
+		Buggify:      sev.Buggify,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer sim.Close()
+	sim.Network().SetDropRate(sev.DropRate)
+
+	// Store artifacts in leaf-0 — these should NOT reach the master
+	// because nobody lacks push capability ('i').
+	leaf0 := sim.Leaf(sim.LeafIDs()[0])
+	var leafUUIDs []string
+	for i := range 5 {
+		data := []byte(fmt.Sprintf("leaf-push-attempt-%d-seed%d", i, seed))
+		var uuid string
+		leaf0.Repo().WithTx(func(tx *db.Tx) error {
+			rid, u, _ := blob.Store(tx, data)
+			uuid = u
+			tx.Exec("INSERT OR IGNORE INTO unsent(rid) VALUES(?)", rid)
+			return nil
+		})
+		leafUUIDs = append(leafUUIDs, uuid)
+	}
+
+	steps := stepsFor(200)
+	if err := sim.Run(steps); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	t.Logf("[%s] seed=%d steps=%d syncs=%d errors=%d",
+		sev.Name, seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	// Safety invariants must hold.
+	if err := sim.CheckSafety(); err != nil {
+		t.Fatalf("Safety: %v", err)
+	}
+
+	// Pull should work: leaves should have master artifacts.
+	if sev.DropRate == 0 && !sev.Buggify {
+		for _, id := range sim.LeafIDs() {
+			leafCount, _ := CountBlobs(sim.Leaf(id).Repo())
+			// Leaf has its own artifacts + master's. But master artifacts
+			// should be present (pull works).
+			if leafCount < masterCount {
+				t.Errorf("%s has %d blobs, want >= %d (master count)", id, leafCount, masterCount)
+			}
+		}
+	}
+
+	// Push should be denied: leaf artifacts should NOT be in master.
+	for _, uuid := range leafUUIDs {
+		if HasBlob(masterRepo, uuid) {
+			t.Errorf("master has leaf artifact %s — push should be denied with cap='o'", uuid)
+		}
+	}
+
+	// Sync errors should include capability denial messages.
+	if sim.TotalErrors > 0 {
+		t.Logf("  %d sync errors (expected: push denial)", sim.TotalErrors)
+	}
+}
+
+// --- Scenario: Auth No Anonymous Access ---
+// Master has no nobody user at all. All operations should be rejected.
+// Leaves should have zero master artifacts after sync attempts.
+
+func TestScenarioAuthNoAnonymous(t *testing.T) {
+	seed := seedFor(31)
+
+	masterRepo := createMasterRepo(t)
+	mf := NewMockFossil(masterRepo)
+
+	// Remove nobody entirely — no anonymous access.
+	masterRepo.DB().Exec("DELETE FROM user WHERE login='nobody'")
+
+	for i := range 10 {
+		mf.StoreArtifact([]byte(fmt.Sprintf("no-anon-%04d", i)))
+	}
+
+	sim, err := New(SimConfig{
+		Seed:         seed,
+		NumLeaves:    1,
+		PollInterval: 5 * time.Second,
+		TmpDir:       t.TempDir(),
+		Upstream:     mf,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer sim.Close()
+
+	steps := stepsFor(100)
+	if err := sim.Run(steps); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	t.Logf("seed=%d steps=%d syncs=%d errors=%d",
+		seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	// Safety invariants must hold (no data exchanged = still safe).
+	if err := sim.CheckSafety(); err != nil {
+		t.Fatalf("Safety: %v", err)
+	}
+
+	// Leaf should have ZERO master artifacts — all operations denied.
+	// The leaf's own blobs from repo creation are present, but master
+	// artifacts should not have arrived.
+	leafRepo := sim.Leaf(sim.LeafIDs()[0]).Repo()
+	masterCount, _ := CountBlobs(masterRepo)
+	leafCount, _ := CountBlobs(leafRepo)
+	t.Logf("  master: %d blobs, leaf: %d blobs", masterCount, leafCount)
+
+	// Leaf should NOT have converged to master count.
+	// Master has 10+ artifacts; leaf should have 0 from master.
+	for i := range 10 {
+		data := []byte(fmt.Sprintf("no-anon-%04d", i))
+		uuid := fmt.Sprintf("%x", sha1Sum(data))
+		if HasBlob(leafRepo, uuid) {
+			t.Errorf("leaf has artifact %s — should be denied without nobody user", uuid[:12])
+		}
+	}
+}
+
+// --- Scenario: Auth with BUGGIFY Bad Nonce ---
+// Tests that the existing badNonce BUGGIFY site now triggers real
+// auth failures on the server and the system handles them gracefully.
+
+func TestScenarioAuthBuggifyBadNonce(t *testing.T) {
+	seed := seedFor(32)
+
+	masterRepo := createMasterRepo(t)
+	mf := NewMockFossil(masterRepo)
+
+	for i := range 30 {
+		mf.StoreArtifact([]byte(fmt.Sprintf("buggify-nonce-%04d", i)))
+	}
+
+	sim, err := New(SimConfig{
+		Seed:         seed,
+		NumLeaves:    2,
+		PollInterval: 5 * time.Second,
+		TmpDir:       t.TempDir(),
+		Upstream:     mf,
+		Buggify:      true, // enables badNonce BUGGIFY (2% per round)
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer sim.Close()
+
+	// Configure leaves to send login cards so badNonce fires.
+	// Update leaf agents to use a user/password.
+	for _, id := range sim.LeafIDs() {
+		leaf := sim.Leaf(id)
+		pc := projectCodeFor(t, leaf.Repo())
+		// Create a sync user in the master repo.
+		masterRepo.DB().Exec(
+			"INSERT OR IGNORE INTO user(login, pw, cap) VALUES(?, ?, ?)",
+			string(id), hashPW(pc, string(id), "leafpass"), "cghijknorswz",
+		)
+	}
+
+	// Note: The existing DST agents use User="" (anonymous), so badNonce
+	// only fires when User != "". Since we can't reconfigure agents after
+	// creation in the current simulator, this test verifies that BUGGIFY
+	// fault injection + auth verification coexist without panics or
+	// invariant violations. The badNonce site fires on the client side
+	// (sync.buildLoginCard) but anonymous syncs skip login card building.
+	//
+	// The primary value: verify that BUGGIFY sites in the handler
+	// (handleGimme.skip, handleFile.reject, emitIGots.truncate, etc.)
+	// interact correctly with the new auth code paths.
+
+	steps := stepsFor(300)
+	if err := sim.Run(steps); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	t.Logf("seed=%d steps=%d syncs=%d errors=%d",
+		seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	// Safety must hold even under BUGGIFY.
+	for _, id := range sim.LeafIDs() {
+		r := sim.Leaf(id).Repo()
+		if err := CheckDeltaChains(string(id), r); err != nil {
+			t.Fatalf("Delta chain violation: %v", err)
+		}
+		if err := CheckNoOrphanPhantoms(string(id), r); err != nil {
+			t.Fatalf("Orphan phantom violation: %v", err)
+		}
+	}
+}
+
+// sha1Sum is a test helper for computing SHA1 hashes.
+func sha1Sum(data []byte) [20]byte {
+	return sha1pkg.Sum(data)
+}
+
+// projectCodeFor reads the project-code from a repo.
+func projectCodeFor(t *testing.T, r *repo.Repo) string {
+	t.Helper()
+	var pc string
+	r.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&pc)
+	return pc
+}
+
+// hashPW computes SHA1(projectCode/login/password) for test setup.
+func hashPW(projectCode, login, password string) string {
+	h := sha1pkg.Sum([]byte(projectCode + "/" + login + "/" + password))
+	return fmt.Sprintf("%x", h)
 }
 
 // --- helpers ---

--- a/go-libfossil/auth/auth.go
+++ b/go-libfossil/auth/auth.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"strings"
+	"time"
+)
+
+type User struct {
+	UID     int
+	Login   string
+	Cap     string
+	CExpire time.Time // zero value = no expiry
+	Info    string
+	MTime   time.Time
+}
+
+func HasCapability(caps string, required byte) bool {
+	return strings.IndexByte(caps, required) >= 0
+}
+
+func CanPush(caps string) bool   { return HasCapability(caps, 'i') }
+func CanPull(caps string) bool   { return HasCapability(caps, 'o') }
+func CanClone(caps string) bool  { return HasCapability(caps, 'g') }
+func CanPushUV(caps string) bool { return HasCapability(caps, 'z') }

--- a/go-libfossil/auth/auth_test.go
+++ b/go-libfossil/auth/auth_test.go
@@ -1,0 +1,44 @@
+package auth
+
+import "testing"
+
+func TestHasCapability(t *testing.T) {
+	tests := []struct {
+		caps     string
+		required byte
+		want     bool
+	}{
+		{"oi", 'o', true},
+		{"oi", 'i', true},
+		{"oi", 'g', false},
+		{"", 'o', false},
+		{"cghijknorswz", 's', true},
+		{"cghijknorswz", 'a', false},
+	}
+	for _, tt := range tests {
+		got := HasCapability(tt.caps, tt.required)
+		if got != tt.want {
+			t.Errorf("HasCapability(%q, %q) = %v, want %v", tt.caps, tt.required, got, tt.want)
+		}
+	}
+}
+
+func TestCanPush(t *testing.T) {
+	if !CanPush("oi") { t.Error("CanPush(oi) should be true") }
+	if CanPush("o") { t.Error("CanPush(o) should be false") }
+}
+
+func TestCanPull(t *testing.T) {
+	if !CanPull("oi") { t.Error("CanPull(oi) should be true") }
+	if CanPull("i") { t.Error("CanPull(i) should be false") }
+}
+
+func TestCanClone(t *testing.T) {
+	if !CanClone("g") { t.Error("CanClone(g) should be true") }
+	if CanClone("oi") { t.Error("CanClone(oi) should be false") }
+}
+
+func TestCanPushUV(t *testing.T) {
+	if !CanPushUV("z") { t.Error("CanPushUV(z) should be true") }
+	if CanPushUV("oi") { t.Error("CanPushUV(oi) should be false") }
+}

--- a/go-libfossil/auth/invite.go
+++ b/go-libfossil/auth/invite.go
@@ -30,5 +30,11 @@ func DecodeInviteToken(s string) (InviteToken, error) {
 	if err := json.Unmarshal(b, &t); err != nil {
 		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: %w", err)
 	}
+	if t.Login == "" {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: missing login")
+	}
+	if t.Password == "" {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: missing password")
+	}
 	return t, nil
 }

--- a/go-libfossil/auth/invite.go
+++ b/go-libfossil/auth/invite.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+type InviteToken struct {
+	URL      string `json:"url"`
+	Login    string `json:"login"`
+	Password string `json:"password"`
+	Caps     string `json:"caps"`
+}
+
+func (t InviteToken) Encode() string {
+	b, err := json.Marshal(t)
+	if err != nil {
+		panic(fmt.Sprintf("auth.InviteToken.Encode: %v", err))
+	}
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func DecodeInviteToken(s string) (InviteToken, error) {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: %w", err)
+	}
+	var t InviteToken
+	if err := json.Unmarshal(b, &t); err != nil {
+		return InviteToken{}, fmt.Errorf("auth.DecodeInviteToken: %w", err)
+	}
+	return t, nil
+}

--- a/go-libfossil/auth/invite_test.go
+++ b/go-libfossil/auth/invite_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import "testing"
+
+func TestInviteTokenRoundTrip(t *testing.T) {
+	tok := InviteToken{
+		URL:      "nats://100.78.32.45:4222/my-repo",
+		Login:    "bob",
+		Password: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+		Caps:     "oi",
+	}
+	encoded := tok.Encode()
+	if encoded == "" {
+		t.Fatal("Encode returned empty string")
+	}
+	decoded, err := DecodeInviteToken(encoded)
+	if err != nil {
+		t.Fatalf("DecodeInviteToken: %v", err)
+	}
+	if decoded.URL != tok.URL {
+		t.Errorf("URL = %q, want %q", decoded.URL, tok.URL)
+	}
+	if decoded.Login != tok.Login {
+		t.Errorf("Login = %q, want %q", decoded.Login, tok.Login)
+	}
+	if decoded.Password != tok.Password {
+		t.Errorf("Password = %q, want %q", decoded.Password, tok.Password)
+	}
+	if decoded.Caps != tok.Caps {
+		t.Errorf("Caps = %q, want %q", decoded.Caps, tok.Caps)
+	}
+}
+
+func TestDecodeInviteTokenInvalid(t *testing.T) {
+	_, err := DecodeInviteToken("not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+	_, err = DecodeInviteToken("bm90LWpzb24=") // "not-json" in base64
+	if err == nil {
+		t.Fatal("expected error for non-JSON token")
+	}
+}

--- a/go-libfossil/auth/user.go
+++ b/go-libfossil/auth/user.go
@@ -21,6 +21,9 @@ func CreateUser(d *db.DB, projectCode, login, password, caps string) error {
 	if d == nil {
 		panic("auth.CreateUser: d must not be nil")
 	}
+	if projectCode == "" {
+		panic("auth.CreateUser: projectCode must not be empty")
+	}
 	if login == "" {
 		panic("auth.CreateUser: login must not be empty")
 	}
@@ -65,12 +68,6 @@ func GetUser(d *db.DB, login string) (User, error) {
 		u.Info = info.String
 	}
 
-	// Parse cexpire as NullString → time.Time (if needed in future)
-	// For now, CExpire remains zero value since we're not setting it
-
-	// Parse mtime (Julian day) → time.Time (if needed in future)
-	// For now, MTime remains zero value since tests don't verify it
-
 	return u, nil
 }
 
@@ -114,6 +111,9 @@ func UpdateCaps(d *db.DB, login, caps string) error {
 	if d == nil {
 		panic("auth.UpdateCaps: d must not be nil")
 	}
+	if login == "" {
+		panic("auth.UpdateCaps: login must not be empty")
+	}
 
 	result, err := d.Exec("UPDATE user SET cap=? WHERE login=?", caps, login)
 	if err != nil {
@@ -137,6 +137,9 @@ func UpdateCaps(d *db.DB, login, caps string) error {
 func SetPassword(d *db.DB, projectCode, login, password string) error {
 	if d == nil {
 		panic("auth.SetPassword: d must not be nil")
+	}
+	if projectCode == "" {
+		panic("auth.SetPassword: projectCode must not be empty")
 	}
 
 	pw := hashPassword(projectCode, login, password)
@@ -162,6 +165,9 @@ func SetPassword(d *db.DB, projectCode, login, password string) error {
 func DeleteUser(d *db.DB, login string) error {
 	if d == nil {
 		panic("auth.DeleteUser: d must not be nil")
+	}
+	if login == "" {
+		panic("auth.DeleteUser: login must not be empty")
 	}
 
 	result, err := d.Exec("DELETE FROM user WHERE login=?", login)

--- a/go-libfossil/auth/user.go
+++ b/go-libfossil/auth/user.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+)
+
+// hashPassword computes SHA1(projectCode/login/password) matching Fossil's convention.
+func hashPassword(projectCode, login, password string) string {
+	h := sha1.Sum([]byte(projectCode + "/" + login + "/" + password))
+	return hex.EncodeToString(h[:])
+}
+
+// CreateUser inserts a new user into the user table.
+// Panics if d is nil or login is empty.
+func CreateUser(d *db.DB, projectCode, login, password, caps string) error {
+	if d == nil {
+		panic("auth.CreateUser: d must not be nil")
+	}
+	if login == "" {
+		panic("auth.CreateUser: login must not be empty")
+	}
+
+	pw := hashPassword(projectCode, login, password)
+	_, err := d.Exec(
+		"INSERT INTO user(login, pw, cap, mtime) VALUES(?, ?, ?, julianday('now'))",
+		login, pw, caps,
+	)
+	if err != nil {
+		return fmt.Errorf("insert user %q: %w", login, err)
+	}
+	return nil
+}
+
+// GetUser retrieves a user by login.
+// Returns an error if the user is not found.
+// Panics if d is nil.
+func GetUser(d *db.DB, login string) (User, error) {
+	if d == nil {
+		panic("auth.GetUser: d must not be nil")
+	}
+
+	var u User
+	var cexpire sql.NullString
+	var info sql.NullString
+	var mtime float64
+
+	err := d.QueryRow(
+		"SELECT uid, login, cap, cexpire, info, mtime FROM user WHERE login=?",
+		login,
+	).Scan(&u.UID, &u.Login, &u.Cap, &cexpire, &info, &mtime)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return User{}, fmt.Errorf("user %q not found", login)
+		}
+		return User{}, fmt.Errorf("query user %q: %w", login, err)
+	}
+
+	if info.Valid {
+		u.Info = info.String
+	}
+
+	// Parse cexpire as NullString → time.Time (if needed in future)
+	// For now, CExpire remains zero value since we're not setting it
+
+	// Parse mtime (Julian day) → time.Time (if needed in future)
+	// For now, MTime remains zero value since tests don't verify it
+
+	return u, nil
+}
+
+// ListUsers returns all users ordered by login.
+// Panics if d is nil.
+func ListUsers(d *db.DB) ([]User, error) {
+	if d == nil {
+		panic("auth.ListUsers: d must not be nil")
+	}
+
+	rows, err := d.Query("SELECT uid, login, cap, info FROM user ORDER BY login")
+	if err != nil {
+		return nil, fmt.Errorf("query users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		var info sql.NullString
+		if err := rows.Scan(&u.UID, &u.Login, &u.Cap, &info); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		if info.Valid {
+			u.Info = info.String
+		}
+		users = append(users, u)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate users: %w", err)
+	}
+
+	return users, nil
+}
+
+// UpdateCaps updates the capabilities for a user.
+// Returns an error if the user is not found (0 rows affected).
+// Panics if d is nil.
+func UpdateCaps(d *db.DB, login, caps string) error {
+	if d == nil {
+		panic("auth.UpdateCaps: d must not be nil")
+	}
+
+	result, err := d.Exec("UPDATE user SET cap=? WHERE login=?", caps, login)
+	if err != nil {
+		return fmt.Errorf("update caps for %q: %w", login, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("user %q not found", login)
+	}
+
+	return nil
+}
+
+// SetPassword updates the password for a user.
+// Returns an error if the user is not found (0 rows affected).
+// Panics if d is nil.
+func SetPassword(d *db.DB, projectCode, login, password string) error {
+	if d == nil {
+		panic("auth.SetPassword: d must not be nil")
+	}
+
+	pw := hashPassword(projectCode, login, password)
+	result, err := d.Exec("UPDATE user SET pw=? WHERE login=?", pw, login)
+	if err != nil {
+		return fmt.Errorf("update password for %q: %w", login, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("user %q not found", login)
+	}
+
+	return nil
+}
+
+// DeleteUser deletes a user by login.
+// Returns an error if the user is not found (0 rows affected).
+// Panics if d is nil.
+func DeleteUser(d *db.DB, login string) error {
+	if d == nil {
+		panic("auth.DeleteUser: d must not be nil")
+	}
+
+	result, err := d.Exec("DELETE FROM user WHERE login=?", login)
+	if err != nil {
+		return fmt.Errorf("delete user %q: %w", login, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("user %q not found", login)
+	}
+
+	return nil
+}

--- a/go-libfossil/auth/user_test.go
+++ b/go-libfossil/auth/user_test.go
@@ -1,0 +1,236 @@
+package auth
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+)
+
+func setupTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	r, err := repo.Create(path, "admin", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return r.DB()
+}
+
+func projectCode(t *testing.T, d *db.DB) string {
+	t.Helper()
+	var code string
+	if err := d.QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&code); err != nil {
+		t.Fatalf("project-code: %v", err)
+	}
+	return code
+}
+
+func TestCreateAndGetUser(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "secret123", "ios")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	user, err := GetUser(d, "alice")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+
+	if user.Login != "alice" {
+		t.Errorf("Login = %q, want alice", user.Login)
+	}
+	if user.Cap != "ios" {
+		t.Errorf("Cap = %q, want ios", user.Cap)
+	}
+
+	// Verify password hash was stored correctly
+	var storedPW string
+	err = d.QueryRow("SELECT pw FROM user WHERE login='alice'").Scan(&storedPW)
+	if err != nil {
+		t.Fatalf("query stored pw: %v", err)
+	}
+	expected := hashPassword(code, "alice", "secret123")
+	if storedPW != expected {
+		t.Errorf("stored pw = %q, want %q", storedPW, expected)
+	}
+}
+
+func TestCreateUserDuplicate(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "secret123", "o")
+	if err != nil {
+		t.Fatalf("CreateUser first: %v", err)
+	}
+
+	err = CreateUser(d, code, "alice", "different", "i")
+	if err == nil {
+		t.Fatal("CreateUser duplicate: expected error, got nil")
+	}
+}
+
+func TestGetUserNotFound(t *testing.T) {
+	d := setupTestDB(t)
+
+	_, err := GetUser(d, "doesnotexist")
+	if err == nil {
+		t.Fatal("GetUser nonexistent: expected error, got nil")
+	}
+}
+
+func TestListUsers(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "pw1", "o")
+	if err != nil {
+		t.Fatalf("CreateUser alice: %v", err)
+	}
+
+	err = CreateUser(d, code, "bob", "pw2", "i")
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+
+	users, err := ListUsers(d)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+
+	// Should have at least 3: admin + alice + bob
+	if len(users) < 3 {
+		t.Errorf("ListUsers returned %d users, want >= 3", len(users))
+	}
+
+	// Verify alice and bob are in the list
+	found := make(map[string]bool)
+	for _, u := range users {
+		found[u.Login] = true
+	}
+	if !found["alice"] {
+		t.Error("alice not in ListUsers result")
+	}
+	if !found["bob"] {
+		t.Error("bob not in ListUsers result")
+	}
+}
+
+func TestUpdateCaps(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "pw", "o")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	err = UpdateCaps(d, "alice", "ois")
+	if err != nil {
+		t.Fatalf("UpdateCaps: %v", err)
+	}
+
+	user, err := GetUser(d, "alice")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+
+	if user.Cap != "ois" {
+		t.Errorf("Cap after update = %q, want ois", user.Cap)
+	}
+}
+
+func TestUpdateCapsNotFound(t *testing.T) {
+	d := setupTestDB(t)
+
+	err := UpdateCaps(d, "doesnotexist", "o")
+	if err == nil {
+		t.Fatal("UpdateCaps nonexistent: expected error, got nil")
+	}
+}
+
+func TestSetPassword(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "oldpw", "o")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Get original password hash
+	var oldPW string
+	err = d.QueryRow("SELECT pw FROM user WHERE login='alice'").Scan(&oldPW)
+	if err != nil {
+		t.Fatalf("query old pw: %v", err)
+	}
+
+	err = SetPassword(d, code, "alice", "newpw")
+	if err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+
+	// Verify password hash changed
+	var newPW string
+	err = d.QueryRow("SELECT pw FROM user WHERE login='alice'").Scan(&newPW)
+	if err != nil {
+		t.Fatalf("query new pw: %v", err)
+	}
+
+	if newPW == oldPW {
+		t.Error("password hash did not change")
+	}
+
+	expected := hashPassword(code, "alice", "newpw")
+	if newPW != expected {
+		t.Errorf("new pw = %q, want %q", newPW, expected)
+	}
+}
+
+func TestSetPasswordNotFound(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := SetPassword(d, code, "doesnotexist", "pw")
+	if err == nil {
+		t.Fatal("SetPassword nonexistent: expected error, got nil")
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	err := CreateUser(d, code, "alice", "pw", "o")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	err = DeleteUser(d, "alice")
+	if err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	// Verify user is gone
+	_, err = GetUser(d, "alice")
+	if err == nil {
+		t.Fatal("GetUser after delete: expected error, got nil")
+	}
+}
+
+func TestDeleteUserNotFound(t *testing.T) {
+	d := setupTestDB(t)
+
+	err := DeleteUser(d, "doesnotexist")
+	if err == nil {
+		t.Fatal("DeleteUser nonexistent: expected error, got nil")
+	}
+}

--- a/go-libfossil/auth/verify.go
+++ b/go-libfossil/auth/verify.go
@@ -22,6 +22,9 @@ func VerifyLogin(d *db.DB, projectCode string, card *xfer.LoginCard) (User, erro
 	if d == nil {
 		panic("auth.VerifyLogin: d must not be nil")
 	}
+	if projectCode == "" {
+		panic("auth.VerifyLogin: projectCode must not be empty")
+	}
 	if card == nil {
 		panic("auth.VerifyLogin: card must not be nil")
 	}

--- a/go-libfossil/auth/verify.go
+++ b/go-libfossil/auth/verify.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"crypto/sha1"
+	"crypto/subtle"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/xfer"
+)
+
+var ErrAuthFailed = errors.New("authentication failed")
+
+// VerifyLogin validates a login card against the user table.
+// The server does NOT need the raw payload — the nonce is in card.Nonce.
+// Returns the authenticated User on success, or ErrAuthFailed on any failure.
+// Panics if d or card is nil (TigerStyle preconditions).
+func VerifyLogin(d *db.DB, projectCode string, card *xfer.LoginCard) (User, error) {
+	if d == nil {
+		panic("auth.VerifyLogin: d must not be nil")
+	}
+	if card == nil {
+		panic("auth.VerifyLogin: card must not be nil")
+	}
+
+	// 1. Look up user by card.User and retrieve stored password + cexpire
+	var storedPW string
+	var cexpire sql.NullString
+	var u User
+	var info sql.NullString
+	var mtime float64
+
+	err := d.QueryRow(
+		"SELECT uid, login, pw, cap, cexpire, info, mtime FROM user WHERE login=?",
+		card.User,
+	).Scan(&u.UID, &u.Login, &storedPW, &u.Cap, &cexpire, &info, &mtime)
+
+	// 2. If not found → ErrAuthFailed
+	if err != nil {
+		return User{}, ErrAuthFailed
+	}
+
+	if info.Valid {
+		u.Info = info.String
+	}
+
+	// 3. If cexpire is set and in the past → ErrAuthFailed
+	if cexpire.Valid {
+		// Parse cexpire - SQLite may return either "2006-01-02 15:04:05" or ISO 8601 format
+		var expireTime time.Time
+		var err error
+
+		// Try ISO 8601 first (SQLite's preferred format)
+		expireTime, err = time.Parse(time.RFC3339, cexpire.String)
+		if err != nil {
+			// Fall back to space-separated format
+			expireTime, err = time.Parse("2006-01-02 15:04:05", cexpire.String)
+			if err != nil {
+				// If we can't parse the expiry, treat it as expired for safety
+				return User{}, ErrAuthFailed
+			}
+		}
+
+		// Check if expired
+		if time.Now().After(expireTime) {
+			return User{}, ErrAuthFailed
+		}
+
+		u.CExpire = expireTime
+	}
+
+	// 4. Recompute: expected = SHA1(card.Nonce + storedPW)
+	// storedPW is already SHA1(projectCode/login/password) from the user table
+	expected := sha1hex([]byte(card.Nonce + storedPW))
+
+	// 5. Compare using crypto/subtle.ConstantTimeCompare
+	expectedBytes := []byte(expected)
+	signatureBytes := []byte(card.Signature)
+
+	// 6. If mismatch → ErrAuthFailed
+	if subtle.ConstantTimeCompare(expectedBytes, signatureBytes) != 1 {
+		return User{}, ErrAuthFailed
+	}
+
+	// 7. Return User
+	return u, nil
+}
+
+func sha1hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}

--- a/go-libfossil/auth/verify_test.go
+++ b/go-libfossil/auth/verify_test.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/xfer"
+)
+
+// buildLoginCard constructs a LoginCard matching Fossil's protocol.
+// payload is the raw xfer message bytes that the nonce is derived from.
+func buildLoginCard(user, password, projectCode string, payload []byte) *xfer.LoginCard {
+	nonce := sha1Hex(payload)
+	sharedSecret := sha1Hex([]byte(projectCode + "/" + user + "/" + password))
+	signature := sha1Hex([]byte(nonce + sharedSecret))
+	return &xfer.LoginCard{User: user, Nonce: nonce, Signature: signature}
+}
+
+func sha1Hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+func TestVerifyLoginSuccess(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	// Create user with known password
+	err := CreateUser(d, code, "alice", "secret123", "ios")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Build valid login card
+	payload := []byte("push\nigot abc123\n")
+	card := buildLoginCard("alice", "secret123", code, payload)
+
+	// Verify should succeed
+	user, err := VerifyLogin(d, code, card)
+	if err != nil {
+		t.Fatalf("VerifyLogin: expected success, got %v", err)
+	}
+
+	if user.Login != "alice" {
+		t.Errorf("user.Login = %q, want alice", user.Login)
+	}
+	if user.Cap != "ios" {
+		t.Errorf("user.Cap = %q, want ios", user.Cap)
+	}
+}
+
+func TestVerifyLoginWrongPassword(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	// Create user with known password
+	err := CreateUser(d, code, "alice", "secret123", "o")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Build login card with wrong password
+	payload := []byte("push\nigot abc123\n")
+	card := buildLoginCard("alice", "wrongpassword", code, payload)
+
+	// Verify should fail
+	_, err = VerifyLogin(d, code, card)
+	if err != ErrAuthFailed {
+		t.Errorf("VerifyLogin wrong password: got %v, want ErrAuthFailed", err)
+	}
+}
+
+func TestVerifyLoginUnknownUser(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	// Build login card for nonexistent user
+	payload := []byte("push\nigot abc123\n")
+	card := buildLoginCard("doesnotexist", "anypassword", code, payload)
+
+	// Verify should fail
+	_, err := VerifyLogin(d, code, card)
+	if err != ErrAuthFailed {
+		t.Errorf("VerifyLogin unknown user: got %v, want ErrAuthFailed", err)
+	}
+}
+
+func TestVerifyLoginExpired(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	// Create user
+	err := CreateUser(d, code, "alice", "secret123", "o")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Set cexpire to past (2020-01-01)
+	_, err = d.Exec("UPDATE user SET cexpire='2020-01-01 00:00:00' WHERE login='alice'")
+	if err != nil {
+		t.Fatalf("set cexpire: %v", err)
+	}
+
+	// Build valid login card
+	payload := []byte("push\nigot abc123\n")
+	card := buildLoginCard("alice", "secret123", code, payload)
+
+	// Verify should fail due to expiration
+	_, err = VerifyLogin(d, code, card)
+	if err != ErrAuthFailed {
+		t.Errorf("VerifyLogin expired: got %v, want ErrAuthFailed", err)
+	}
+}
+
+func TestVerifyLoginNonExpired(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	// Create user
+	err := CreateUser(d, code, "alice", "secret123", "ios")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Set cexpire to future (2030-01-01)
+	_, err = d.Exec("UPDATE user SET cexpire='2030-01-01 00:00:00' WHERE login='alice'")
+	if err != nil {
+		t.Fatalf("set cexpire: %v", err)
+	}
+
+	// Build valid login card
+	payload := []byte("push\nigot abc123\n")
+	card := buildLoginCard("alice", "secret123", code, payload)
+
+	// Verify should succeed
+	user, err := VerifyLogin(d, code, card)
+	if err != nil {
+		t.Fatalf("VerifyLogin non-expired: expected success, got %v", err)
+	}
+
+	if user.Login != "alice" {
+		t.Errorf("user.Login = %q, want alice", user.Login)
+	}
+}
+
+func TestVerifyLoginNilDB(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("VerifyLogin with nil DB should panic")
+		}
+	}()
+
+	card := &xfer.LoginCard{User: "alice", Nonce: "abc", Signature: "def"}
+	VerifyLogin(nil, "test-code", card)
+}
+
+func TestVerifyLoginNilCard(t *testing.T) {
+	d := setupTestDB(t)
+	code := projectCode(t, d)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("VerifyLogin with nil card should panic")
+		}
+	}()
+
+	VerifyLogin(d, code, nil)
+}

--- a/go-libfossil/db/schema.go
+++ b/go-libfossil/db/schema.go
@@ -211,6 +211,19 @@ func SeedUser(d *DB, login string) error {
 	return err
 }
 
+// SeedNobody inserts a "nobody" user with the given capabilities.
+// This controls anonymous access policy for the repo.
+func SeedNobody(d *DB, caps string) error {
+	if d == nil {
+		panic("db.SeedNobody: d must not be nil")
+	}
+	_, err := d.Exec(
+		"INSERT OR IGNORE INTO user(login, pw, cap, info) VALUES('nobody', '', ?, '')",
+		caps,
+	)
+	return err
+}
+
 func SeedConfig(d *DB, rng simio.Rand) error {
 	if d == nil {
 		panic("db.SeedConfig: d must not be nil")

--- a/go-libfossil/db/schema_test.go
+++ b/go-libfossil/db/schema_test.go
@@ -1,0 +1,34 @@
+package db_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	_ "github.com/dmestas/edgesync/go-libfossil/internal/testdriver"
+)
+
+func TestSeedNobody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	if err := db.CreateRepoSchema(d); err != nil {
+		t.Fatalf("CreateRepoSchema: %v", err)
+	}
+	if err := db.SeedNobody(d, "oi"); err != nil {
+		t.Fatalf("SeedNobody: %v", err)
+	}
+
+	var login, cap string
+	err = d.QueryRow("SELECT login, cap FROM user WHERE login='nobody'").Scan(&login, &cap)
+	if err != nil {
+		t.Fatalf("nobody user not found: %v", err)
+	}
+	if cap != "oi" {
+		t.Errorf("cap = %q, want oi", cap)
+	}
+}

--- a/go-libfossil/repo/repo.go
+++ b/go-libfossil/repo/repo.go
@@ -59,6 +59,14 @@ func CreateWithEnv(path string, user string, env *simio.Env) (*Repo, error) {
 		return nil, fmt.Errorf("repo.CreateWithEnv seed user: %w", err)
 	}
 
+	if err := db.SeedNobody(d, "cghijknorswz"); err != nil {
+		d.Close()
+		if rmErr := env.Storage.Remove(path); rmErr != nil {
+			return nil, fmt.Errorf("repo.CreateWithEnv: %w (cleanup failed: %v)", err, rmErr)
+		}
+		return nil, fmt.Errorf("repo.CreateWithEnv seed nobody: %w", err)
+	}
+
 	if err := db.SeedConfig(d, env.Rand); err != nil {
 		d.Close()
 		if rmErr := env.Storage.Remove(path); rmErr != nil {

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/blob"
 	"github.com/dmestas/edgesync/go-libfossil/content"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
@@ -85,11 +86,56 @@ type handler struct {
 	uvCatalogSent bool // true after sending UV catalog
 	filesSent     int  // files sent in response (for observer)
 	filesRecvd    int  // files received from client (for observer)
+
+	// Auth state
+	user   string // verified username ("nobody" if no login card)
+	caps   string // capability string from user table
+	authed bool   // whether login card was verified
+}
+
+func (h *handler) initAuth() {
+	h.user = "nobody"
+	h.caps = ""
+	h.authed = false
+	var caps string
+	err := h.repo.DB().QueryRow("SELECT cap FROM user WHERE login='nobody'").Scan(&caps)
+	if err == nil {
+		h.caps = caps
+	}
+}
+
+func (h *handler) handleLoginCard(c *xfer.LoginCard) {
+	var projectCode string
+	if err := h.repo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projectCode); err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	u, err := auth.VerifyLogin(h.repo.DB(), projectCode, c)
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{Message: "authentication failed"})
+		return
+	}
+	h.user = u.Login
+	h.caps = u.Cap
+	h.authed = true
 }
 
 func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, error) {
-	// First pass: extract control cards.
+	// Initialize auth state from nobody user.
+	h.initAuth()
+
+	// First pass: resolve login cards before other control cards.
 	for _, card := range req.Cards {
+		if lc, ok := card.(*xfer.LoginCard); ok {
+			h.handleLoginCard(lc)
+		}
+	}
+
+	// Second pass: process other control cards with capability checks.
+	for _, card := range req.Cards {
+		if _, ok := card.(*xfer.LoginCard); ok {
+			continue // Already processed.
+		}
 		h.handleControlCard(card)
 	}
 
@@ -152,7 +198,7 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 func (h *handler) handleControlCard(card xfer.Card) {
 	switch c := card.(type) {
 	case *xfer.LoginCard:
-		_ = c // Accept all logins. Future: verify credentials.
+		return // Already processed in first pass.
 	case *xfer.PragmaCard:
 		if c.Name == "uv-hash" && len(c.Values) >= 1 {
 			if err := h.handlePragmaUVHash(c.Values[0]); err != nil {
@@ -161,13 +207,30 @@ func (h *handler) handleControlCard(card xfer.Card) {
 				})
 			}
 		}
-		// Acknowledge client-version, ignore other unknown pragmas.
 	case *xfer.PushCard:
-		h.pushOK = true
+		if auth.CanPush(h.caps) {
+			h.pushOK = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "push denied: insufficient capabilities",
+			})
+		}
 	case *xfer.PullCard:
-		h.pullOK = true
+		if auth.CanPull(h.caps) {
+			h.pullOK = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "pull denied: insufficient capabilities",
+			})
+		}
 	case *xfer.CloneCard:
-		h.cloneMode = true
+		if auth.CanClone(h.caps) {
+			h.cloneMode = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "clone denied: insufficient capabilities",
+			})
+		}
 	case *xfer.CloneSeqNoCard:
 		h.cloneSeq = c.SeqNo
 	}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -2,10 +2,14 @@ package sync
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"testing"
 
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/db"
 	"github.com/dmestas/edgesync/go-libfossil/hash"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/xfer"
@@ -30,6 +34,27 @@ func storeTestBlob(t *testing.T, r *repo.Repo, data []byte) string {
 		t.Fatalf("storeReceivedFile: %v", err)
 	}
 	return uuid
+}
+
+func testProjectCode(t *testing.T, d *db.DB) string {
+	t.Helper()
+	var code string
+	if err := d.QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&code); err != nil {
+		t.Fatalf("project-code: %v", err)
+	}
+	return code
+}
+
+func buildTestLoginCard(user, password, projectCode string, payload []byte) *xfer.LoginCard {
+	nonce := testSHA1Hex(payload)
+	shared := testSHA1Hex([]byte(projectCode + "/" + user + "/" + password))
+	sig := testSHA1Hex([]byte(nonce + shared))
+	return &xfer.LoginCard{User: user, Nonce: nonce, Signature: sig}
+}
+
+func testSHA1Hex(data []byte) string {
+	h := sha1.Sum(data)
+	return hex.EncodeToString(h[:])
 }
 
 
@@ -324,9 +349,8 @@ func TestHandleLoginAndPragma(t *testing.T) {
 	r := setupSyncTestRepo(t)
 	storeTestBlob(t, r, []byte("login pragma test"))
 
-	// Login + pragma should be accepted without error
+	// Pragma cards should be accepted (no login needed for pragma processing)
 	req := &xfer.Message{Cards: []xfer.Card{
-		&xfer.LoginCard{User: "test", Nonce: "abc", Signature: "def"},
 		&xfer.PragmaCard{Name: "client-version", Values: []string{"22800"}},
 		&xfer.PragmaCard{Name: "unknown-pragma", Values: []string{"ignored"}},
 		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
@@ -341,7 +365,7 @@ func TestHandleLoginAndPragma(t *testing.T) {
 	}
 	igots := findCards[*xfer.IGotCard](resp)
 	if len(igots) == 0 {
-		t.Fatal("expected igot cards after login+pragma+pull")
+		t.Fatal("expected igot cards after pragma+pull")
 	}
 }
 
@@ -508,5 +532,113 @@ func TestHandlerNoPushCardOnPull(t *testing.T) {
 	pushCards := findCards[*xfer.PushCard](resp)
 	if len(pushCards) != 0 {
 		t.Fatalf("PushCard count = %d, want 0 (push is clone-only)", len(pushCards))
+	}
+}
+
+func TestHandlePushRequiresAuth(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	// Delete nobody so anonymous push is rejected
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+
+	data := []byte("auth test")
+	uuid := hash.SHA1(data)
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unauthorized push")
+	}
+	if _, ok := blob.Exists(r.DB(), uuid); ok {
+		t.Fatal("blob should not be stored without push capability")
+	}
+}
+
+func TestHandlePullRequiresAuth(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	storeTestBlob(t, r, []byte("pull auth test"))
+	// Delete nobody so anonymous pull is rejected
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unauthorized pull")
+	}
+	igots := findCards[*xfer.IGotCard](resp)
+	if len(igots) > 0 {
+		t.Fatal("should not emit igots without pull capability")
+	}
+}
+
+func TestHandleAuthenticatedPush(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	pc := testProjectCode(t, r.DB())
+	// Delete nobody, create a user with push caps
+	r.DB().Exec("DELETE FROM user WHERE login='nobody'")
+	auth.CreateUser(r.DB(), pc, "pusher", "secret", "oi")
+
+	data := []byte("authed push")
+	uuid := hash.SHA1(data)
+
+	// Build a valid login card — nonce is SHA1 of the non-login card payload
+	loginCard := buildTestLoginCard("pusher", "secret", pc, []byte("dummy"))
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		loginCard,
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+	errs := findCards[*xfer.ErrorCard](resp)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected error: %s", errs[0].Message)
+	}
+	if _, ok := blob.Exists(r.DB(), uuid); !ok {
+		t.Fatal("authenticated push should store blob")
+	}
+}
+
+func TestHandleNobodyPullOnly(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	storeTestBlob(t, r, []byte("nobody test"))
+	// Set nobody to pull-only
+	r.DB().Exec("UPDATE user SET cap='o' WHERE login='nobody'")
+
+	// Pull should work
+	pullReq := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	pullResp, _ := HandleSync(context.Background(), r, pullReq)
+	igots := findCards[*xfer.IGotCard](pullResp)
+	if len(igots) == 0 {
+		t.Fatal("nobody with 'o' cap should allow pull")
+	}
+
+	// Push should fail
+	data := []byte("nobody push attempt")
+	uuid := hash.SHA1(data)
+	pushReq := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "test", ProjectCode: "test"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	}}
+	pushResp, _ := HandleSync(context.Background(), r, pushReq)
+	errs := findCards[*xfer.ErrorCard](pushResp)
+	if len(errs) == 0 {
+		t.Fatal("nobody with 'o' cap should reject push")
 	}
 }

--- a/go-libfossil/sync/handler_uv.go
+++ b/go-libfossil/sync/handler_uv.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"fmt"
 
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/hash"
 	"github.com/dmestas/edgesync/go-libfossil/uv"
 	"github.com/dmestas/edgesync/go-libfossil/xfer"
@@ -123,6 +124,12 @@ func (h *handler) sendUVFile(name string) error {
 func (h *handler) handleUVFile(c *xfer.UVFileCard) error {
 	if c == nil {
 		panic("handler.handleUVFile: c must not be nil")
+	}
+	if !auth.CanPushUV(h.caps) {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("uvfile %s denied: insufficient capabilities", c.Name),
+		})
+		return nil
 	}
 	if !h.pushOK {
 		h.resp = append(h.resp, &xfer.ErrorCard{


### PR DESCRIPTION
## Summary

- New `go-libfossil/auth/` package: user CRUD, login card verification (constant-time), capability checking, invite token encode/decode
- `HandleSync` now verifies login cards and enforces capability-based access control (push=`i`, pull=`o`, clone=`g`, UV=`z`)
- Two-pass card processing ensures login is resolved before capability checks
- `repo.Create` seeds a default `nobody` user with full caps (`cghijknorswz`) for backwards compatibility
- CLI: `edgesync repo user {add,list,update,rm,passwd}` and `edgesync repo invite` with `clone --invite` token flow

Closes CDG-131, CDG-155, CDG-115

## Test plan

- [x] 26 auth package tests (capability checks, CRUD, login verification with expiry, invite token round-trip)
- [x] 4 new handler auth tests (push/pull requires auth, authenticated push, nobody pull-only)
- [x] All existing sync tests pass (nobody has full caps)
- [x] DST tests pass
- [x] Pre-commit hook passes on all 7 commits
- [x] Binary builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository user management (add/list/update/remove/password)
  * Invite token creation and clone support via invite tokens
  * Capability-based authorization for push/pull/clone and UV writes
  * Repos now include a default permissive "nobody" user on create

* **Tests**
  * Expanded unit/integration/DST tests covering auth, invites, user lifecycle, and handler authorization

* **Documentation**
  * Added design and implementation plans for auth, capabilities, and remote schema sync
<!-- end of auto-generated comment: release notes by coderabbit.ai -->