### PR TITLE
fix(auth): CanPushUV capability letter z → y

### DIFF
--- a/dst/scenario_test.go
+++ b/dst/scenario_test.go
@@ -1365,7 +1365,7 @@ func TestScenarioAuthBuggifyBadNonce(t *testing.T) {
 		// Create a sync user in the master repo.
 		masterRepo.DB().Exec(
 			"INSERT OR IGNORE INTO user(login, pw, cap) VALUES(?, ?, ?)",
-			string(id), hashPW(pc, string(id), "leafpass"), "cghijknorswz",
+			string(id), hashPW(pc, string(id), "leafpass"), "cghijknorswy",
 		)
 	}
 

--- a/go-libfossil/auth/auth.go
+++ b/go-libfossil/auth/auth.go
@@ -21,4 +21,4 @@ func HasCapability(caps string, required byte) bool {
 func CanPush(caps string) bool   { return HasCapability(caps, 'i') }
 func CanPull(caps string) bool   { return HasCapability(caps, 'o') }
 func CanClone(caps string) bool  { return HasCapability(caps, 'g') }
-func CanPushUV(caps string) bool { return HasCapability(caps, 'z') }
+func CanPushUV(caps string) bool { return HasCapability(caps, 'y') }

--- a/go-libfossil/auth/auth_test.go
+++ b/go-libfossil/auth/auth_test.go
@@ -12,8 +12,8 @@ func TestHasCapability(t *testing.T) {
 		{"oi", 'i', true},
 		{"oi", 'g', false},
 		{"", 'o', false},
-		{"cghijknorswz", 's', true},
-		{"cghijknorswz", 'a', false},
+		{"cghijknorswy", 's', true},
+		{"cghijknorswy", 'a', false},
 	}
 	for _, tt := range tests {
 		got := HasCapability(tt.caps, tt.required)
@@ -39,6 +39,6 @@ func TestCanClone(t *testing.T) {
 }
 
 func TestCanPushUV(t *testing.T) {
-	if !CanPushUV("z") { t.Error("CanPushUV(z) should be true") }
+	if !CanPushUV("y") { t.Error("CanPushUV(y) should be true") }
 	if CanPushUV("oi") { t.Error("CanPushUV(oi) should be false") }
 }

--- a/go-libfossil/repo/repo.go
+++ b/go-libfossil/repo/repo.go
@@ -59,7 +59,7 @@ func CreateWithEnv(path string, user string, env *simio.Env) (*Repo, error) {
 		return nil, fmt.Errorf("repo.CreateWithEnv seed user: %w", err)
 	}
 
-	if err := db.SeedNobody(d, "cghijknorswz"); err != nil {
+	if err := db.SeedNobody(d, "cghijknorswy"); err != nil {
 		d.Close()
 		if rmErr := env.Storage.Remove(path); rmErr != nil {
 			return nil, fmt.Errorf("repo.CreateWithEnv: %w (cleanup failed: %v)", err, rmErr)

--- a/go-libfossil/sync/integration_test.go
+++ b/go-libfossil/sync/integration_test.go
@@ -158,8 +158,8 @@ func TestIntegrationPushToFossilServer(t *testing.T) {
 
 	// 3. Create nobody user and grant write capabilities for testing
 	// (Go-created repos don't have the standard nobody/anonymous users that fossil new creates)
-	exec.Command(bin, "user", "new", "nobody", "", "cghijknorswz", "-R", remotePath).Run()
-	exec.Command(bin, "user", "capabilities", "nobody", "cghijknorswz", "-R", remotePath).Run()
+	exec.Command(bin, "user", "new", "nobody", "", "cghijknorswy", "-R", remotePath).Run()
+	exec.Command(bin, "user", "capabilities", "nobody", "cghijknorswy", "-R", remotePath).Run()
 
 	// 4. Read project-code and server-code from the remote (they match local after clone)
 	projCode := getProjectCode(t, remotePath)

--- a/sim/equivalence_test.go
+++ b/sim/equivalence_test.go
@@ -257,8 +257,8 @@ func fossilInit(t *testing.T, dir, name string) string {
 	}
 	// Grant nobody user capabilities for unauthenticated sync.
 	// fossil init may already create the nobody user, so "user new" can fail — that's fine.
-	exec.Command("fossil", "user", "new", "nobody", "", "cghijknorswz", "-R", path).Run()
-	if out, err := exec.Command("fossil", "user", "capabilities", "nobody", "cghijknorswz", "-R", path).CombinedOutput(); err != nil {
+	exec.Command("fossil", "user", "new", "nobody", "", "cghijknorswy", "-R", path).Run()
+	if out, err := exec.Command("fossil", "user", "capabilities", "nobody", "cghijknorswy", "-R", path).CombinedOutput(); err != nil {
 		t.Fatalf("fossil user capabilities nobody: %v\n%s", err, out)
 	}
 	return path

--- a/sim/equivalence_test.go
+++ b/sim/equivalence_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/manifest"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
@@ -424,6 +425,65 @@ func testFossilToLeaf(t *testing.T, commits []map[string]string, messages []stri
 	// 4. fossil open the leaf repo + verify files.
 	leafWorkDir := fossilCheckout(t, leafPath)
 	assertFiles(t, leafWorkDir, expected)
+}
+
+// TestCapabilityLetterCrossCheck creates a repo with `fossil new`, reads the
+// default nobody user's capabilities, and verifies go-libfossil's auth
+// functions return the correct results. This catches capability letter
+// mismatches between Fossil and go-libfossil (e.g., using 'z' instead of 'y'
+// for WrUnver).
+func TestCapabilityLetterCrossCheck(t *testing.T) {
+	requireFossil(t)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "caps.fossil")
+	runFossil(t, "new", repoPath)
+
+	// Read the default nobody user caps that `fossil new` creates.
+	r, err := repo.Open(repoPath)
+	if err != nil {
+		t.Fatalf("repo.Open: %v", err)
+	}
+	defer r.Close()
+
+	var fossilCaps string
+	if err := r.DB().QueryRow("SELECT cap FROM user WHERE login='nobody'").Scan(&fossilCaps); err != nil {
+		t.Fatalf("read nobody caps: %v", err)
+	}
+	t.Logf("Fossil nobody caps: %q", fossilCaps)
+
+	// Fossil's default nobody has 'o' (pull) and 'g' (clone) but NOT 'i'
+	// (push) and NOT 'y' (WrUnver). Verify our functions agree.
+	if !auth.CanPull(fossilCaps) {
+		t.Error("CanPull should be true for Fossil's default nobody")
+	}
+	if !auth.CanClone(fossilCaps) {
+		t.Error("CanClone should be true for Fossil's default nobody")
+	}
+	if auth.CanPush(fossilCaps) {
+		t.Error("CanPush should be false for Fossil's default nobody")
+	}
+	if auth.CanPushUV(fossilCaps) {
+		t.Error("CanPushUV should be false for Fossil's default nobody")
+	}
+
+	// Now grant 'y' (WrUnver) and verify CanPushUV recognizes it.
+	newCaps := fossilCaps + "y"
+	if _, err := r.DB().Exec("UPDATE user SET cap=? WHERE login='nobody'", newCaps); err != nil {
+		t.Fatalf("update caps: %v", err)
+	}
+	if !auth.CanPushUV(newCaps) {
+		t.Error("CanPushUV should be true after granting 'y'")
+	}
+
+	// Verify that 'z' (Zip) does NOT satisfy CanPushUV — this is the
+	// exact bug that was missed: 'z' is Zip download, not WrUnver.
+	if auth.CanPushUV("oiz") {
+		t.Error("CanPushUV must not accept 'z' — that's Zip, not WrUnver")
+	}
 }
 
 func TestLeafToLeaf(t *testing.T) {

--- a/sim/uv_test.go
+++ b/sim/uv_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
 	"github.com/dmestas/edgesync/go-libfossil/sync"
 	"github.com/dmestas/edgesync/go-libfossil/uv"
-	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
 )
 
 // TestSimUVSyncPull verifies that UV files added via fossil CLI can be
@@ -353,6 +353,111 @@ func TestSimUVRoundTrip(t *testing.T) {
 	}
 
 	t.Log("PASS: UV round-trip pull→modify→push via HTTP")
+}
+
+// TestSimUVSyncAgainstFossilServe pushes UV files from go-libfossil to a real
+// `fossil serve` instance. This catches capability letter mismatches: if
+// go-libfossil checked 'z' instead of 'y' for CanPushUV, the server-side
+// handler would gate on the wrong letter when using Fossil-created user tables.
+//
+// The test creates a Fossil repo with nobody granted 'y' (WrUnver), serves it,
+// then uses go-libfossil to push UV files and verifies they arrive.
+func TestSimUVSyncAgainstFossilServe(t *testing.T) {
+	if !hasFossil() {
+		t.Skip("fossil binary not found in PATH")
+	}
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+
+	// 1. Create Fossil repo and grant nobody UV push capability ('y').
+	repoPath := filepath.Join(dir, "fossil-server.fossil")
+	runFossil(t, "new", repoPath)
+	// Grant nobody: pull + push + UV push (o + i + y).
+	exec.Command("fossil", "user", "capabilities", "nobody", "oiy", "-R", repoPath).Run()
+
+	// Seed a UV file on the server so we can test pull too.
+	uvFile := filepath.Join(dir, "server-doc.txt")
+	os.WriteFile(uvFile, []byte("from fossil"), 0644)
+	runFossil(t, "uv", "add", uvFile, "--as", "server-doc.txt", "-R", repoPath)
+
+	// 2. Start fossil serve.
+	serverURL := startFossilServe(t, repoPath)
+
+	// 3. Create a go-libfossil repo and sync UV files.
+	clientPath := filepath.Join(dir, "leaf-client.fossil")
+	clientRepo, err := repo.Create(clientPath, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("repo.Create: %v", err)
+	}
+	defer clientRepo.Close()
+	uv.EnsureSchema(clientRepo.DB())
+
+	// Read project/server codes from the Fossil repo.
+	fossilRepo, err := repo.Open(repoPath)
+	if err != nil {
+		t.Fatalf("open fossil repo for codes: %v", err)
+	}
+	var projCode, srvCode string
+	fossilRepo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+	fossilRepo.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&srvCode)
+	fossilRepo.Close()
+
+	// Set matching project code on client.
+	clientRepo.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	transport := &sync.HTTPTransport{URL: serverURL}
+
+	// Pull UV files from fossil serve.
+	result, err := sync.Sync(ctx, clientRepo, transport, sync.SyncOpts{
+		Pull: true, UV: true,
+		ProjectCode: projCode, ServerCode: srvCode,
+	})
+	if err != nil {
+		t.Fatalf("Sync pull: %v", err)
+	}
+	t.Logf("Pull sync: files_recv=%d", result.FilesRecvd)
+
+	// Verify the UV file arrived.
+	content, _, _, err := uv.Read(clientRepo.DB(), "server-doc.txt")
+	if err != nil {
+		t.Fatalf("uv.Read after pull: %v", err)
+	}
+	if string(content) != "from fossil" {
+		t.Errorf("pulled UV content = %q, want %q", content, "from fossil")
+	}
+
+	// Now push a UV file back to fossil serve.
+	uv.Write(clientRepo.DB(), "leaf-doc.txt", []byte("from leaf"), time.Now().Unix())
+	_, err = sync.Sync(ctx, clientRepo, transport, sync.SyncOpts{
+		Push: true, Pull: true, UV: true,
+		ProjectCode: projCode, ServerCode: srvCode,
+	})
+	if err != nil {
+		t.Fatalf("Sync push: %v", err)
+	}
+
+	// Verify by reading the fossil repo directly.
+	fossilRepo2, err := repo.Open(repoPath)
+	if err != nil {
+		t.Fatalf("reopen fossil repo: %v", err)
+	}
+	defer fossilRepo2.Close()
+
+	pushed, _, _, err := uv.Read(fossilRepo2.DB(), "leaf-doc.txt")
+	if err != nil {
+		t.Fatalf("uv.Read pushed file: %v", err)
+	}
+	if string(pushed) != "from leaf" {
+		t.Errorf("pushed UV content = %q, want %q", pushed, "from leaf")
+	}
+
+	t.Log("PASS: UV sync (pull + push) against real fossil serve")
 }
 
 // runFossil runs a fossil command and fails the test on error.


### PR DESCRIPTION
## Summary
- `CanPushUV` was checking for `'z'` (Zip download in Fossil) instead of `'y'` (WrUnver). This meant go-libfossil's UV push gate was keyed to the wrong capability letter, which would fail when interoperating with a real Fossil user table.
- Updated all 6 files: auth check, nobody seed caps, DST user caps, sim/integration Fossil CLI caps.

## Why testing didn't catch it
The bug was **self-consistent**: `CanPushUV` checked `'z'`, and every test seeded nobody with `cghijknorswz` (which includes `z`). So the check always passed. No test ever verified go-libfossil's capability letters against Fossil's actual capability semantics.

## Test plan
- [x] Pre-commit hook passes (unit + DST + sim serve)
- [ ] Add sim/ equivalence test that reads caps from a `fossil new`-created repo and verifies go-libfossil auth functions agree with Fossil's capability semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)