### PR TITLE
feat: exclude shunned/private blobs from sync (CDG-166)

### DIFF
--- a/go-libfossil/content/cluster.go
+++ b/go-libfossil/content/cluster.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"fmt"
+	"strings"
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/blob"
@@ -18,39 +19,49 @@ const (
 	ClusterMaxSize = 800
 )
 
-// GenerateClusters creates cluster artifacts for unclustered, non-phantom blobs.
-// Returns the number of clusters created.
+// GenerateClusters creates cluster artifacts for unclustered blobs that are
+// not phantoms, shunned, or private. Returns the number of clusters created.
 func GenerateClusters(q db.Querier) (int, error) {
 	if q == nil {
 		panic("content.GenerateClusters: q must not be nil")
 	}
 
-	// Count non-phantom unclustered entries.
-	var count int
-	err := q.QueryRow(`
-		SELECT count(*) FROM unclustered u
-		WHERE NOT EXISTS (SELECT 1 FROM phantom WHERE rid = u.rid)
-		AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = (SELECT uuid FROM blob WHERE rid = u.rid))
-		AND NOT EXISTS (SELECT 1 FROM private WHERE rid = u.rid)
-	`).Scan(&count)
+	uuids, err := clusterableUUIDs(q)
 	if err != nil {
-		return 0, fmt.Errorf("content.GenerateClusters count: %w", err)
+		return 0, err
 	}
-	if count < ClusterThreshold {
+	if len(uuids) < ClusterThreshold {
 		return 0, nil
 	}
 
-	// Query UUIDs sorted.
+	clusterRIDs, err := buildClusters(q, uuids)
+	if err != nil {
+		return len(clusterRIDs), err
+	}
+
+	if err := cleanupUnclustered(q, clusterRIDs); err != nil {
+		return len(clusterRIDs), err
+	}
+	return len(clusterRIDs), nil
+}
+
+// clusterableUUIDs returns sorted UUIDs of unclustered blobs that are not
+// phantoms, shunned, or private.
+func clusterableUUIDs(q db.Querier) ([]string, error) {
+	if q == nil {
+		panic("content.clusterableUUIDs: q must not be nil")
+	}
+
 	rows, err := q.Query(`
 		SELECT b.uuid FROM unclustered u
 		JOIN blob b ON b.rid = u.rid
 		WHERE NOT EXISTS (SELECT 1 FROM phantom WHERE rid = u.rid)
-		AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = b.uuid)
-		AND NOT EXISTS (SELECT 1 FROM private WHERE rid = u.rid)
+		  AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = b.uuid)
+		  AND NOT EXISTS (SELECT 1 FROM private WHERE rid = u.rid)
 		ORDER BY b.uuid
 	`)
 	if err != nil {
-		return 0, fmt.Errorf("content.GenerateClusters query: %w", err)
+		return nil, fmt.Errorf("content.clusterableUUIDs query: %w", err)
 	}
 	defer rows.Close()
 
@@ -58,15 +69,23 @@ func GenerateClusters(q db.Querier) (int, error) {
 	for rows.Next() {
 		var uuid string
 		if err := rows.Scan(&uuid); err != nil {
-			return 0, fmt.Errorf("content.GenerateClusters scan: %w", err)
+			return nil, fmt.Errorf("content.clusterableUUIDs scan: %w", err)
 		}
 		uuids = append(uuids, uuid)
 	}
 	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("content.GenerateClusters rows: %w", err)
+		return nil, fmt.Errorf("content.clusterableUUIDs rows: %w", err)
+	}
+	return uuids, nil
+}
+
+// buildClusters batches UUIDs into cluster artifacts, stores them, and applies
+// the cluster tag. Returns the RIDs of created cluster blobs.
+func buildClusters(q db.Querier, uuids []string) ([]libfossil.FslID, error) {
+	if q == nil {
+		panic("content.buildClusters: q must not be nil")
 	}
 
-	// Batch into clusters.
 	var clusterRIDs []libfossil.FslID
 	for len(uuids) > 0 {
 		batchSize := ClusterMaxSize
@@ -82,53 +101,59 @@ func GenerateClusters(q db.Querier) (int, error) {
 		batch := uuids[:batchSize]
 		uuids = uuids[batchSize:]
 
-		// Build cluster artifact.
 		d := &deck.Deck{Type: deck.Cluster, M: batch}
 		data, err := d.Marshal()
 		if err != nil {
-			return len(clusterRIDs), fmt.Errorf("content.GenerateClusters marshal: %w", err)
+			return clusterRIDs, fmt.Errorf("content.buildClusters marshal: %w", err)
 		}
 
 		rid, _, err := blob.Store(q, data)
 		if err != nil {
-			return len(clusterRIDs), fmt.Errorf("content.GenerateClusters store: %w", err)
+			return clusterRIDs, fmt.Errorf("content.buildClusters store: %w", err)
 		}
 
 		// Apply cluster singleton tag (tagid=7, tagtype=1).
-		// This is the same logic as manifest.CrosslinkCluster but inlined to
-		// avoid an import cycle (content -> manifest -> content).
-		// We skip the M-card UUID resolution because all UUIDs are known to
-		// exist — we just queried them from the blob table.
+		// Inlined to avoid import cycle (content -> manifest -> content).
 		if _, err := q.Exec(
 			"INSERT OR REPLACE INTO tagxref(tagid, tagtype, srcid, origid, value, mtime, rid) VALUES(7, 1, ?, ?, NULL, 0, ?)",
 			rid, rid, rid,
 		); err != nil {
-			return len(clusterRIDs), fmt.Errorf("content.GenerateClusters tag: %w", err)
+			return clusterRIDs, fmt.Errorf("content.buildClusters tag: %w", err)
 		}
 
 		clusterRIDs = append(clusterRIDs, rid)
 	}
+	return clusterRIDs, nil
+}
 
-	// Clean up unclustered: remove all non-phantom entries except cluster RIDs.
-	// Cluster blobs themselves stay in unclustered until a future clustering pass.
-	if len(clusterRIDs) > 0 {
-		placeholders := ""
-		args := make([]any, len(clusterRIDs))
-		for i, rid := range clusterRIDs {
-			if i > 0 {
-				placeholders += ","
-			}
-			placeholders += "?"
-			args[i] = rid
-		}
-		query := fmt.Sprintf(
-			"DELETE FROM unclustered WHERE rid NOT IN (%s) AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = unclustered.rid) AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = (SELECT uuid FROM blob WHERE rid = unclustered.rid)) AND NOT EXISTS (SELECT 1 FROM private WHERE rid = unclustered.rid)",
-			placeholders,
-		)
-		if _, err := q.Exec(query, args...); err != nil {
-			return len(clusterRIDs), fmt.Errorf("content.GenerateClusters cleanup: %w", err)
-		}
+// cleanupUnclustered removes non-phantom, non-shunned, non-private entries
+// from the unclustered table, preserving only the newly created cluster blobs.
+func cleanupUnclustered(q db.Querier, clusterRIDs []libfossil.FslID) error {
+	if q == nil {
+		panic("content.cleanupUnclustered: q must not be nil")
+	}
+	if len(clusterRIDs) == 0 {
+		return nil
 	}
 
-	return len(clusterRIDs), nil
+	placeholders := make([]string, len(clusterRIDs))
+	args := make([]any, len(clusterRIDs))
+	for i, rid := range clusterRIDs {
+		placeholders[i] = "?"
+		args[i] = rid
+	}
+
+	query := fmt.Sprintf(`
+		DELETE FROM unclustered
+		WHERE rid NOT IN (%s)
+		  AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = unclustered.rid)
+		  AND NOT EXISTS (SELECT 1 FROM shun
+		      WHERE uuid = (SELECT uuid FROM blob WHERE rid = unclustered.rid))
+		  AND NOT EXISTS (SELECT 1 FROM private WHERE rid = unclustered.rid)`,
+		strings.Join(placeholders, ","),
+	)
+	if _, err := q.Exec(query, args...); err != nil {
+		return fmt.Errorf("content.cleanupUnclustered: %w", err)
+	}
+	return nil
 }

--- a/go-libfossil/content/cluster.go
+++ b/go-libfossil/content/cluster.go
@@ -30,6 +30,8 @@ func GenerateClusters(q db.Querier) (int, error) {
 	err := q.QueryRow(`
 		SELECT count(*) FROM unclustered u
 		WHERE NOT EXISTS (SELECT 1 FROM phantom WHERE rid = u.rid)
+		AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = (SELECT uuid FROM blob WHERE rid = u.rid))
+		AND NOT EXISTS (SELECT 1 FROM private WHERE rid = u.rid)
 	`).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("content.GenerateClusters count: %w", err)
@@ -43,6 +45,8 @@ func GenerateClusters(q db.Querier) (int, error) {
 		SELECT b.uuid FROM unclustered u
 		JOIN blob b ON b.rid = u.rid
 		WHERE NOT EXISTS (SELECT 1 FROM phantom WHERE rid = u.rid)
+		AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = b.uuid)
+		AND NOT EXISTS (SELECT 1 FROM private WHERE rid = u.rid)
 		ORDER BY b.uuid
 	`)
 	if err != nil {
@@ -118,7 +122,7 @@ func GenerateClusters(q db.Querier) (int, error) {
 			args[i] = rid
 		}
 		query := fmt.Sprintf(
-			"DELETE FROM unclustered WHERE rid NOT IN (%s) AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = unclustered.rid)",
+			"DELETE FROM unclustered WHERE rid NOT IN (%s) AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = unclustered.rid) AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = (SELECT uuid FROM blob WHERE rid = unclustered.rid)) AND NOT EXISTS (SELECT 1 FROM private WHERE rid = unclustered.rid)",
 			placeholders,
 		)
 		if _, err := q.Exec(query, args...); err != nil {

--- a/go-libfossil/content/cluster_test.go
+++ b/go-libfossil/content/cluster_test.go
@@ -183,6 +183,67 @@ func TestGenerateClusters_ShunnedExcluded(t *testing.T) {
 	}
 }
 
+func TestGenerateClusters_PrivateExcluded(t *testing.T) {
+	d := setupTestDB(t)
+
+	var rids []libfossil.FslID
+	for i := 0; i < 100; i++ {
+		rid, _, err := blob.Store(d, []byte(fmt.Sprintf("blob-%04d-content-padding", i)))
+		if err != nil {
+			t.Fatalf("Store %d: %v", i, err)
+		}
+		rids = append(rids, rid)
+	}
+
+	for _, rid := range rids[90:] {
+		if _, err := d.Exec("INSERT INTO private(rid) VALUES(?)", rid); err != nil {
+			t.Fatalf("private: %v", err)
+		}
+	}
+
+	n, err := GenerateClusters(d)
+	if err != nil {
+		t.Fatalf("GenerateClusters: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("clusters = %d, want 0 (90 non-private < 100 threshold)", n)
+	}
+}
+
+func TestGenerateClusters_PrivateStayUnclustered(t *testing.T) {
+	d := setupTestDB(t)
+
+	var privateRids []libfossil.FslID
+	for i := 0; i < 110; i++ {
+		rid, _, err := blob.Store(d, []byte(fmt.Sprintf("blob-%05d-content-padding-extra", i)))
+		if err != nil {
+			t.Fatalf("Store %d: %v", i, err)
+		}
+		if i >= 100 {
+			if _, err := d.Exec("INSERT INTO private(rid) VALUES(?)", rid); err != nil {
+				t.Fatalf("private: %v", err)
+			}
+			privateRids = append(privateRids, rid)
+		}
+	}
+
+	n, err := GenerateClusters(d)
+	if err != nil {
+		t.Fatalf("GenerateClusters: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("clusters = %d, want 1", n)
+	}
+
+	for _, rid := range privateRids {
+		var count int
+		d.QueryRow("SELECT count(*) FROM unclustered WHERE rid=?", rid).Scan(&count)
+		if count != 1 {
+			t.Fatalf("private rid=%d missing from unclustered", rid)
+		}
+	}
+}
+
 func TestGenerateClusters_ValidArtifactFormat(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/go-libfossil/content/cluster_test.go
+++ b/go-libfossil/content/cluster_test.go
@@ -156,6 +156,33 @@ func TestGenerateClusters_PhantomsExcluded(t *testing.T) {
 	}
 }
 
+func TestGenerateClusters_ShunnedExcluded(t *testing.T) {
+	d := setupTestDB(t)
+
+	// Store 100 real blobs (at threshold).
+	for i := 0; i < 100; i++ {
+		_, uuid, err := blob.Store(d, []byte(fmt.Sprintf("blob-%04d-content-padding", i)))
+		if err != nil {
+			t.Fatalf("Store %d: %v", i, err)
+		}
+		// Shun the last 10 blobs.
+		if i >= 90 {
+			if _, err := d.Exec("INSERT INTO shun(uuid, mtime) VALUES(?, 0)", uuid); err != nil {
+				t.Fatalf("shun %d: %v", i, err)
+			}
+		}
+	}
+
+	// 90 non-shunned blobs < 100 threshold -> no clusters.
+	n, err := GenerateClusters(d)
+	if err != nil {
+		t.Fatalf("GenerateClusters: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("clusters = %d, want 0 (90 non-shunned < 100 threshold)", n)
+	}
+}
+
 func TestGenerateClusters_ValidArtifactFormat(t *testing.T) {
 	d := setupTestDB(t)
 

--- a/go-libfossil/content/cluster_test.go
+++ b/go-libfossil/content/cluster_test.go
@@ -237,7 +237,9 @@ func TestGenerateClusters_PrivateStayUnclustered(t *testing.T) {
 
 	for _, rid := range privateRids {
 		var count int
-		d.QueryRow("SELECT count(*) FROM unclustered WHERE rid=?", rid).Scan(&count)
+		if err := d.QueryRow("SELECT count(*) FROM unclustered WHERE rid=?", rid).Scan(&count); err != nil {
+			t.Fatalf("query unclustered rid=%d: %v", rid, err)
+		}
 		if count != 1 {
 			t.Fatalf("private rid=%d missing from unclustered", rid)
 		}

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -189,6 +189,8 @@ func (s *session) sendAllClusters() ([]xfer.Card, error) {
 		WHERE tx.tagid=7
 		AND NOT EXISTS(SELECT 1 FROM unclustered WHERE rid=b.rid)
 		AND NOT EXISTS(SELECT 1 FROM phantom WHERE rid=b.rid)
+		AND NOT EXISTS(SELECT 1 FROM shun WHERE uuid=b.uuid)
+		AND NOT EXISTS(SELECT 1 FROM private WHERE rid=b.rid)
 		AND b.size >= 0`,
 	)
 	if err != nil {

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -157,7 +157,9 @@ func (s *session) sendUnclustered() ([]xfer.Card, error) {
 	rows, err := s.repo.DB().Query(`
 		SELECT b.uuid FROM unclustered u JOIN blob b ON b.rid=u.rid
 		WHERE b.size >= 0
-		AND NOT EXISTS(SELECT 1 FROM phantom WHERE rid=u.rid)`,
+		AND NOT EXISTS(SELECT 1 FROM phantom WHERE rid=u.rid)
+		AND NOT EXISTS(SELECT 1 FROM shun WHERE uuid=b.uuid)
+		AND NOT EXISTS(SELECT 1 FROM private WHERE rid=u.rid)`,
 	)
 	if err != nil {
 		return nil, err

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -417,6 +417,8 @@ func (h *handler) sendAllClusters() error {
 		WHERE tx.tagid = 7
 		  AND NOT EXISTS (SELECT 1 FROM unclustered WHERE rid = b.rid)
 		  AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = b.rid)
+		  AND NOT EXISTS (SELECT 1 FROM shun WHERE uuid = b.uuid)
+		  AND NOT EXISTS (SELECT 1 FROM private WHERE rid = b.rid)
 		  AND b.size >= 0
 	`)
 	if err != nil {

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -375,8 +375,10 @@ func (h *handler) emitIGots() error {
 	// Emit igot for all non-phantom blobs so the client can discover
 	// everything the server has. Cluster generation is a client-side
 	// optimization for push; the server always advertises all blobs.
-	rows, err := h.repo.DB().Query(
-		"SELECT uuid FROM blob WHERE size >= 0",
+	rows, err := h.repo.DB().Query(`
+		SELECT uuid FROM blob WHERE size >= 0
+		AND NOT EXISTS(SELECT 1 FROM shun WHERE uuid=blob.uuid)
+		AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)`,
 	)
 	if err != nil {
 		return fmt.Errorf("handler: listing blobs: %w", err)

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -776,3 +776,56 @@ func TestHandleNobodyPullOnly(t *testing.T) {
 		t.Fatal("nobody with 'o' cap should reject push")
 	}
 }
+
+func TestEmitIGots_ExcludesShunAndPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	_, normalUUID, err := blob.Store(r.DB(), []byte("normal-blob-content"))
+	if err != nil {
+		t.Fatalf("Store normal: %v", err)
+	}
+	_, shunnedUUID, err := blob.Store(r.DB(), []byte("shunned-blob-content"))
+	if err != nil {
+		t.Fatalf("Store shunned: %v", err)
+	}
+	privRid, _, err := blob.Store(r.DB(), []byte("private-blob-content"))
+	if err != nil {
+		t.Fatalf("Store private: %v", err)
+	}
+
+	if _, err := r.DB().Exec("INSERT INTO shun(uuid, mtime) VALUES(?, 0)", shunnedUUID); err != nil {
+		t.Fatalf("shun: %v", err)
+	}
+	if _, err := r.DB().Exec("INSERT INTO private(rid) VALUES(?)", privRid); err != nil {
+		t.Fatalf("private: %v", err)
+	}
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PullCard{ServerCode: "test", ProjectCode: "test"},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	igotUUIDs := make(map[string]bool)
+	for _, c := range resp.Cards {
+		if ig, ok := c.(*xfer.IGotCard); ok {
+			igotUUIDs[ig.UUID] = true
+		}
+	}
+
+	if !igotUUIDs[normalUUID] {
+		t.Error("normal blob missing from igots")
+	}
+
+	if igotUUIDs[shunnedUUID] {
+		t.Error("shunned blob appeared in igots")
+	}
+
+	var privUUID string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", privRid).Scan(&privUUID)
+	if igotUUIDs[privUUID] {
+		t.Error("private blob appeared in igots")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -824,7 +824,9 @@ func TestEmitIGots_ExcludesShunAndPrivate(t *testing.T) {
 	}
 
 	var privUUID string
-	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", privRid).Scan(&privUUID)
+	if err := r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", privRid).Scan(&privUUID); err != nil {
+		t.Fatalf("query privUUID: %v", err)
+	}
 	if igotUUIDs[privUUID] {
 		t.Error("private blob appeared in igots")
 	}

--- a/sim/serve_test.go
+++ b/sim/serve_test.go
@@ -13,6 +13,7 @@ import (
 
 	natsserver "github.com/nats-io/nats-server/v2/server"
 
+	"github.com/dmestas/edgesync/go-libfossil/blob"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
 	"github.com/dmestas/edgesync/go-libfossil/sync"
@@ -542,6 +543,134 @@ func TestAgentServeHTTPFossilClone(t *testing.T) {
 	}
 
 	t.Logf("PASS: agent.Start() ServeHTTP → fossil clone — %d blobs, healthz + xfer verified", len(uuids))
+}
+
+// TestShunPrivateNotPropagated verifies that shunned and private blobs on a
+// server are never sent to a syncing client. Exercises the real client-side
+// sendUnclustered + emitIGots code paths via HTTP sync.
+func TestShunPrivateNotPropagated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dir := t.TempDir()
+	projCode := "shuntest0123456789abcdef0123456789abcdef"
+
+	// 1. Create server repo with normal + shunned + private blobs.
+	pathSrv := filepath.Join(dir, "server.fossil")
+	rSrv, err := repo.Create(pathSrv, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+	rSrv.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	normalData := []byte("normal-blob-content-for-sync-test")
+	shunnedData := []byte("shunned-blob-should-not-propagate")
+	privateData := []byte("private-blob-should-not-propagate")
+
+	_, normalUUID, err := blob.Store(rSrv.DB(), normalData)
+	if err != nil {
+		t.Fatalf("store normal: %v", err)
+	}
+	_, shunnedUUID, err := blob.Store(rSrv.DB(), shunnedData)
+	if err != nil {
+		t.Fatalf("store shunned: %v", err)
+	}
+	privRid, _, err := blob.Store(rSrv.DB(), privateData)
+	if err != nil {
+		t.Fatalf("store private: %v", err)
+	}
+
+	if _, err := rSrv.DB().Exec("INSERT INTO shun(uuid, mtime) VALUES(?, 0)", shunnedUUID); err != nil {
+		t.Fatalf("insert shun: %v", err)
+	}
+	if _, err := rSrv.DB().Exec("INSERT INTO private(rid) VALUES(?)", privRid); err != nil {
+		t.Fatalf("insert private: %v", err)
+	}
+
+	var privUUID string
+	if err := rSrv.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", privRid).Scan(&privUUID); err != nil {
+		t.Fatalf("query privUUID: %v", err)
+	}
+	rSrv.Close()
+
+	// 2. Create client repo — empty, same project code.
+	pathCli := filepath.Join(dir, "client.fossil")
+	rCli, err := repo.Create(pathCli, "testuser", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	rCli.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+	var srvCode string
+	if err := rCli.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&srvCode); err != nil {
+		t.Fatalf("query server-code: %v", err)
+	}
+	rCli.Close()
+
+	// 3. Start server via ServeHTTP.
+	rSrv, err = repo.Open(pathSrv)
+	if err != nil {
+		t.Fatalf("reopen server: %v", err)
+	}
+	defer rSrv.Close()
+
+	addr := freeAddr(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go sync.ServeHTTP(ctx, addr, rSrv, sync.HandleSync)
+	waitForAddr(t, addr, 5*time.Second)
+
+	// 4. Client syncs from server.
+	rCli, err = repo.Open(pathCli)
+	if err != nil {
+		t.Fatalf("reopen client: %v", err)
+	}
+	defer rCli.Close()
+
+	transport := &sync.HTTPTransport{URL: fmt.Sprintf("http://%s", addr)}
+	for round := 0; round < 10; round++ {
+		result, err := sync.Sync(ctx, rCli, transport, sync.SyncOpts{
+			Pull:        true,
+			ProjectCode: projCode,
+			ServerCode:  srvCode,
+		})
+		if err != nil {
+			t.Fatalf("sync round %d: %v", round, err)
+		}
+		t.Logf("round %d: recv=%d", round, result.FilesRecvd)
+		if result.FilesRecvd == 0 {
+			break
+		}
+	}
+
+	// 5. Verify: normal blob present, shunned + private absent.
+	var normalCount int
+	if err := rCli.DB().QueryRow("SELECT count(*) FROM blob WHERE uuid=?", normalUUID).Scan(&normalCount); err != nil {
+		t.Fatalf("query normal: %v", err)
+	}
+	if normalCount != 1 {
+		t.Errorf("normal blob missing from client (count=%d)", normalCount)
+	}
+
+	var shunnedCount int
+	if err := rCli.DB().QueryRow("SELECT count(*) FROM blob WHERE uuid=?", shunnedUUID).Scan(&shunnedCount); err != nil {
+		t.Fatalf("query shunned: %v", err)
+	}
+	if shunnedCount != 0 {
+		t.Errorf("shunned blob propagated to client (count=%d)", shunnedCount)
+	}
+
+	var privateCount int
+	if err := rCli.DB().QueryRow("SELECT count(*) FROM blob WHERE uuid=?", privUUID).Scan(&privateCount); err != nil {
+		t.Fatalf("query private: %v", err)
+	}
+	if privateCount != 0 {
+		t.Errorf("private blob propagated to client (count=%d)", privateCount)
+	}
+
+	t.Logf("PASS: shun/private exclusion — normal=%d shunned=%d private=%d",
+		normalCount, shunnedCount, privateCount)
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- Add `NOT EXISTS(shun)` and `NOT EXISTS(private)` exclusions to all sync SQL queries: `GenerateClusters`, `emitIGots`, `sendUnclustered`, `sendAllClusters` (handler + client)
- Private blobs remain in `unclustered` table after cleanup (matches Fossil behavior)
- TigerStyle refactor: split 112-line `GenerateClusters` into 4 functions (all ≤44 lines), fix unchecked `Scan` errors
- Sim integration test verifying shunned/private blobs never propagate via real HTTP sync

## Test plan

- [x] 3 new unit tests in `content/cluster_test.go` (shun excluded, private excluded, private stays unclustered)
- [x] 1 new unit test in `handler_test.go` (emitIGots excludes shun/private)
- [x] 1 new sim integration test in `serve_test.go` (real HTTP sync, shunned/private blobs do not propagate)
- [x] All existing tests pass (`make test`, `make dst`, sim serve)
- [x] Pre-commit hook passes on all 6 commits

Closes CDG-166

🤖 Generated with [Claude Code](https://claude.com/claude-code)