### PR TITLE
feat(sync): handle private branch cards (CDG-117)

### DIFF
--- a/docs/superpowers/plans/2026-03-25-private-branch-sync.md
+++ b/docs/superpowers/plans/2026-03-25-private-branch-sync.md
@@ -1,0 +1,1216 @@
+# Private Branch Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port Fossil's private artifact sync to go-libfossil — private blobs are excluded from normal sync and only transferred when both peers have `x` capability and the client opts in via `pragma send-private`.
+
+**Architecture:** Three layers: content helpers (`IsPrivate`/`MakePrivate`/`MakePublic`), auth capability check (`CanSyncPrivate` for `x`), and sync protocol changes (client filters igot/file/gimme; server handles `pragma send-private`, `private` card, and igot filtering). The `private` table already exists in the schema.
+
+**Tech Stack:** Go, SQLite, xfer card protocol
+
+**Spec:** `docs/superpowers/specs/2026-03-25-private-branch-sync-design.md`
+**Worktree:** `.worktrees/cdg-117`
+**Branch:** `feature/cdg-117-handle-private-branch-cards`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `go-libfossil/content/private.go` | Create | `IsPrivate`, `MakePrivate`, `MakePublic` |
+| `go-libfossil/content/private_test.go` | Create | Unit tests for private helpers |
+| `go-libfossil/auth/auth.go` | Modify | Add `CanSyncPrivate` |
+| `go-libfossil/auth/auth_test.go` | Modify | Add `TestCanSyncPrivate` |
+| `go-libfossil/sync/session.go` | Modify | Add `Private` to `SyncOpts`, `nextIsPrivate` to session |
+| `go-libfossil/sync/handler.go` | Modify | `syncPrivate`/`nextIsPrivate` on handler, pragma handling, private card dispatch, igot/clone filtering, MakePrivate/MakePublic on receive |
+| `go-libfossil/sync/handler_test.go` | Modify | Handler tests for private sync |
+| `go-libfossil/sync/client.go` | Modify | `sendUnclustered`/`sendAllClusters`/`buildFileCards`/`buildGimmeCards`/`processResponse` private filtering; new `sendPrivate()` |
+| `dst/scenario_test.go` | Modify | DST private sync scenario |
+| `sim/equivalence_test.go` | Modify | Equivalence test against real `fossil serve` |
+
+---
+
+### Task 1: Content helpers — `IsPrivate`, `MakePrivate`, `MakePublic`
+
+**Files:**
+- Create: `go-libfossil/content/private.go`
+- Create: `go-libfossil/content/private_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+In `go-libfossil/content/private_test.go`:
+
+```go
+package content
+
+import (
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
+	"github.com/dmestas/edgesync/go-libfossil/testutil"
+)
+
+func TestIsPrivate_NotPrivate(t *testing.T) {
+	r := testutil.NewTestRepo(t)
+	rid, _, _ := blob.Store(r.DB(), []byte("public blob"))
+	if IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should not be private by default")
+	}
+}
+
+func TestMakePrivate_ThenIsPrivate(t *testing.T) {
+	r := testutil.NewTestRepo(t)
+	rid, _, _ := blob.Store(r.DB(), []byte("will be private"))
+	if err := MakePrivate(r.DB(), int64(rid)); err != nil {
+		t.Fatalf("MakePrivate: %v", err)
+	}
+	if !IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should be private after MakePrivate")
+	}
+}
+
+func TestMakePrivate_Idempotent(t *testing.T) {
+	r := testutil.NewTestRepo(t)
+	rid, _, _ := blob.Store(r.DB(), []byte("double private"))
+	MakePrivate(r.DB(), int64(rid))
+	if err := MakePrivate(r.DB(), int64(rid)); err != nil {
+		t.Fatalf("second MakePrivate should not error: %v", err)
+	}
+}
+
+func TestMakePublic_ClearsPrivate(t *testing.T) {
+	r := testutil.NewTestRepo(t)
+	rid, _, _ := blob.Store(r.DB(), []byte("private then public"))
+	MakePrivate(r.DB(), int64(rid))
+	if err := MakePublic(r.DB(), int64(rid)); err != nil {
+		t.Fatalf("MakePublic: %v", err)
+	}
+	if IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should not be private after MakePublic")
+	}
+}
+
+func TestMakePublic_NoopIfNotPrivate(t *testing.T) {
+	r := testutil.NewTestRepo(t)
+	rid, _, _ := blob.Store(r.DB(), []byte("never private"))
+	if err := MakePublic(r.DB(), int64(rid)); err != nil {
+		t.Fatalf("MakePublic on non-private should not error: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/content/ -run TestIsPrivate -v`
+Expected: FAIL — `IsPrivate` not defined
+
+- [ ] **Step 3: Write implementation**
+
+In `go-libfossil/content/private.go`:
+
+```go
+package content
+
+import (
+	"github.com/dmestas/edgesync/go-libfossil/db"
+)
+
+// IsPrivate returns true if the blob with the given rid is in the private table.
+func IsPrivate(q db.Querier, rid int64) bool {
+	if q == nil {
+		panic("content.IsPrivate: q must not be nil")
+	}
+	var n int
+	err := q.QueryRow("SELECT 1 FROM private WHERE rid=?", rid).Scan(&n)
+	return err == nil
+}
+
+// MakePrivate inserts the rid into the private table (no-op if already present).
+func MakePrivate(q db.Querier, rid int64) error {
+	if q == nil {
+		panic("content.MakePrivate: q must not be nil")
+	}
+	_, err := q.Exec("INSERT OR IGNORE INTO private(rid) VALUES(?)", rid)
+	return err
+}
+
+// MakePublic removes the rid from the private table (no-op if not present).
+func MakePublic(q db.Querier, rid int64) error {
+	if q == nil {
+		panic("content.MakePublic: q must not be nil")
+	}
+	_, err := q.Exec("DELETE FROM private WHERE rid=?", rid)
+	return err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/content/ -run "TestIsPrivate|TestMakePrivate|TestMakePublic" -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/content/private.go go-libfossil/content/private_test.go
+git commit -m "feat(content): add IsPrivate, MakePrivate, MakePublic helpers"
+```
+
+---
+
+### Task 2: Auth — `CanSyncPrivate`
+
+**Files:**
+- Modify: `go-libfossil/auth/auth.go:24` (add after `CanPushUV`)
+- Modify: `go-libfossil/auth/auth_test.go` (add test)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `go-libfossil/auth/auth_test.go`:
+
+```go
+func TestCanSyncPrivate(t *testing.T) {
+	if !CanSyncPrivate("x") { t.Error("CanSyncPrivate(x) should be true") }
+	if CanSyncPrivate("oi") { t.Error("CanSyncPrivate(oi) should be false") }
+	// 'x' is NOT implied by 'a' (admin) or 's' (setup)
+	if CanSyncPrivate("as") { t.Error("CanSyncPrivate(as) should be false — x must be explicit") }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/auth/ -run TestCanSyncPrivate -v`
+Expected: FAIL — `CanSyncPrivate` not defined
+
+- [ ] **Step 3: Write implementation**
+
+Add to `go-libfossil/auth/auth.go` after line 24:
+
+```go
+func CanSyncPrivate(caps string) bool { return HasCapability(caps, 'x') }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/auth/ -run TestCanSyncPrivate -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/auth/auth.go go-libfossil/auth/auth_test.go
+git commit -m "feat(auth): add CanSyncPrivate for 'x' capability"
+```
+
+---
+
+### Task 3: SyncOpts + session state
+
+**Files:**
+- Modify: `go-libfossil/sync/session.go:36` (add `Private` to SyncOpts)
+- Modify: `go-libfossil/sync/session.go:52-79` (add `nextIsPrivate` to session)
+
+- [ ] **Step 1: Add `Private` field to `SyncOpts`**
+
+In `go-libfossil/sync/session.go`, after line 36 (`UV bool`), add:
+
+```go
+	Private                 bool              // enable private artifact sync
+```
+
+- [ ] **Step 2: Add `nextIsPrivate` to `session` struct**
+
+In the `session` struct (after the `nGimmeRcvd` field at line 72), add:
+
+```go
+	nextIsPrivate       bool // true when a PrivateCard precedes the next file/cfile
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cd .worktrees/cdg-117 && go build -buildvcs=false ./go-libfossil/sync/`
+Expected: builds clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/session.go
+git commit -m "feat(sync): add Private to SyncOpts, nextIsPrivate to session"
+```
+
+---
+
+### Task 4: Server — `pragma send-private` + handler state
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:78-98` (add `syncPrivate`/`nextIsPrivate` to handler struct)
+- Modify: `go-libfossil/sync/handler.go:211-258` (handle pragma in `handleControlCard`)
+- Modify: `go-libfossil/sync/handler_test.go` (add tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `go-libfossil/sync/handler_test.go`:
+
+```go
+func TestHandlerPragmaSendPrivate_Accepted(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	// Grant 'x' capability to nobody
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+
+	// Should NOT have an error card about private
+	for _, c := range resp.Cards {
+		if e, ok := c.(*xfer.ErrorCard); ok {
+			if e.Message == "not authorized to sync private content" {
+				t.Error("should not get auth error with 'x' capability")
+			}
+		}
+	}
+}
+
+func TestHandlerPragmaSendPrivate_Rejected(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	// nobody has default caps (no 'x')
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'")
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+
+	errors := findCards[*xfer.ErrorCard](resp)
+	found := false
+	for _, e := range errors {
+		if e.Message == "not authorized to sync private content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'not authorized to sync private content' error")
+	}
+}
+```
+
+Note: `handleReq` is defined in `handler_uv_test.go`. It calls `HandleSync` and returns the response. `findCards` is a generic helper in `handler_test.go`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerPragmaSendPrivate" -v`
+Expected: FAIL — pragma not handled yet (tests may pass vacuously if no error expected; adjust assertions)
+
+- [ ] **Step 3: Add handler struct fields and pragma handling**
+
+In `go-libfossil/sync/handler.go`, add to the `handler` struct (after `filesRecvd` at line 89):
+
+```go
+	syncPrivate   bool // true if pragma send-private was accepted
+	nextIsPrivate bool // true if a private card precedes the next file/cfile
+```
+
+In `handleControlCard`, inside the `*xfer.PragmaCard` case (after the `req-clusters` handling around line 225), add:
+
+```go
+	if c.Name == "send-private" {
+		if auth.CanSyncPrivate(h.caps) {
+			h.syncPrivate = true
+		} else {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "not authorized to sync private content",
+			})
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerPragmaSendPrivate" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go go-libfossil/sync/handler_test.go
+git commit -m "feat(sync): handle pragma send-private with x capability check"
+```
+
+---
+
+### Task 5: Server — `private` card + file/cfile MakePrivate/MakePublic
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:260-286` (`handleDataCard` — add PrivateCard case)
+- Modify: `go-libfossil/sync/handler.go:326-351` (`handleFile` — add MakePrivate/MakePublic)
+- Modify: `go-libfossil/sync/handler_test.go` (add tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `go-libfossil/sync/handler_test.go`:
+
+```go
+func TestHandlerPrivateCardAccepted(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	data := []byte("private content")
+	uuid := hash.SHA1(data)
+
+	resp := handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+		&xfer.PrivateCard{},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	// No error cards
+	for _, c := range resp.Cards {
+		if e, ok := c.(*xfer.ErrorCard); ok {
+			t.Errorf("unexpected error: %s", e.Message)
+		}
+	}
+
+	// Verify blob is stored and marked private
+	rid, ok := blob.Exists(r.DB(), uuid)
+	if !ok {
+		t.Fatal("blob should exist")
+	}
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should be marked private")
+	}
+}
+
+func TestHandlerPrivateCardRejected(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'") // no 'x'
+
+	resp := handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PrivateCard{},
+		&xfer.FileCard{UUID: "0000000000000000000000000000000000000000", Content: []byte("x")},
+	)
+
+	errors := findCards[*xfer.ErrorCard](resp)
+	found := false
+	for _, e := range errors {
+		if e.Message == "not authorized to sync private content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'not authorized to sync private content' error")
+	}
+}
+
+func TestHandlerPublicFileClarsPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	data := []byte("was private now public")
+	uuid := hash.SHA1(data)
+
+	// First: store as private
+	handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+		&xfer.PrivateCard{},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	rid, _ := blob.Exists(r.DB(), uuid)
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Fatal("should be private after first store")
+	}
+
+	// Second: receive same blob as public (no private card prefix)
+	handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	if content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should be public after receiving without private card")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerPrivateCard|TestHandlerPublicFile" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement PrivateCard handling + MakePrivate/MakePublic in handleFile**
+
+In `handleDataCard`, add a new case before the existing `case *xfer.ReqConfigCard:`:
+
+```go
+	case *xfer.PrivateCard:
+		if !auth.CanSyncPrivate(h.caps) {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "not authorized to sync private content",
+			})
+			h.nextIsPrivate = false
+		} else {
+			h.nextIsPrivate = true
+		}
+		return nil
+```
+
+In `handleFile`, after the `storeReceivedFile` call succeeds and before `h.filesRecvd++`, add:
+
+```go
+	// Mark private/public based on preceding private card.
+	rid, _ := blob.Exists(h.repo.DB(), uuid)
+	if h.nextIsPrivate {
+		content.MakePrivate(h.repo.DB(), int64(rid))
+		h.nextIsPrivate = false
+	} else {
+		content.MakePublic(h.repo.DB(), int64(rid))
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerPrivateCard|TestHandlerPublicFile" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go go-libfossil/sync/handler_test.go
+git commit -m "feat(sync): handle private card + MakePrivate/MakePublic on file receipt"
+```
+
+---
+
+### Task 6: Server — `emitIGots` private filtering
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:374-404` (`emitIGots`)
+- Modify: `go-libfossil/sync/handler_test.go` (add tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `go-libfossil/sync/handler_test.go`:
+
+```go
+func TestEmitIGotsExcludesPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	// Store a public and a private blob
+	pubData := []byte("public blob")
+	privData := []byte("private blob")
+	pubUUID := hash.SHA1(pubData)
+	privUUID := hash.SHA1(privData)
+	blob.Store(r.DB(), pubData)
+	privRid, _, _ := blob.Store(r.DB(), privData)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+	)
+
+	igots := findCards[*xfer.IGotCard](resp)
+	for _, ig := range igots {
+		if ig.UUID == privUUID {
+			t.Error("private blob should be excluded from igot in normal sync")
+		}
+	}
+	foundPub := false
+	for _, ig := range igots {
+		if ig.UUID == pubUUID {
+			foundPub = true
+		}
+	}
+	if !foundPub {
+		t.Error("public blob should be in igot")
+	}
+}
+
+func TestEmitIGotsIncludesPrivateWhenAuthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	privData := []byte("private blob for sync")
+	privUUID := hash.SHA1(privData)
+	privRid, _, _ := blob.Store(r.DB(), privData)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+
+	igots := findCards[*xfer.IGotCard](resp)
+	found := false
+	for _, ig := range igots {
+		if ig.UUID == privUUID {
+			found = true
+			if !ig.IsPrivate {
+				t.Error("private igot should have IsPrivate=true")
+			}
+		}
+	}
+	if !found {
+		t.Error("private blob should be included in igot when syncPrivate")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestEmitIGots" -v`
+Expected: FAIL — private blob appears in igot without filtering
+
+- [ ] **Step 3: Modify `emitIGots` to filter private blobs**
+
+In `handler.go`, replace the `emitIGots` query with:
+
+```go
+func (h *handler) emitIGots() error {
+	// Emit igot for all non-phantom, non-private blobs.
+	rows, err := h.repo.DB().Query(
+		`SELECT uuid FROM blob WHERE size >= 0
+		 AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)`,
+	)
+	if err != nil {
+		return fmt.Errorf("handler: listing blobs: %w", err)
+	}
+	defer rows.Close()
+
+	var uuids []string
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return err
+		}
+		uuids = append(uuids, uuid)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// BUGGIFY: 10% chance truncate igot list to test multi-round convergence.
+	if h.buggify != nil && h.buggify.Check("handler.emitIGots.truncate", 0.10) && len(uuids) > 1 {
+		uuids = uuids[:len(uuids)/2]
+	}
+
+	for _, uuid := range uuids {
+		h.resp = append(h.resp, &xfer.IGotCard{UUID: uuid})
+	}
+
+	// If syncPrivate, also emit igot UUID 1 for private blobs.
+	if h.syncPrivate {
+		if err := h.emitPrivateIGots(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *handler) emitPrivateIGots() error {
+	rows, err := h.repo.DB().Query(
+		"SELECT b.uuid FROM private p JOIN blob b ON p.rid=b.rid WHERE b.size >= 0",
+	)
+	if err != nil {
+		return fmt.Errorf("handler: listing private blobs: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return err
+		}
+		h.resp = append(h.resp, &xfer.IGotCard{UUID: uuid, IsPrivate: true})
+	}
+	return rows.Err()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestEmitIGots" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full sync test suite to check for regressions**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All existing tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go go-libfossil/sync/handler_test.go
+git commit -m "feat(sync): filter private blobs from emitIGots, add emitPrivateIGots"
+```
+
+---
+
+### Task 7: Server — `handleIGot` private awareness
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:288-300` (`handleIGot`)
+- Modify: `go-libfossil/sync/handler_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `go-libfossil/sync/handler_test.go`:
+
+```go
+func TestHandlerIGotPrivate_Authorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+		&xfer.IGotCard{UUID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", IsPrivate: true},
+	)
+
+	// Should gimme the private artifact when authorized
+	gimmes := findCards[*xfer.GimmeCard](resp)
+	if len(gimmes) != 1 || gimmes[0].UUID != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("expected gimme for private igot, got %d gimmes", len(gimmes))
+	}
+}
+
+func TestHandlerIGotPrivate_Unauthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'") // no 'x'
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.IGotCard{UUID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", IsPrivate: true},
+	)
+
+	// Should NOT gimme the private artifact — just ignore it
+	gimmes := findCards[*xfer.GimmeCard](resp)
+	if len(gimmes) != 0 {
+		t.Errorf("should not gimme private artifact without x capability, got %d", len(gimmes))
+	}
+}
+
+func TestHandlerIGotPublic_ClearsPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	// Pre-store a blob and mark it private
+	data := []byte("was private")
+	uuid := hash.SHA1(data)
+	rid, _, _ := blob.Store(r.DB(), data)
+	content.MakePrivate(r.DB(), int64(rid))
+
+	handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.IGotCard{UUID: uuid, IsPrivate: false},
+	)
+
+	if content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("public igot should clear private status")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerIGotPrivate|TestHandlerIGotPublic" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Modify `handleIGot` for private awareness**
+
+Replace the `handleIGot` method:
+
+```go
+func (h *handler) handleIGot(c *xfer.IGotCard) error {
+	if c == nil {
+		panic("handler.handleIGot: c must not be nil")
+	}
+	if !h.pullOK {
+		return nil
+	}
+	rid, exists := blob.Exists(h.repo.DB(), c.UUID)
+	if exists {
+		// Update private/public status based on igot flag.
+		if c.IsPrivate {
+			content.MakePrivate(h.repo.DB(), int64(rid))
+		} else {
+			content.MakePublic(h.repo.DB(), int64(rid))
+		}
+		return nil
+	}
+	// Blob doesn't exist locally.
+	if c.IsPrivate && !h.syncPrivate {
+		// Not authorized for private sync — don't request it.
+		return nil
+	}
+	h.resp = append(h.resp, &xfer.GimmeCard{UUID: c.UUID})
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestHandlerIGotPrivate|TestHandlerIGotPublic" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go go-libfossil/sync/handler_test.go
+git commit -m "feat(sync): private-aware handleIGot with MakePrivate/MakePublic"
+```
+
+---
+
+### Task 8: Server — `handleGimme` private card prefix + `emitCloneBatch` filtering
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:302-324` (`handleGimme`)
+- Modify: `go-libfossil/sync/handler.go:435+` (`emitCloneBatch`)
+
+- [ ] **Step 1: Modify `handleGimme` to prepend private card**
+
+In `handleGimme`, after the file card is appended (line ~321), add a private check:
+
+```go
+func (h *handler) handleGimme(c *xfer.GimmeCard) error {
+	if c == nil {
+		panic("handler.handleGimme: c must not be nil")
+	}
+	if h.buggify != nil && h.buggify.Check("handler.handleGimme.skip", 0.05) {
+		return nil
+	}
+	rid, ok := blob.Exists(h.repo.DB(), c.UUID)
+	if !ok {
+		return nil
+	}
+	isPriv := content.IsPrivate(h.repo.DB(), int64(rid))
+	if isPriv && !h.syncPrivate {
+		return nil // don't send private content without authorization
+	}
+	data, err := content.Expand(h.repo.DB(), rid)
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("expand %s: %v", c.UUID, err),
+		})
+		return nil
+	}
+	if isPriv {
+		h.resp = append(h.resp, &xfer.PrivateCard{})
+	}
+	h.resp = append(h.resp, &xfer.FileCard{UUID: c.UUID, Content: data})
+	h.filesSent++
+	return nil
+}
+```
+
+- [ ] **Step 2: Modify `emitCloneBatch` to filter/prefix private blobs**
+
+In `emitCloneBatch`, after scanning each `(rid, uuid)` row and before appending the file card, add:
+
+```go
+		isPriv := content.IsPrivate(h.repo.DB(), int64(rid))
+		if isPriv && !h.syncPrivate {
+			continue // skip private blobs in clone when not authorized
+		}
+		// ... existing expand + file card code ...
+		if isPriv {
+			h.resp = append(h.resp, &xfer.PrivateCard{})
+		}
+```
+
+Note: Be careful with the count/lastRID tracking — skipped private blobs should still advance the cursor but not count toward the batch limit. Read the existing `emitCloneBatch` code carefully and adjust the skip logic to maintain correct pagination.
+
+- [ ] **Step 3: Run full handler test suite**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go
+git commit -m "feat(sync): private card prefix in handleGimme + emitCloneBatch filtering"
+```
+
+---
+
+### Task 9: Server — `sendAllClusters` private filtering
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:409-433` (`sendAllClusters`)
+
+- [ ] **Step 1: Add private exclusion to `sendAllClusters` query**
+
+Add `AND NOT EXISTS (SELECT 1 FROM private WHERE rid = b.rid)` to the query in `sendAllClusters`:
+
+```sql
+SELECT b.uuid FROM tagxref tx
+JOIN blob b ON tx.rid = b.rid
+WHERE tx.tagid = 7
+  AND NOT EXISTS (SELECT 1 FROM unclustered WHERE rid = b.rid)
+  AND NOT EXISTS (SELECT 1 FROM phantom WHERE rid = b.rid)
+  AND NOT EXISTS (SELECT 1 FROM private WHERE rid = b.rid)
+  AND b.size >= 0
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/handler.go
+git commit -m "feat(sync): exclude private blobs from sendAllClusters"
+```
+
+---
+
+### Task 10: Client — `pragma send-private` + `sendUnclustered` filtering
+
+**Files:**
+- Modify: `go-libfossil/sync/client.go` (buildRequest, sendUnclustered, new sendPrivate)
+
+- [ ] **Step 1: Add `pragma send-private` to `buildRequest`**
+
+In `buildRequest`, after the UV pragma block (around line 78 `// UV: pragma uv-hash on first round`), add:
+
+```go
+	// Private: send pragma on first round
+	if cycle == 0 && s.opts.Private {
+		cards = append(cards, &xfer.PragmaCard{Name: "send-private"})
+	}
+```
+
+- [ ] **Step 2: Add private exclusion to `sendUnclustered`**
+
+Modify the query in `sendUnclustered` (around line 157) to exclude private blobs:
+
+```sql
+SELECT uuid FROM unclustered JOIN blob USING(rid)
+WHERE size >= 0
+  AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
+```
+
+- [ ] **Step 3: Add `sendPrivate` function**
+
+After `sendUnclustered`, add:
+
+```go
+// sendPrivate emits igot UUID 1 for all private blobs.
+// Called when opts.Private is true.
+func (s *session) sendPrivate() ([]xfer.Card, error) {
+	rows, err := s.repo.DB().Query(
+		"SELECT b.uuid FROM private p JOIN blob b ON p.rid=b.rid WHERE b.size >= 0",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sendPrivate: %w", err)
+	}
+	defer rows.Close()
+
+	var cards []xfer.Card
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, err
+		}
+		if s.remoteHas[uuid] {
+			continue
+		}
+		cards = append(cards, &xfer.IGotCard{UUID: uuid, IsPrivate: true})
+	}
+	return cards, rows.Err()
+}
+```
+
+- [ ] **Step 4: Call `sendPrivate` in `buildRequest`**
+
+After the `sendUnclustered` call in `buildRequest` (around line 67), add:
+
+```go
+	// Private: emit igot UUID 1 for private blobs
+	if s.opts.Private {
+		privCards, err := s.sendPrivate()
+		if err != nil {
+			return nil, fmt.Errorf("buildRequest sendPrivate: %w", err)
+		}
+		s.igotSentThisRound += len(privCards)
+		s.roundStats.IgotsSent += len(privCards)
+		cards = append(cards, privCards...)
+	}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/client.go
+git commit -m "feat(sync): client pragma send-private, sendUnclustered filtering, sendPrivate"
+```
+
+---
+
+### Task 11: Client — `sendAllClusters`, `buildFileCards`, `buildGimmeCards` filtering
+
+**Files:**
+- Modify: `go-libfossil/sync/client.go`
+
+- [ ] **Step 1: Add private exclusion to `sendAllClusters`**
+
+Add `AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)` to the client's `sendAllClusters` query.
+
+- [ ] **Step 2: Add private exclusion to `buildFileCards` unsent query**
+
+In `buildFileCards`, if there is an unsent table query, modify it to:
+
+```sql
+SELECT rid FROM unsent EXCEPT SELECT rid FROM private
+```
+
+Also, when loading a file card for a blob in `pendingSend`, check `content.IsPrivate` and prepend `PrivateCard` if private. Only do this when `s.opts.Private` — if `!s.opts.Private`, skip private blobs entirely.
+
+- [ ] **Step 3: Add private exclusion to `buildGimmeCards`**
+
+When `!s.opts.Private`, filter private phantoms from the gimme list. Check `content.IsPrivate` for each phantom's rid before emitting a gimme card. Since phantoms may not have a rid in the private table, this check is best-effort — the server-side filtering is the primary gate.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/client.go
+git commit -m "feat(sync): client-side private filtering in sendAllClusters, buildFileCards, buildGimmeCards"
+```
+
+---
+
+### Task 12: Client — `processResponse` private handling
+
+**Files:**
+- Modify: `go-libfossil/sync/client.go:360-530` (`processResponse`)
+
+- [ ] **Step 1: Handle `PrivateCard` in processResponse**
+
+In the `switch c := card.(type)` block in `processResponse`, add:
+
+```go
+		case *xfer.PrivateCard:
+			s.nextIsPrivate = true
+```
+
+- [ ] **Step 2: Add MakePrivate/MakePublic after FileCard/CFileCard storage**
+
+After the `handleFileCard` call for `FileCard` and `CFileCard`, add:
+
+```go
+			// Mark private/public based on preceding private card.
+			if s.nextIsPrivate {
+				rid, _ := blob.Exists(s.repo.DB(), c.UUID)
+				content.MakePrivate(s.repo.DB(), int64(rid))
+				s.nextIsPrivate = false
+			} else {
+				rid, exists := blob.Exists(s.repo.DB(), c.UUID)
+				if exists {
+					content.MakePublic(s.repo.DB(), int64(rid))
+				}
+			}
+```
+
+- [ ] **Step 3: Handle `IGotCard.IsPrivate` in processResponse**
+
+Replace the existing `IGotCard` case entirely. The current code just tracks `remoteHas` and creates phantoms. The new code adds private awareness:
+
+```go
+		case *xfer.IGotCard:
+			s.remoteHas[c.UUID] = true
+			rid, exists := blob.Exists(s.repo.DB(), c.UUID)
+			if c.IsPrivate {
+				if exists {
+					// Already have it — update private status
+					content.MakePrivate(s.repo.DB(), int64(rid))
+				} else if s.opts.Private && s.opts.Pull {
+					// Authorized for private sync — create phantom to request it
+					s.phantoms[c.UUID] = true
+				}
+				// else: not authorized for private sync — don't create phantom
+			} else {
+				// Public artifact
+				if exists {
+					content.MakePublic(s.repo.DB(), int64(rid))
+				} else if s.opts.Pull {
+					s.phantoms[c.UUID] = true
+				}
+			}
+```
+
+Note: The existing code's `remoteHas` tracking is preserved at the top. The existing phantom creation logic (`if s.opts.Pull && !exists`) is preserved in the public branch. Read the current implementation to verify no other logic (e.g., unsent table removal) needs preserving.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/client.go
+git commit -m "feat(sync): client processResponse private card + igot handling"
+```
+
+---
+
+### Task 13: Integration test — private sync end-to-end
+
+**Files:**
+- Modify: `go-libfossil/sync/handler_test.go` or create `go-libfossil/sync/private_integration_test.go`
+
+- [ ] **Step 1: Write integration test**
+
+Test that a full sync session with `Private: true` transfers private blobs, and `Private: false` excludes them:
+
+```go
+func TestSyncPrivateEndToEnd(t *testing.T) {
+	// Create server repo with mix of public and private blobs.
+	// Create client repo.
+	// Sync with Private: false — only public blobs arrive.
+	// Sync with Private: true — all blobs arrive, private ones marked in private table.
+}
+```
+
+This test uses `MockTransport` with `HandleSyncWithOpts` to run a full sync loop without HTTP.
+
+- [ ] **Step 2: Write test for private→public transition**
+
+```go
+func TestSyncPrivateArtifactTransition(t *testing.T) {
+	// Server has a blob marked private.
+	// Client syncs with Private: true — gets it, marked private.
+	// Server removes from private table (MakePublic).
+	// Client syncs again — blob's private status is cleared.
+}
+```
+
+- [ ] **Step 3: Run integration tests**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./go-libfossil/sync/ -run "TestSyncPrivate" -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add go-libfossil/sync/
+git commit -m "test(sync): private sync integration tests"
+```
+
+---
+
+### Task 14: DST scenario — private sync
+
+**Files:**
+- Modify: `dst/scenario_test.go`
+
+- [ ] **Step 1: Write DST scenario**
+
+Add `TestScenarioPrivateSync`:
+
+- Master repo with 50 public + 10 private blobs.
+- Leaf A: `SyncOpts{Private: true}`, nobody has `x` capability → gets all 60 blobs.
+- Leaf B: `SyncOpts{Private: false}`, nobody without `x` → gets only 50 public blobs.
+- Run sim, check convergence, verify blob counts per leaf.
+
+Note: The DST uses `MockFossil` and the simulator. Study existing scenarios like `TestScenarioCleanSync` for the pattern. You'll need to seed blobs on the master and mark some as private via `content.MakePrivate`.
+
+- [ ] **Step 2: Run DST**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./dst/ -run TestScenarioPrivateSync -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add dst/scenario_test.go
+git commit -m "test(dst): add TestScenarioPrivateSync"
+```
+
+---
+
+### Task 15: Sim equivalence test — against real `fossil serve`
+
+**Files:**
+- Modify: `sim/equivalence_test.go`
+
+- [ ] **Step 1: Write equivalence test**
+
+Add `TestPrivateSyncAgainstFossilServe`:
+
+1. `fossil new` a repo.
+2. `fossil user capabilities nobody oix -R <repo>` — grant `x`.
+3. Create a commit (so the repo has content).
+4. `fossil checkout`, create a file on a private branch: `fossil branch new private-branch trunk --private -R <repo>`.
+5. `fossil serve` the repo.
+6. Clone/sync with go-libfossil `Private: true` — verify private artifacts arrive.
+
+Note: Creating a private branch via `fossil branch new --private` is the Fossil way. Study `fossilInit`/`fossilCommitFiles`/`startFossilServe` helpers in `sim/equivalence_test.go`.
+
+- [ ] **Step 2: Run test**
+
+Run: `cd .worktrees/cdg-117 && go test -buildvcs=false ./sim/ -run TestPrivateSyncAgainstFossilServe -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd .worktrees/cdg-117
+git add sim/equivalence_test.go
+git commit -m "test(sim): add TestPrivateSyncAgainstFossilServe"
+```
+
+---
+
+### Task 16: Full test suite + pre-commit
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd .worktrees/cdg-117 && make test`
+Expected: All PASS
+
+- [ ] **Step 2: Run DST full**
+
+Run: `cd .worktrees/cdg-117 && make dst`
+Expected: All PASS
+
+- [ ] **Step 3: Push branch**
+
+```bash
+cd .worktrees/cdg-117
+git push -u origin feature/cdg-117-handle-private-branch-cards
+```

--- a/docs/superpowers/specs/2026-03-25-private-branch-sync-design.md
+++ b/docs/superpowers/specs/2026-03-25-private-branch-sync-design.md
@@ -1,0 +1,241 @@
+# Private Branch Sync — Design Spec
+
+**Ticket:** CDG-117
+**Date:** 2026-03-25
+**Status:** Approved
+
+## Summary
+
+Port Fossil's private artifact sync to go-libfossil. Private artifacts are blobs listed in the `private` table. They are excluded from normal sync and only transferred when both peers have the `x` capability and the client explicitly opts in via `pragma send-private`.
+
+## Fossil Reference
+
+Fossil's `xfer.c` implements private sync with these mechanics:
+
+- **`private` table** — `CREATE TABLE private(rid INTEGER PRIMARY KEY)`. Tracks which blobs are private.
+- **`private` card** — a bare `private\n` line that precedes a `file` or `cfile` card, marking the next payload as private content.
+- **`igot UUID 1`** — the second argument `1` signals the artifact is private. Peers without `x` capability treat these as "don't request this."
+- **`pragma send-private`** — client requests the server to include private artifacts in its responses.
+- **`x` capability** — required to sync private content. Not implied by `a` (admin) or `s` (setup) — must be explicitly granted.
+- **`content_is_private(rid)`** — checks the `private` table.
+- **`content_make_private(rid)` / `content_make_public(rid)`** — inserts/removes from the `private` table. Receiving a public artifact that was previously private makes it public.
+
+### Key behaviors from Fossil C source
+
+1. **`send_file`**: If artifact is private and `syncPrivate` is false, emit `igot UUID 1` instead of sending file content. If `syncPrivate` is true, prepend `private\n` before the `file` card.
+2. **`send_unsent`**: `SELECT rid FROM unsent EXCEPT SELECT rid FROM private` — never proactively send private blobs in normal sync.
+3. **`send_unclustered`**: Excludes `NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)` from igot emission.
+4. **`send_all_clusters`**: Same private exclusion.
+5. **`request_phantoms`**: Excludes private phantoms when `syncPrivate` is false.
+6. **`send_private`**: Separate function that emits `igot UUID 1` for all private blobs when `syncPrivate` is true.
+7. **Server `private` card**: Sets `nextIsPrivate` flag. If peer lacks `x` capability, emits error.
+8. **Server `pragma send-private`**: Checks `x` capability, sets `syncPrivate` on the session.
+9. **Server `igot` with IsPrivate**: If authorized, creates private phantom. If not authorized, marks as private and doesn't request.
+10. **Client `igot` with IsPrivate**: If pulling private, creates private phantom. Otherwise marks existing blob as private and ignores.
+11. **Client `private` card**: Sets `nextIsPrivate`. Next file/cfile is stored and marked private.
+12. **Delta safety**: Never send a delta against a private artifact (the base might not exist on the peer).
+
+## Design
+
+### 1. Content helpers — `content/private.go`
+
+New file in `go-libfossil/content/`:
+
+```go
+// IsPrivate returns true if the blob with the given rid is in the private table.
+func IsPrivate(db *db.DB, rid int64) bool
+
+// MakePrivate inserts the rid into the private table (no-op if already present).
+func MakePrivate(db *db.DB, rid int64) error
+
+// MakePublic removes the rid from the private table (no-op if not present).
+func MakePublic(db *db.DB, rid int64) error
+```
+
+### 2. Auth — `auth/auth.go`
+
+New capability check:
+
+```go
+func CanSyncPrivate(caps string) bool { return HasCapability(caps, 'x') }
+```
+
+### 3. Client-side — `sync/`
+
+#### SyncOpts
+
+New field:
+
+```go
+type SyncOpts struct {
+    // ... existing fields ...
+    Private bool // enable private artifact sync (requires 'x' capability)
+}
+```
+
+#### First round — `pragma send-private`
+
+When `opts.Private` is true, emit `pragma send-private\n` on the first round (same pattern as `pragma uv-hash`).
+
+#### `sendUnclustered`
+
+Add exclusion filter when `!s.opts.Private`:
+
+```sql
+SELECT uuid FROM unclustered JOIN blob USING(rid)
+WHERE size >= 0
+  AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
+```
+
+When `s.opts.Private`, also call `sendPrivate()` which emits `igot UUID 1` for all private blobs.
+
+#### `sendAllClusters`
+
+Add same `NOT EXISTS(SELECT 1 FROM private ...)` filter.
+
+#### `buildFileCards`
+
+Before emitting a `FileCard` for a private blob, prepend a `PrivateCard`. Check `content.IsPrivate(db, rid)` when loading.
+
+Delta safety: when building a delta, skip if the delta source is private (use full content instead).
+
+#### `buildGimmeCards`
+
+When `!opts.Private`, exclude private phantoms:
+
+```sql
+AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
+```
+
+#### `processResponse`
+
+- **`PrivateCard`**: Set `s.nextIsPrivate = true`.
+- **`FileCard` / `CFileCard`**: After storing, if `s.nextIsPrivate`, call `content.MakePrivate`. Reset flag.
+- **`IGotCard` with `IsPrivate`**:
+  - If `s.opts.Private`: create private phantom (request it).
+  - If `!s.opts.Private`: if blob exists locally, call `content.MakePrivate`. Don't create phantom (don't request).
+
+### 4. Server-side — `sync/handler.go`
+
+#### Handler state
+
+New fields on the `handler` struct:
+
+```go
+syncPrivate    bool // true if pragma send-private was accepted
+nextIsPrivate  bool // true if a private card precedes the next file/cfile
+```
+
+#### `pragma send-private`
+
+In `handleControlCard`, handle the pragma:
+
+```go
+if c.Name == "send-private" {
+    if auth.CanSyncPrivate(h.caps) {
+        h.syncPrivate = true
+    } else {
+        h.resp = append(h.resp, &xfer.ErrorCard{
+            Message: "not authorized to sync private content",
+        })
+    }
+}
+```
+
+#### `private` card
+
+In `handleDataCard`, handle `*xfer.PrivateCard`:
+
+```go
+case *xfer.PrivateCard:
+    if !auth.CanSyncPrivate(h.caps) {
+        h.resp = append(h.resp, &xfer.ErrorCard{
+            Message: "not authorized to sync private content",
+        })
+    } else {
+        h.nextIsPrivate = true
+    }
+```
+
+#### File/CFile handling
+
+After storing a received file, if `h.nextIsPrivate`:
+- Call `content.MakePrivate(db, rid)`.
+- Reset `h.nextIsPrivate = false`.
+
+If not `nextIsPrivate`, call `content.MakePublic(db, rid)` — a public artifact replaces any prior private status.
+
+#### `emitIGots`
+
+Exclude private blobs:
+
+```sql
+SELECT uuid FROM blob
+WHERE size >= 0
+  AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
+```
+
+When `h.syncPrivate`, also emit `igot UUID 1` for private blobs via a separate query on the `private` table.
+
+#### `emitCloneBatch`
+
+Same private exclusion. When `syncPrivate`, include private blobs with `private\n` prefix.
+
+#### `handleIGotCard` (in `handleDataCard`)
+
+Respect `IsPrivate` flag:
+- If `IsPrivate` and `h.syncPrivate` (authorized): create phantom, mark private.
+- If `IsPrivate` and `!h.syncPrivate`: mark as private if exists locally, don't create phantom.
+- If not `IsPrivate` and blob exists: call `MakePublic` (in case it was previously private).
+
+### 5. Testing
+
+#### Unit tests
+
+- `content/private_test.go` — `IsPrivate`, `MakePrivate`, `MakePublic` round-trip.
+- `auth/auth_test.go` — `CanSyncPrivate` checks `'x'`.
+
+#### Handler tests (`sync/handler_test.go`)
+
+- `TestHandlerPrivateCardAccepted` — with `x` capability, private + file stores and marks private.
+- `TestHandlerPrivateCardRejected` — without `x`, error card emitted.
+- `TestHandlerPragmaSendPrivate` — with `x`, sets syncPrivate; without `x`, error.
+- `TestHandlerIGotPrivate` — private igot creates private phantom when authorized.
+- `TestEmitIGotsExcludesPrivate` — private blobs excluded from igot emission in normal sync.
+- `TestEmitIGotsIncludesPrivateWhenAuthorized` — private blobs emitted as `igot UUID 1` when syncPrivate.
+
+#### Client tests (`sync/client_test.go` or similar)
+
+- `TestSyncPrivatePragmaSent` — `Private: true` emits `pragma send-private`.
+- `TestSyncPrivateIGotEmission` — private blobs emitted as `igot UUID 1`.
+- `TestSyncPrivateFileCardPrefix` — private file cards preceded by `PrivateCard`.
+- `TestSyncExcludesPrivateByDefault` — `Private: false` excludes private from igot/gimme.
+
+#### DST scenario (`dst/scenario_test.go`)
+
+- `TestScenarioPrivateSync` — master has mix of public and private blobs. Two leaves sync: one with `x` capability gets all blobs, one without `x` gets only public blobs.
+
+#### Sim equivalence test (`sim/equivalence_test.go`)
+
+- `TestPrivateSyncAgainstFossilServe` — create Fossil repo with private branch, grant `x` to nobody, serve via `fossil serve`, sync with go-libfossil `Private: true`, verify private artifacts arrive.
+
+### 6. Files changed
+
+| File | Change |
+|------|--------|
+| `go-libfossil/content/private.go` | **New** — `IsPrivate`, `MakePrivate`, `MakePublic` |
+| `go-libfossil/content/private_test.go` | **New** — unit tests |
+| `go-libfossil/auth/auth.go` | Add `CanSyncPrivate` |
+| `go-libfossil/auth/auth_test.go` | Add `TestCanSyncPrivate` |
+| `go-libfossil/sync/session.go` | Add `Private` to `SyncOpts`, `nextIsPrivate` to session |
+| `go-libfossil/sync/client.go` | Private filtering in `sendUnclustered`, `sendAllClusters`, `buildFileCards`, `buildGimmeCards`, `processResponse`; new `sendPrivate()` |
+| `go-libfossil/sync/handler.go` | `syncPrivate`/`nextIsPrivate` fields, `pragma send-private`, `PrivateCard` handling, igot filtering, `MakePrivate`/`MakePublic` on receive |
+| `go-libfossil/sync/handler_test.go` | Handler tests for private sync |
+| `dst/scenario_test.go` | DST private sync scenario |
+| `sim/equivalence_test.go` | Equivalence test against real Fossil |
+
+### 7. Not in scope
+
+- **Shun table** — CDG-166 covers shun/private exclusions in cluster generation. This ticket focuses on sync protocol handling.
+- **Private branch creation UI** — creating private branches (tagging with `private`) is a separate concern from syncing them.
+- **`content_deltify` for private** — Fossil re-deltifies after making content public. Deferred.

--- a/docs/superpowers/specs/2026-03-25-private-branch-sync-design.md
+++ b/docs/superpowers/specs/2026-03-25-private-branch-sync-design.md
@@ -87,7 +87,13 @@ WHERE size >= 0
   AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
 ```
 
-When `s.opts.Private`, also call `sendPrivate()` which emits `igot UUID 1` for all private blobs.
+#### `sendPrivate`
+
+New function, called after `sendUnclustered` in `buildRequest` when `s.opts.Private`. Emits `igot UUID 1` for all private blobs:
+
+```sql
+SELECT uuid FROM private JOIN blob USING(rid) WHERE blob.size >= 0
+```
 
 #### `sendAllClusters`
 
@@ -95,9 +101,11 @@ Add same `NOT EXISTS(SELECT 1 FROM private ...)` filter.
 
 #### `buildFileCards`
 
-Before emitting a `FileCard` for a private blob, prepend a `PrivateCard`. Check `content.IsPrivate(db, rid)` when loading.
+Exclude private blobs from the unsent table query: `SELECT rid FROM unsent EXCEPT SELECT rid FROM private` (matches Fossil's `send_unsent`).
 
-Delta safety: when building a delta, skip if the delta source is private (use full content instead).
+Before emitting a `FileCard` for a private blob (from `pendingSend`), prepend a `PrivateCard`. Check `content.IsPrivate(db, rid)` when loading.
+
+Delta safety: when building a delta, skip if the delta source is private UNLESS `opts.Private` is true. Fossil allows deltas against private sources when both peers are in private sync mode (xfer.c line ~453).
 
 #### `buildGimmeCards`
 
@@ -110,10 +118,10 @@ AND NOT EXISTS(SELECT 1 FROM private WHERE rid=blob.rid)
 #### `processResponse`
 
 - **`PrivateCard`**: Set `s.nextIsPrivate = true`.
-- **`FileCard` / `CFileCard`**: After storing, if `s.nextIsPrivate`, call `content.MakePrivate`. Reset flag.
+- **`FileCard` / `CFileCard`**: After storing, if `s.nextIsPrivate`, call `content.MakePrivate` and reset flag. If `!s.nextIsPrivate`, call `content.MakePublic` (a public artifact clears any prior private status).
 - **`IGotCard` with `IsPrivate`**:
-  - If `s.opts.Private`: create private phantom (request it).
-  - If `!s.opts.Private`: if blob exists locally, call `content.MakePrivate`. Don't create phantom (don't request).
+  - If `s.opts.Private`: create private phantom (request it), call `MakePrivate`.
+  - If `!s.opts.Private`: if blob exists locally, call `content.MakePrivate`. Do NOT create phantom (don't request it).
 
 ### 4. Server-side — `sync/handler.go`
 
@@ -152,6 +160,7 @@ case *xfer.PrivateCard:
         h.resp = append(h.resp, &xfer.ErrorCard{
             Message: "not authorized to sync private content",
         })
+        h.nextIsPrivate = false // ensure flag is NOT set on auth failure
     } else {
         h.nextIsPrivate = true
     }
@@ -211,6 +220,12 @@ Respect `IsPrivate` flag:
 - `TestSyncPrivateFileCardPrefix` — private file cards preceded by `PrivateCard`.
 - `TestSyncExcludesPrivateByDefault` — `Private: false` excludes private from igot/gimme.
 
+#### Integration tests
+
+- `TestSyncPrivateArtifactTransition` — receive blob as private, then receive same UUID as public. Verify `MakePublic` clears private status.
+- `TestSyncPrivateDeltaSource` — delta against private artifact is sent as full content when `Private: false`, but as delta when `Private: true`.
+- `TestSyncMixedPrivatePublic` — sync with a mix of private and public artifacts. Verify igot filtering works correctly.
+
 #### DST scenario (`dst/scenario_test.go`)
 
 - `TestScenarioPrivateSync` — master has mix of public and private blobs. Two leaves sync: one with `x` capability gets all blobs, one without `x` gets only public blobs.
@@ -218,6 +233,11 @@ Respect `IsPrivate` flag:
 #### Sim equivalence test (`sim/equivalence_test.go`)
 
 - `TestPrivateSyncAgainstFossilServe` — create Fossil repo with private branch, grant `x` to nobody, serve via `fossil serve`, sync with go-libfossil `Private: true`, verify private artifacts arrive.
+
+#### Clone tests
+
+- `TestCloneExcludesPrivate` — clone without `Private: true` excludes private artifacts.
+- `TestCloneIncludesPrivateWhenAuthorized` — clone with `Private: true` and `x` capability includes private artifacts with `private\n` prefix.
 
 ### 6. Files changed
 
@@ -239,3 +259,5 @@ Respect `IsPrivate` flag:
 - **Shun table** — CDG-166 covers shun/private exclusions in cluster generation. This ticket focuses on sync protocol handling.
 - **Private branch creation UI** — creating private branches (tagging with `private`) is a separate concern from syncing them.
 - **`content_deltify` for private** — Fossil re-deltifies after making content public. Deferred.
+- **`remoteDate` backward compatibility** — Fossil checks `remoteDate>=20200413` before emitting `igot UUID 1` to avoid confusing older clients. go-libfossil always emits `igot UUID 1` for private artifacts, assuming all peers are go-libfossil or modern Fossil (2020+).
+- **Observer/telemetry counters** — `RoundStats.PrivateIGotsSent` (matching Fossil's `nPrivIGot`) is deferred to a follow-up.

--- a/dst/scenario_test.go
+++ b/dst/scenario_test.go
@@ -632,6 +632,20 @@ func TestDST(t *testing.T) {
 			[]byte(fmt.Sprintf("sweep-content-%d-seed%d", i, seed)), int64(100+i))
 	}
 
+	// Seed private blobs so sweep exercises private sync paths.
+	for i := range 3 {
+		data := []byte(fmt.Sprintf("dst-private-%04d-seed%d", i, seed))
+		masterRepo.WithTx(func(tx *db.Tx) error {
+			rid, _, err := blob.Store(tx, data)
+			if err != nil {
+				return err
+			}
+			return content.MakePrivate(tx, int64(rid))
+		})
+	}
+	// Grant 'x' capability to nobody for private sync.
+	masterRepo.DB().Exec("UPDATE user SET cap='oixy' WHERE login='nobody'")
+
 	sim, err := New(SimConfig{
 		Seed:         seed,
 		NumLeaves:    3,
@@ -640,6 +654,7 @@ func TestDST(t *testing.T) {
 		Upstream:     mf,
 		Buggify:      sev.Buggify,
 		UV:           true,
+		Private:      true,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -682,6 +697,14 @@ func TestDST(t *testing.T) {
 		}
 		if err := sim.CheckAllUVConverged(masterRepo); err != nil {
 			t.Fatalf("UV convergence violation at seed=%d: %v", seed, err)
+		}
+		// Check private blob convergence: all leaves should have private blobs.
+		for _, id := range sim.LeafIDs() {
+			var n int
+			sim.Leaf(id).Repo().DB().QueryRow("SELECT count(*) FROM private").Scan(&n)
+			if n == 0 {
+				t.Errorf("Private convergence: %s has no private blobs at seed=%d", id, seed)
+			}
 		}
 	}
 

--- a/dst/scenario_test.go
+++ b/dst/scenario_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dmestas/edgesync/go-libfossil/db"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
+	libsync "github.com/dmestas/edgesync/go-libfossil/sync"
 	"github.com/dmestas/edgesync/go-libfossil/uv"
 	"github.com/dmestas/edgesync/leaf/agent"
 )
@@ -1486,6 +1487,155 @@ func hashPW(projectCode, login, password string) string {
 }
 
 // --- helpers ---
+
+// --- Scenario: Private Sync ---
+// Master has public + private blobs. Two leaves sync: one with 'x'
+// capability (Private: true), one without. Only the authorized leaf
+// gets private blobs.
+
+func TestScenarioPrivateSync(t *testing.T) {
+	seed := seedFor(40)
+
+	masterRepo := createMasterRepo(t)
+	mf := NewMockFossil(masterRepo)
+
+	// Grant nobody pull + push + private sync capability.
+	masterRepo.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	// Seed 5 public blobs in master.
+	publicUUIDs := make([]string, 5)
+	for i := range 5 {
+		uuid, err := mf.StoreArtifact([]byte(fmt.Sprintf("private-sync-public-%d-seed%d", i, seed)))
+		if err != nil {
+			t.Fatalf("StoreArtifact public: %v", err)
+		}
+		publicUUIDs[i] = uuid
+	}
+
+	// Seed 3 private blobs in master.
+	privateUUIDs := make([]string, 3)
+	for i := range 3 {
+		data := []byte(fmt.Sprintf("private-sync-secret-%d-seed%d", i, seed))
+		var uuid string
+		masterRepo.WithTx(func(tx *db.Tx) error {
+			rid, u, err := blob.Store(tx, data)
+			if err != nil {
+				return err
+			}
+			uuid = u
+			return content.MakePrivate(tx, int64(rid))
+		})
+		privateUUIDs[i] = uuid
+	}
+
+	masterCount, _ := CountBlobs(masterRepo)
+	t.Logf("master: %d total blobs (%d public, %d private)",
+		masterCount, len(publicUUIDs), len(privateUUIDs))
+
+	// Read master's project-code and server-code.
+	var projCode, srvCode string
+	masterRepo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+	masterRepo.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&srvCode)
+
+	// Create two leaf repos with matching project code.
+	tmpDir := t.TempDir()
+	simRand := simio.NewSeededRand(seed)
+
+	leafPrivPath := filepath.Join(tmpDir, "leaf-priv.fossil")
+	leafPriv, err := repo.Create(leafPrivPath, "user", simRand)
+	if err != nil {
+		t.Fatalf("create leaf-priv: %v", err)
+	}
+	t.Cleanup(func() { leafPriv.Close() })
+	leafPriv.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	leafPubPath := filepath.Join(tmpDir, "leaf-pub.fossil")
+	leafPub, err := repo.Create(leafPubPath, "user", simRand)
+	if err != nil {
+		t.Fatalf("create leaf-pub: %v", err)
+	}
+	t.Cleanup(func() { leafPub.Close() })
+	leafPub.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	ctx := context.Background()
+
+	// Sync leaf-priv with Private=true (authorized).
+	for round := 0; round < 10; round++ {
+		result, err := libsync.Sync(ctx, leafPriv, mf, libsync.SyncOpts{
+			Pull:        true,
+			Push:        true,
+			Private:     true,
+			ProjectCode: projCode,
+			ServerCode:  srvCode,
+		})
+		if err != nil {
+			t.Fatalf("leaf-priv sync round %d: %v", round, err)
+		}
+		if result.FilesSent == 0 && result.FilesRecvd == 0 {
+			t.Logf("leaf-priv converged at outer round %d", round)
+			break
+		}
+	}
+
+	// Sync leaf-pub with Private=false (no private sync).
+	for round := 0; round < 10; round++ {
+		result, err := libsync.Sync(ctx, leafPub, mf, libsync.SyncOpts{
+			Pull:        true,
+			Push:        true,
+			Private:     false,
+			ProjectCode: projCode,
+			ServerCode:  srvCode,
+		})
+		if err != nil {
+			t.Fatalf("leaf-pub sync round %d: %v", round, err)
+		}
+		if result.FilesSent == 0 && result.FilesRecvd == 0 {
+			t.Logf("leaf-pub converged at outer round %d", round)
+			break
+		}
+	}
+
+	// Verify leaf-priv has ALL blobs (public + private).
+	for _, uuid := range publicUUIDs {
+		if !HasBlob(leafPriv, uuid) {
+			t.Errorf("leaf-priv missing public blob %s", uuid)
+		}
+	}
+	for _, uuid := range privateUUIDs {
+		rid, ok := blob.Exists(leafPriv.DB(), uuid)
+		if !ok {
+			t.Errorf("leaf-priv missing private blob %s", uuid)
+			continue
+		}
+		if !content.IsPrivate(leafPriv.DB(), int64(rid)) {
+			t.Errorf("leaf-priv: blob %s should be in private table", uuid)
+		}
+	}
+
+	// Verify leaf-pub has ONLY public blobs.
+	for _, uuid := range publicUUIDs {
+		if !HasBlob(leafPub, uuid) {
+			t.Errorf("leaf-pub missing public blob %s", uuid)
+		}
+	}
+	for _, uuid := range privateUUIDs {
+		if HasBlob(leafPub, uuid) {
+			t.Errorf("leaf-pub should NOT have private blob %s", uuid)
+		}
+	}
+
+	// Safety: blob integrity on both leaves.
+	if err := CheckBlobIntegrity("leaf-priv", leafPriv); err != nil {
+		t.Fatalf("leaf-priv integrity: %v", err)
+	}
+	if err := CheckBlobIntegrity("leaf-pub", leafPub); err != nil {
+		t.Fatalf("leaf-pub integrity: %v", err)
+	}
+
+	privCount, _ := CountBlobs(leafPriv)
+	pubCount, _ := CountBlobs(leafPub)
+	t.Logf("leaf-priv: %d blobs, leaf-pub: %d blobs", privCount, pubCount)
+}
 
 func createMasterRepoAt(t *testing.T, path string) *repo.Repo {
 	t.Helper()

--- a/dst/simulator.go
+++ b/dst/simulator.go
@@ -62,6 +62,7 @@ type SimConfig struct {
 	Upstream            sync.Transport // mock Fossil master
 	Buggify             bool           // enable BUGGIFY fault injection
 	UV                  bool           // sync unversioned files
+	Private             bool           // sync private artifacts
 	SafetyCheckInterval int            // run CheckSafety() every N steps; 0 = disabled
 }
 
@@ -130,6 +131,7 @@ func New(cfg SimConfig) (*Simulator, error) {
 			Clock:        clock,
 			PollInterval: cfg.PollInterval,
 			UV:           cfg.UV,
+			Private:      cfg.Private,
 		}, r, transport, projCode, srvCode)
 
 		s.leaves[id] = a

--- a/go-libfossil/auth/auth.go
+++ b/go-libfossil/auth/auth.go
@@ -18,7 +18,8 @@ func HasCapability(caps string, required byte) bool {
 	return strings.IndexByte(caps, required) >= 0
 }
 
-func CanPush(caps string) bool   { return HasCapability(caps, 'i') }
-func CanPull(caps string) bool   { return HasCapability(caps, 'o') }
-func CanClone(caps string) bool  { return HasCapability(caps, 'g') }
-func CanPushUV(caps string) bool { return HasCapability(caps, 'y') }
+func CanPush(caps string) bool        { return HasCapability(caps, 'i') }
+func CanPull(caps string) bool        { return HasCapability(caps, 'o') }
+func CanClone(caps string) bool       { return HasCapability(caps, 'g') }
+func CanPushUV(caps string) bool      { return HasCapability(caps, 'y') }
+func CanSyncPrivate(caps string) bool { return HasCapability(caps, 'x') }

--- a/go-libfossil/auth/auth_test.go
+++ b/go-libfossil/auth/auth_test.go
@@ -42,3 +42,9 @@ func TestCanPushUV(t *testing.T) {
 	if !CanPushUV("y") { t.Error("CanPushUV(y) should be true") }
 	if CanPushUV("oi") { t.Error("CanPushUV(oi) should be false") }
 }
+
+func TestCanSyncPrivate(t *testing.T) {
+	if !CanSyncPrivate("x") { t.Error("CanSyncPrivate(x) should be true") }
+	if CanSyncPrivate("oi") { t.Error("CanSyncPrivate(oi) should be false") }
+	if CanSyncPrivate("as") { t.Error("CanSyncPrivate(as) should be false — x must be explicit") }
+}

--- a/go-libfossil/content/private.go
+++ b/go-libfossil/content/private.go
@@ -1,0 +1,33 @@
+package content
+
+import (
+	"github.com/dmestas/edgesync/go-libfossil/db"
+)
+
+// IsPrivate returns true if the blob with the given rid is in the private table.
+func IsPrivate(q db.Querier, rid int64) bool {
+	if q == nil {
+		panic("content.IsPrivate: q must not be nil")
+	}
+	var n int
+	err := q.QueryRow("SELECT 1 FROM private WHERE rid=?", rid).Scan(&n)
+	return err == nil
+}
+
+// MakePrivate inserts the rid into the private table (no-op if already present).
+func MakePrivate(q db.Querier, rid int64) error {
+	if q == nil {
+		panic("content.MakePrivate: q must not be nil")
+	}
+	_, err := q.Exec("INSERT OR IGNORE INTO private(rid) VALUES(?)", rid)
+	return err
+}
+
+// MakePublic removes the rid from the private table (no-op if not present).
+func MakePublic(q db.Querier, rid int64) error {
+	if q == nil {
+		panic("content.MakePublic: q must not be nil")
+	}
+	_, err := q.Exec("DELETE FROM private WHERE rid=?", rid)
+	return err
+}

--- a/go-libfossil/content/private.go
+++ b/go-libfossil/content/private.go
@@ -9,6 +9,9 @@ func IsPrivate(q db.Querier, rid int64) bool {
 	if q == nil {
 		panic("content.IsPrivate: q must not be nil")
 	}
+	if rid <= 0 {
+		panic("content.IsPrivate: rid must be positive")
+	}
 	var n int
 	err := q.QueryRow("SELECT 1 FROM private WHERE rid=?", rid).Scan(&n)
 	return err == nil
@@ -19,6 +22,9 @@ func MakePrivate(q db.Querier, rid int64) error {
 	if q == nil {
 		panic("content.MakePrivate: q must not be nil")
 	}
+	if rid <= 0 {
+		panic("content.MakePrivate: rid must be positive")
+	}
 	_, err := q.Exec("INSERT OR IGNORE INTO private(rid) VALUES(?)", rid)
 	return err
 }
@@ -27,6 +33,9 @@ func MakePrivate(q db.Querier, rid int64) error {
 func MakePublic(q db.Querier, rid int64) error {
 	if q == nil {
 		panic("content.MakePublic: q must not be nil")
+	}
+	if rid <= 0 {
+		panic("content.MakePublic: rid must be positive")
 	}
 	_, err := q.Exec("DELETE FROM private WHERE rid=?", rid)
 	return err

--- a/go-libfossil/content/private_test.go
+++ b/go-libfossil/content/private_test.go
@@ -1,0 +1,56 @@
+package content
+
+import (
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	_ "github.com/dmestas/edgesync/go-libfossil/internal/testdriver"
+)
+
+func TestIsPrivate_NotPrivate(t *testing.T) {
+	d := setupTestDB(t)
+	rid, _, _ := blob.Store(d, []byte("public blob"))
+	if IsPrivate(d, int64(rid)) {
+		t.Error("blob should not be private by default")
+	}
+}
+
+func TestMakePrivate_ThenIsPrivate(t *testing.T) {
+	d := setupTestDB(t)
+	rid, _, _ := blob.Store(d, []byte("will be private"))
+	if err := MakePrivate(d, int64(rid)); err != nil {
+		t.Fatalf("MakePrivate: %v", err)
+	}
+	if !IsPrivate(d, int64(rid)) {
+		t.Error("blob should be private after MakePrivate")
+	}
+}
+
+func TestMakePrivate_Idempotent(t *testing.T) {
+	d := setupTestDB(t)
+	rid, _, _ := blob.Store(d, []byte("double private"))
+	MakePrivate(d, int64(rid))
+	if err := MakePrivate(d, int64(rid)); err != nil {
+		t.Fatalf("second MakePrivate should not error: %v", err)
+	}
+}
+
+func TestMakePublic_ClearsPrivate(t *testing.T) {
+	d := setupTestDB(t)
+	rid, _, _ := blob.Store(d, []byte("private then public"))
+	MakePrivate(d, int64(rid))
+	if err := MakePublic(d, int64(rid)); err != nil {
+		t.Fatalf("MakePublic: %v", err)
+	}
+	if IsPrivate(d, int64(rid)) {
+		t.Error("blob should not be private after MakePublic")
+	}
+}
+
+func TestMakePublic_NoopIfNotPrivate(t *testing.T) {
+	d := setupTestDB(t)
+	rid, _, _ := blob.Store(d, []byte("never private"))
+	if err := MakePublic(d, int64(rid)); err != nil {
+		t.Fatalf("MakePublic on non-private should not error: %v", err)
+	}
+}

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -443,15 +443,8 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 			if err := s.handleFileCard(c.UUID, c.DeltaSrc, c.Content); err != nil {
 				return false, err
 			}
-			if s.nextIsPrivate {
-				rid, _ := blob.Exists(s.repo.DB(), c.UUID)
-				content.MakePrivate(s.repo.DB(), int64(rid))
-				s.nextIsPrivate = false
-			} else {
-				rid, exists := blob.Exists(s.repo.DB(), c.UUID)
-				if exists {
-					content.MakePublic(s.repo.DB(), int64(rid))
-				}
+			if err := s.applyPrivateStatus(c.UUID); err != nil {
+				return false, err
 			}
 			filesRecvd++
 			s.roundStats.BytesReceived += int64(len(c.Content))
@@ -461,15 +454,8 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 			if err := s.handleFileCard(c.UUID, c.DeltaSrc, c.Content); err != nil {
 				return false, err
 			}
-			if s.nextIsPrivate {
-				rid, _ := blob.Exists(s.repo.DB(), c.UUID)
-				content.MakePrivate(s.repo.DB(), int64(rid))
-				s.nextIsPrivate = false
-			} else {
-				rid, exists := blob.Exists(s.repo.DB(), c.UUID)
-				if exists {
-					content.MakePublic(s.repo.DB(), int64(rid))
-				}
+			if err := s.applyPrivateStatus(c.UUID); err != nil {
+				return false, err
 			}
 			filesRecvd++
 			s.roundStats.BytesReceived += int64(len(c.Content))
@@ -480,13 +466,17 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 			rid, exists := blob.Exists(s.repo.DB(), c.UUID)
 			if c.IsPrivate {
 				if exists {
-					content.MakePrivate(s.repo.DB(), int64(rid))
+					if err := content.MakePrivate(s.repo.DB(), int64(rid)); err != nil {
+						return false, fmt.Errorf("sync: MakePrivate %s: %w", c.UUID, err)
+					}
 				} else if s.opts.Private && s.opts.Pull {
 					s.phantoms[c.UUID] = true
 				}
 			} else {
 				if exists {
-					content.MakePublic(s.repo.DB(), int64(rid))
+					if err := content.MakePublic(s.repo.DB(), int64(rid)); err != nil {
+						return false, fmt.Errorf("sync: MakePublic %s: %w", c.UUID, err)
+					}
 				} else if s.opts.Pull {
 					s.phantoms[c.UUID] = true
 				}
@@ -785,6 +775,27 @@ func (s *session) handleFileCard(uuid, deltaSrc string, payload []byte) error {
 		return fmt.Errorf("buggify: simulated storage failure for %s", uuid)
 	}
 
+	return nil
+}
+
+// applyPrivateStatus marks a just-stored blob as private or public based on
+// whether a PrivateCard preceded it. Extracted from FileCard/CFileCard handlers
+// to eliminate duplication.
+func (s *session) applyPrivateStatus(uuid string) error {
+	if s.nextIsPrivate {
+		rid, _ := blob.Exists(s.repo.DB(), uuid)
+		if err := content.MakePrivate(s.repo.DB(), int64(rid)); err != nil {
+			return fmt.Errorf("sync: MakePrivate %s: %w", uuid, err)
+		}
+		s.nextIsPrivate = false
+	} else {
+		rid, exists := blob.Exists(s.repo.DB(), uuid)
+		if exists {
+			if err := content.MakePublic(s.repo.DB(), int64(rid)); err != nil {
+				return fmt.Errorf("sync: MakePublic %s: %w", uuid, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -95,6 +95,22 @@ func (s *session) buildRequest(cycle int) (*xfer.Message, error) {
 	gimmeCards := s.buildGimmeCards()
 	cards = append(cards, gimmeCards...)
 
+	// Private: send pragma on first round
+	if cycle == 0 && s.opts.Private {
+		cards = append(cards, &xfer.PragmaCard{Name: "send-private"})
+	}
+
+	// Private: send igot cards for private blobs
+	if s.opts.Private {
+		privCards, err := s.sendPrivate()
+		if err != nil {
+			return nil, fmt.Errorf("buildRequest sendPrivate: %w", err)
+		}
+		s.igotSentThisRound += len(privCards)
+		s.roundStats.IgotsSent += len(privCards)
+		cards = append(cards, privCards...)
+	}
+
 	// UV: pragma uv-hash on first round
 	if s.opts.UV && !s.uvHashSent {
 		if err := uv.EnsureSchema(s.repo.DB()); err != nil {
@@ -208,6 +224,31 @@ func (s *session) sendAllClusters() ([]xfer.Card, error) {
 			continue
 		}
 		cards = append(cards, &xfer.IGotCard{UUID: uuid})
+	}
+	return cards, rows.Err()
+}
+
+// sendPrivate emits igot cards with IsPrivate=true for all blobs in the
+// private table. This advertises private artifacts to the server so it can
+// request them via gimme cards.
+func (s *session) sendPrivate() ([]xfer.Card, error) {
+	rows, err := s.repo.DB().Query(
+		"SELECT b.uuid FROM private p JOIN blob b ON p.rid=b.rid WHERE b.size >= 0",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sendPrivate: %w", err)
+	}
+	defer rows.Close()
+	var cards []xfer.Card
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return nil, err
+		}
+		if s.remoteHas[uuid] {
+			continue
+		}
+		cards = append(cards, &xfer.IGotCard{UUID: uuid, IsPrivate: true})
 	}
 	return cards, rows.Err()
 }

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -436,9 +436,22 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 
 	for _, card := range msg.Cards {
 		switch c := card.(type) {
+		case *xfer.PrivateCard:
+			s.nextIsPrivate = true
+
 		case *xfer.FileCard:
 			if err := s.handleFileCard(c.UUID, c.DeltaSrc, c.Content); err != nil {
 				return false, err
+			}
+			if s.nextIsPrivate {
+				rid, _ := blob.Exists(s.repo.DB(), c.UUID)
+				content.MakePrivate(s.repo.DB(), int64(rid))
+				s.nextIsPrivate = false
+			} else {
+				rid, exists := blob.Exists(s.repo.DB(), c.UUID)
+				if exists {
+					content.MakePublic(s.repo.DB(), int64(rid))
+				}
 			}
 			filesRecvd++
 			s.roundStats.BytesReceived += int64(len(c.Content))
@@ -448,15 +461,33 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 			if err := s.handleFileCard(c.UUID, c.DeltaSrc, c.Content); err != nil {
 				return false, err
 			}
+			if s.nextIsPrivate {
+				rid, _ := blob.Exists(s.repo.DB(), c.UUID)
+				content.MakePrivate(s.repo.DB(), int64(rid))
+				s.nextIsPrivate = false
+			} else {
+				rid, exists := blob.Exists(s.repo.DB(), c.UUID)
+				if exists {
+					content.MakePublic(s.repo.DB(), int64(rid))
+				}
+			}
 			filesRecvd++
 			s.roundStats.BytesReceived += int64(len(c.Content))
 			delete(s.phantoms, c.UUID)
 
 		case *xfer.IGotCard:
 			s.remoteHas[c.UUID] = true
-			if s.opts.Pull {
-				_, exists := blob.Exists(s.repo.DB(), c.UUID)
-				if !exists {
+			rid, exists := blob.Exists(s.repo.DB(), c.UUID)
+			if c.IsPrivate {
+				if exists {
+					content.MakePrivate(s.repo.DB(), int64(rid))
+				} else if s.opts.Private && s.opts.Pull {
+					s.phantoms[c.UUID] = true
+				}
+			} else {
+				if exists {
+					content.MakePublic(s.repo.DB(), int64(rid))
+				} else if s.opts.Pull {
 					s.phantoms[c.UUID] = true
 				}
 			}

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -95,8 +95,8 @@ func (s *session) buildRequest(cycle int) (*xfer.Message, error) {
 	gimmeCards := s.buildGimmeCards()
 	cards = append(cards, gimmeCards...)
 
-	// Private: send pragma on first round
-	if cycle == 0 && s.opts.Private {
+	// Private: send pragma every round (handler is stateless per-round).
+	if s.opts.Private {
 		cards = append(cards, &xfer.PragmaCard{Name: "send-private"})
 	}
 

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -232,6 +232,12 @@ func (s *session) sendAllClusters() ([]xfer.Card, error) {
 // private table. This advertises private artifacts to the server so it can
 // request them via gimme cards.
 func (s *session) sendPrivate() ([]xfer.Card, error) {
+	// BUGGIFY: 10% chance skip all private igots this round to test
+	// multi-round private convergence.
+	if s.opts.Buggify != nil && s.opts.Buggify.Check("sync.sendPrivate.skip", 0.10) {
+		return nil, nil
+	}
+
 	rows, err := s.repo.DB().Query(
 		"SELECT b.uuid FROM private p JOIN blob b ON p.rid=b.rid WHERE b.size >= 0",
 	)
@@ -783,6 +789,12 @@ func (s *session) handleFileCard(uuid, deltaSrc string, payload []byte) error {
 // to eliminate duplication.
 func (s *session) applyPrivateStatus(uuid string) error {
 	if s.nextIsPrivate {
+		// BUGGIFY: 3% chance skip MakePrivate — leave blob as public;
+		// the next sync round should correct the status.
+		if s.opts.Buggify != nil && s.opts.Buggify.Check("sync.applyPrivateStatus.skipMakePrivate", 0.03) {
+			s.nextIsPrivate = false
+			return nil
+		}
 		rid, _ := blob.Exists(s.repo.DB(), uuid)
 		if err := content.MakePrivate(s.repo.DB(), int64(rid)); err != nil {
 			return fmt.Errorf("sync: MakePrivate %s: %w", uuid, err)

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -268,6 +268,20 @@ func (s *session) buildFileCards() ([]xfer.Card, error) {
 		if budget <= 0 {
 			break
 		}
+
+		// Private filtering: check if blob is private.
+		rid, ridOK := blob.Exists(s.repo.DB(), uuid)
+		if ridOK {
+			isPriv := content.IsPrivate(s.repo.DB(), int64(rid))
+			if isPriv && !s.opts.Private {
+				delete(s.pendingSend, uuid)
+				continue
+			}
+			if isPriv {
+				cards = append(cards, &xfer.PrivateCard{})
+			}
+		}
+
 		card, size, err := s.loadFileCard(uuid)
 		if err != nil {
 			// Skip files we can't load (phantoms, etc.)
@@ -320,6 +334,15 @@ func (s *session) buildGimmeCards() []xfer.Card {
 	for uuid := range s.phantoms {
 		if count >= maxGimme {
 			break
+		}
+		// Best-effort private filtering: if the blob exists locally and is
+		// private but Private mode is off, skip it. Phantoms (not yet in DB)
+		// pass through — the server is the primary gate.
+		if !s.opts.Private {
+			rid, exists := blob.Exists(s.repo.DB(), uuid)
+			if exists && content.IsPrivate(s.repo.DB(), int64(rid)) {
+				continue
+			}
 		}
 		cards = append(cards, &xfer.GimmeCard{UUID: uuid})
 		s.roundStats.GimmesSent++

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -361,7 +361,11 @@ func (h *handler) handleGimme(c *xfer.GimmeCard) error {
 		return nil
 	}
 	if isPriv {
-		h.resp = append(h.resp, &xfer.PrivateCard{})
+		// BUGGIFY: 5% chance skip the PrivateCard prefix — client should
+		// treat the file as public; next sync round corrects the status.
+		if h.buggify == nil || !h.buggify.Check("handler.handleGimme.dropPrivateCard", 0.05) {
+			h.resp = append(h.resp, &xfer.PrivateCard{})
+		}
 	}
 	h.resp = append(h.resp, &xfer.FileCard{UUID: c.UUID, Content: data})
 	h.filesSent++
@@ -482,14 +486,27 @@ func (h *handler) emitPrivateIGots() error {
 	}
 	defer rows.Close()
 
+	var uuids []string
 	for rows.Next() {
 		var uuid string
 		if err := rows.Scan(&uuid); err != nil {
 			return err
 		}
+		uuids = append(uuids, uuid)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// BUGGIFY: 10% chance truncate private igot list to test multi-round convergence.
+	if h.buggify != nil && h.buggify.Check("handler.emitPrivateIGots.truncate", 0.10) && len(uuids) > 1 {
+		uuids = uuids[:len(uuids)/2]
+	}
+
+	for _, uuid := range uuids {
 		h.resp = append(h.resp, &xfer.IGotCard{UUID: uuid, IsPrivate: true})
 	}
-	return rows.Err()
+	return nil
 }
 
 // sendAllClusters emits igot cards for all cluster artifacts that are

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -314,10 +314,19 @@ func (h *handler) handleIGot(c *xfer.IGotCard) error {
 	if !h.pullOK {
 		return nil
 	}
-	_, exists := blob.Exists(h.repo.DB(), c.UUID)
-	if !exists {
-		h.resp = append(h.resp, &xfer.GimmeCard{UUID: c.UUID})
+	rid, exists := blob.Exists(h.repo.DB(), c.UUID)
+	if exists {
+		if c.IsPrivate {
+			content.MakePrivate(h.repo.DB(), int64(rid))
+		} else {
+			content.MakePublic(h.repo.DB(), int64(rid))
+		}
+		return nil
 	}
+	if c.IsPrivate && !h.syncPrivate {
+		return nil // not authorized — don't request
+	}
+	h.resp = append(h.resp, &xfer.GimmeCard{UUID: c.UUID})
 	return nil
 }
 

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -434,7 +434,35 @@ func (h *handler) emitIGots() error {
 	for _, uuid := range uuids {
 		h.resp = append(h.resp, &xfer.IGotCard{UUID: uuid})
 	}
+
+	if h.syncPrivate {
+		if err := h.emitPrivateIGots(); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// emitPrivateIGots emits igot cards with IsPrivate=true for all blobs in
+// the private table. Only called when the client sent pragma send-private
+// and has the 'x' capability.
+func (h *handler) emitPrivateIGots() error {
+	rows, err := h.repo.DB().Query(
+		"SELECT b.uuid FROM private p JOIN blob b ON p.rid=b.rid WHERE b.size >= 0",
+	)
+	if err != nil {
+		return fmt.Errorf("handler: listing private blobs: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			return err
+		}
+		h.resp = append(h.resp, &xfer.IGotCard{UUID: uuid, IsPrivate: true})
+	}
+	return rows.Err()
 }
 
 // sendAllClusters emits igot cards for all cluster artifacts that are

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -87,6 +87,8 @@ type handler struct {
 	reqClusters   bool // client sent pragma req-clusters
 	filesSent     int  // files sent in response (for observer)
 	filesRecvd    int  // files received from client (for observer)
+	syncPrivate   bool // true if pragma send-private was accepted
+	nextIsPrivate bool // true if a private card precedes the next file/cfile
 	syncedTables  map[string]*SyncedTable // cached table definitions
 	xrowsSent     int  // table sync rows sent
 	xrowsRecvd    int  // table sync rows received
@@ -224,6 +226,15 @@ func (h *handler) handleControlCard(card xfer.Card) {
 		}
 		if c.Name == "req-clusters" {
 			h.reqClusters = true
+		}
+		if c.Name == "send-private" {
+			if auth.CanSyncPrivate(h.caps) {
+				h.syncPrivate = true
+			} else {
+				h.resp = append(h.resp, &xfer.ErrorCard{
+					Message: "not authorized to sync private content",
+				})
+			}
 		}
 		// Acknowledge client-version, ignore other unknown pragmas.
 	case *xfer.PushCard:

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -342,12 +342,19 @@ func (h *handler) handleGimme(c *xfer.GimmeCard) error {
 	if !ok {
 		return nil // blob not found — not fatal, skip.
 	}
+	isPriv := content.IsPrivate(h.repo.DB(), int64(rid))
+	if isPriv && !h.syncPrivate {
+		return nil // private blob, client not authorized — skip.
+	}
 	data, err := content.Expand(h.repo.DB(), rid)
 	if err != nil {
 		h.resp = append(h.resp, &xfer.ErrorCard{
 			Message: fmt.Sprintf("expand %s: %v", c.UUID, err),
 		})
 		return nil
+	}
+	if isPriv {
+		h.resp = append(h.resp, &xfer.PrivateCard{})
 	}
 	h.resp = append(h.resp, &xfer.FileCard{UUID: c.UUID, Content: data})
 	h.filesSent++
@@ -510,8 +517,8 @@ func (h *handler) emitCloneBatch() error {
 	}
 
 	rows, err := h.repo.DB().Query(
-		"SELECT rid, uuid FROM blob WHERE rid > ? AND size >= 0 ORDER BY rid LIMIT ?",
-		h.cloneSeq, batchSize+1,
+		"SELECT rid, uuid FROM blob WHERE rid > ? AND size >= 0 ORDER BY rid",
+		h.cloneSeq,
 	)
 	if err != nil {
 		return fmt.Errorf("handler: clone batch: %w", err)
@@ -519,33 +526,45 @@ func (h *handler) emitCloneBatch() error {
 	defer rows.Close()
 
 	count := 0
-	var lastRID int
+	var lastSentRID int
+	more := false
 	for rows.Next() {
 		var rid int
 		var uuid string
 		if err := rows.Scan(&rid, &uuid); err != nil {
 			return err
 		}
-		if count >= batchSize {
-			if err := rows.Err(); err != nil {
-				return err
-			}
-			h.resp = append(h.resp, &xfer.CloneSeqNoCard{SeqNo: lastRID})
-			return nil
+
+		isPriv := content.IsPrivate(h.repo.DB(), int64(rid))
+		if isPriv && !h.syncPrivate {
+			continue // skip private blob, don't count toward batch
 		}
+
+		if count >= batchSize {
+			more = true
+			break
+		}
+
 		data, err := content.Expand(h.repo.DB(), libfossil.FslID(rid))
 		if err != nil {
 			return fmt.Errorf("handler: expanding rid %d: %w", rid, err)
 		}
+		if isPriv {
+			h.resp = append(h.resp, &xfer.PrivateCard{})
+		}
 		h.resp = append(h.resp, &xfer.FileCard{UUID: uuid, Content: data})
 		h.filesSent++
-		lastRID = rid
+		lastSentRID = rid
 		count++
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	// All blobs sent — signal completion so the client stops requesting.
-	h.resp = append(h.resp, &xfer.CloneSeqNoCard{SeqNo: 0})
+	if more {
+		h.resp = append(h.resp, &xfer.CloneSeqNoCard{SeqNo: lastSentRID})
+	} else {
+		// All blobs sent — signal completion so the client stops requesting.
+		h.resp = append(h.resp, &xfer.CloneSeqNoCard{SeqNo: 0})
+	}
 	return nil
 }

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -165,27 +165,38 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 		}
 	}
 
-	// Second pass: handle file cards (and private prefix) first so blobs
-	// are stored before IGotCard checks blob.Exists. Without this, a
-	// request containing both IGotCard and FileCard for the same blob
-	// produces a spurious GimmeCard — the IGotCard runs before the
-	// FileCard stores it.
-	for _, card := range req.Cards {
+	// Process data cards and emit response blobs.
+	if err := h.processDataCards(req.Cards); err != nil {
+		return nil, err
+	}
+
+	return &xfer.Message{Cards: h.resp}, nil
+}
+
+// processDataCards handles file, igot, gimme, and other data cards in the
+// correct order, then emits igot/clone batches. Extracted from process() to
+// keep each function under 70 lines.
+func (h *handler) processDataCards(cards []xfer.Card) error {
+	// File cards (and private prefix) first so blobs are stored before
+	// IGotCard checks blob.Exists. Without this, a request containing
+	// both IGotCard and FileCard for the same blob produces a spurious
+	// GimmeCard — the IGotCard runs before the FileCard stores it.
+	for _, card := range cards {
 		switch card.(type) {
 		case *xfer.FileCard, *xfer.CFileCard, *xfer.PrivateCard:
 			if err := h.handleDataCard(card); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
-	// Third pass: handle remaining data cards (igot, gimme, etc.).
-	for _, card := range req.Cards {
+	// Remaining data cards (igot, gimme, etc.).
+	for _, card := range cards {
 		switch card.(type) {
 		case *xfer.FileCard, *xfer.CFileCard, *xfer.PrivateCard:
 			continue // Already handled above.
 		default:
 			if err := h.handleDataCard(card); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
@@ -193,22 +204,20 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 	// If pull was requested, emit igot for all non-phantom blobs.
 	if h.pullOK {
 		if err := h.emitIGots(); err != nil {
-			return nil, err
+			return err
 		}
-		// Emit xigots for table sync.
 		if err := h.emitXIGots(); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	// If clone, emit paginated file cards.
 	if h.cloneMode {
 		if err := h.emitCloneBatch(); err != nil {
-			return nil, err
+			return err
 		}
 	}
-
-	return &xfer.Message{Cards: h.resp}, nil
+	return nil
 }
 
 func (h *handler) handleControlCard(card xfer.Card) {
@@ -384,10 +393,14 @@ func (h *handler) handleFile(uuid, deltaSrc string, payload []byte) error {
 	}
 	rid, _ := blob.Exists(h.repo.DB(), uuid)
 	if h.nextIsPrivate {
-		content.MakePrivate(h.repo.DB(), int64(rid))
+		if err := content.MakePrivate(h.repo.DB(), int64(rid)); err != nil {
+			return fmt.Errorf("handler: MakePrivate %s: %w", uuid, err)
+		}
 		h.nextIsPrivate = false
 	} else {
-		content.MakePublic(h.repo.DB(), int64(rid))
+		if err := content.MakePublic(h.repo.DB(), int64(rid)); err != nil {
+			return fmt.Errorf("handler: MakePublic %s: %w", uuid, err)
+		}
 	}
 	h.filesRecvd++
 	return nil

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -165,13 +165,14 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 		}
 	}
 
-	// Second pass: handle file cards first so blobs are stored before
-	// IGotCard checks blob.Exists. Without this, a request containing
-	// both IGotCard and FileCard for the same blob produces a spurious
-	// GimmeCard — the IGotCard runs before the FileCard stores it.
+	// Second pass: handle file cards (and private prefix) first so blobs
+	// are stored before IGotCard checks blob.Exists. Without this, a
+	// request containing both IGotCard and FileCard for the same blob
+	// produces a spurious GimmeCard — the IGotCard runs before the
+	// FileCard stores it.
 	for _, card := range req.Cards {
 		switch card.(type) {
-		case *xfer.FileCard, *xfer.CFileCard:
+		case *xfer.FileCard, *xfer.CFileCard, *xfer.PrivateCard:
 			if err := h.handleDataCard(card); err != nil {
 				return nil, err
 			}
@@ -180,7 +181,7 @@ func (h *handler) process(_ context.Context, req *xfer.Message) (*xfer.Message, 
 	// Third pass: handle remaining data cards (igot, gimme, etc.).
 	for _, card := range req.Cards {
 		switch card.(type) {
-		case *xfer.FileCard, *xfer.CFileCard:
+		case *xfer.FileCard, *xfer.CFileCard, *xfer.PrivateCard:
 			continue // Already handled above.
 		default:
 			if err := h.handleDataCard(card); err != nil {
@@ -278,6 +279,16 @@ func (h *handler) handleDataCard(card xfer.Card) error {
 		return h.handleFile(c.UUID, c.DeltaSrc, c.Content)
 	case *xfer.CFileCard:
 		return h.handleFile(c.UUID, c.DeltaSrc, c.Content)
+	case *xfer.PrivateCard:
+		if !auth.CanSyncPrivate(h.caps) {
+			h.resp = append(h.resp, &xfer.ErrorCard{
+				Message: "not authorized to sync private content",
+			})
+			h.nextIsPrivate = false
+		} else {
+			h.nextIsPrivate = true
+		}
+		return nil
 	case *xfer.ReqConfigCard:
 		return h.handleReqConfig(c)
 	case *xfer.UVIGotCard:
@@ -356,6 +367,13 @@ func (h *handler) handleFile(uuid, deltaSrc string, payload []byte) error {
 			Message: fmt.Sprintf("storing %s: %v", uuid, err),
 		})
 		return nil
+	}
+	rid, _ := blob.Exists(h.repo.DB(), uuid)
+	if h.nextIsPrivate {
+		content.MakePrivate(h.repo.DB(), int64(rid))
+		h.nextIsPrivate = false
+	} else {
+		content.MakePublic(h.repo.DB(), int64(rid))
 	}
 	h.filesRecvd++
 	return nil

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -314,13 +314,11 @@ func (h *handler) handleIGot(c *xfer.IGotCard) error {
 	if !h.pullOK {
 		return nil
 	}
-	rid, exists := blob.Exists(h.repo.DB(), c.UUID)
+	_, exists := blob.Exists(h.repo.DB(), c.UUID)
 	if exists {
-		if c.IsPrivate {
-			content.MakePrivate(h.repo.DB(), int64(rid))
-		} else {
-			content.MakePublic(h.repo.DB(), int64(rid))
-		}
+		// Server already has this blob — nothing to do.
+		// Server is authoritative for private status; do NOT apply
+		// the client's IsPrivate flag to the server's private table.
 		return nil
 	}
 	if c.IsPrivate && !h.syncPrivate {

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -1013,3 +1013,66 @@ func TestEmitIGotsIncludesPrivateWhenAuthorized(t *testing.T) {
 		t.Error("private blob should be included when send-private is authorized")
 	}
 }
+
+func TestHandlerIGotPrivate_Authorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+	unknownUUID := "dddddddddddddddddddddddddddddddddddddd"
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+		&xfer.IGotCard{UUID: unknownUUID, IsPrivate: true},
+	)
+
+	gimmes := findCards[*xfer.GimmeCard](resp)
+	found := false
+	for _, g := range gimmes {
+		if g.UUID == unknownUUID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("authorized private igot should produce gimme")
+	}
+}
+
+func TestHandlerIGotPrivate_Unauthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'")
+	unknownUUID := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.IGotCard{UUID: unknownUUID, IsPrivate: true},
+	)
+
+	gimmes := findCards[*xfer.GimmeCard](resp)
+	for _, g := range gimmes {
+		if g.UUID == unknownUUID {
+			t.Error("unauthorized private igot should NOT produce gimme")
+		}
+	}
+}
+
+func TestHandlerIGotPublic_ClearsPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	// Store a blob and mark it private.
+	data := []byte("igot clears private")
+	uuid := storeTestBlob(t, r, data)
+	rid, _ := blob.Exists(r.DB(), uuid)
+	content.MakePrivate(r.DB(), int64(rid))
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Fatal("precondition: blob should be private")
+	}
+
+	// Send a public igot for the existing blob.
+	handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.IGotCard{UUID: uuid, IsPrivate: false},
+	)
+
+	if content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("public igot should clear private flag on existing blob")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -1076,3 +1076,113 @@ func TestHandlerIGotPublic_ClearsPrivate(t *testing.T) {
 		t.Error("public igot should clear private flag on existing blob")
 	}
 }
+
+func TestHandleGimmePrivate_Authorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+	data := []byte("gimme private blob")
+	uuid := storeTestBlob(t, r, data)
+	rid, _ := blob.Exists(r.DB(), uuid)
+	content.MakePrivate(r.DB(), int64(rid))
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+		&xfer.GimmeCard{UUID: uuid},
+	)
+
+	// Should get PrivateCard followed by FileCard.
+	files := findCards[*xfer.FileCard](resp)
+	found := false
+	for _, f := range files {
+		if f.UUID == uuid {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("authorized gimme for private blob should return file")
+	}
+	privCards := findCards[*xfer.PrivateCard](resp)
+	if len(privCards) == 0 {
+		t.Error("expected PrivateCard prefix before private file")
+	}
+}
+
+func TestHandleGimmePrivate_Unauthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'")
+	data := []byte("gimme private unauthorized")
+	uuid := storeTestBlob(t, r, data)
+	rid, _ := blob.Exists(r.DB(), uuid)
+	content.MakePrivate(r.DB(), int64(rid))
+
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.GimmeCard{UUID: uuid},
+	)
+
+	files := findCards[*xfer.FileCard](resp)
+	for _, f := range files {
+		if f.UUID == uuid {
+			t.Error("unauthorized gimme for private blob should NOT return file")
+		}
+	}
+}
+
+func TestEmitCloneBatchSkipsPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	pubData := []byte("clone public blob")
+	pubUUID := storeTestBlob(t, r, pubData)
+	privData := []byte("clone private blob")
+	privUUID := storeTestBlob(t, r, privData)
+	privRid, _ := blob.Exists(r.DB(), privUUID)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	resp := handleReq(t, r,
+		&xfer.CloneCard{Version: 1},
+	)
+
+	files := findCards[*xfer.FileCard](resp)
+	fileUUIDs := make(map[string]bool)
+	for _, f := range files {
+		fileUUIDs[f.UUID] = true
+	}
+	if !fileUUIDs[pubUUID] {
+		t.Error("public blob missing from clone batch")
+	}
+	if fileUUIDs[privUUID] {
+		t.Error("private blob should be excluded from clone batch without send-private")
+	}
+}
+
+func TestEmitCloneBatchIncludesPrivateWhenAuthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='gx' WHERE login='nobody'")
+	pubData := []byte("clone pub auth")
+	pubUUID := storeTestBlob(t, r, pubData)
+	privData := []byte("clone priv auth")
+	privUUID := storeTestBlob(t, r, privData)
+	privRid, _ := blob.Exists(r.DB(), privUUID)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	resp := handleReq(t, r,
+		&xfer.CloneCard{Version: 1},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+
+	files := findCards[*xfer.FileCard](resp)
+	fileUUIDs := make(map[string]bool)
+	for _, f := range files {
+		fileUUIDs[f.UUID] = true
+	}
+	if !fileUUIDs[pubUUID] {
+		t.Error("public blob missing from clone batch")
+	}
+	if !fileUUIDs[privUUID] {
+		t.Error("private blob should be included when send-private authorized")
+	}
+	privCards := findCards[*xfer.PrivateCard](resp)
+	if len(privCards) == 0 {
+		t.Error("expected PrivateCard prefix for private blob in clone batch")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -1055,10 +1055,10 @@ func TestHandlerIGotPrivate_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestHandlerIGotPublic_ClearsPrivate(t *testing.T) {
+func TestHandlerIGotDoesNotChangeServerPrivateStatus(t *testing.T) {
 	r := setupSyncTestRepo(t)
 	// Store a blob and mark it private.
-	data := []byte("igot clears private")
+	data := []byte("igot does not change server private status")
 	uuid := storeTestBlob(t, r, data)
 	rid, _ := blob.Exists(r.DB(), uuid)
 	content.MakePrivate(r.DB(), int64(rid))
@@ -1066,14 +1066,15 @@ func TestHandlerIGotPublic_ClearsPrivate(t *testing.T) {
 		t.Fatal("precondition: blob should be private")
 	}
 
-	// Send a public igot for the existing blob.
+	// Client sends a public igot for the existing blob.
+	// Server is authoritative — this should NOT change the server's private status.
 	handleReq(t, r,
 		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
 		&xfer.IGotCard{UUID: uuid, IsPrivate: false},
 	)
 
-	if content.IsPrivate(r.DB(), int64(rid)) {
-		t.Error("public igot should clear private flag on existing blob")
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("server private status should not be changed by client igot")
 	}
 }
 

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -831,3 +831,38 @@ func TestEmitIGots_ExcludesShunAndPrivate(t *testing.T) {
 		t.Error("private blob appeared in igots")
 	}
 }
+
+func TestHandlerPragmaSendPrivate_Accepted(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+	for _, c := range resp.Cards {
+		if e, ok := c.(*xfer.ErrorCard); ok {
+			if e.Message == "not authorized to sync private content" {
+				t.Error("should not get auth error with 'x' capability")
+			}
+		}
+	}
+}
+
+func TestHandlerPragmaSendPrivate_Rejected(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'")
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+	errors := findCards[*xfer.ErrorCard](resp)
+	found := false
+	for _, e := range errors {
+		if e.Message == "not authorized to sync private content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'not authorized to sync private content' error")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -866,3 +866,84 @@ func TestHandlerPragmaSendPrivate_Rejected(t *testing.T) {
 		t.Error("expected 'not authorized to sync private content' error")
 	}
 }
+
+func TestHandlerPrivateCardAccepted(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+	data := []byte("private blob data")
+	uuid := hash.SHA1(data)
+
+	resp := handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PrivateCard{},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	for _, c := range resp.Cards {
+		if e, ok := c.(*xfer.ErrorCard); ok {
+			t.Errorf("unexpected error: %s", e.Message)
+		}
+	}
+
+	rid, ok := blob.Exists(r.DB(), uuid)
+	if !ok {
+		t.Fatal("blob not stored")
+	}
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should be marked private")
+	}
+}
+
+func TestHandlerPrivateCardRejected(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oi' WHERE login='nobody'")
+	data := []byte("private blob rejected")
+	uuid := hash.SHA1(data)
+
+	resp := handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PrivateCard{},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	errors := findCards[*xfer.ErrorCard](resp)
+	found := false
+	for _, e := range errors {
+		if e.Message == "not authorized to sync private content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'not authorized to sync private content' error")
+	}
+}
+
+func TestHandlerPublicFileClearsPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	data := []byte("was private now public")
+	uuid := hash.SHA1(data)
+
+	// Pre-store as private.
+	storeReceivedFile(r, uuid, "", data)
+	rid, _ := blob.Exists(r.DB(), uuid)
+	content.MakePrivate(r.DB(), int64(rid))
+	if !content.IsPrivate(r.DB(), int64(rid)) {
+		t.Fatal("precondition: blob should be private")
+	}
+
+	// Push same blob WITHOUT private card — should clear private.
+	resp := handleReq(t, r,
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.FileCard{UUID: uuid, Content: data},
+	)
+
+	for _, c := range resp.Cards {
+		if e, ok := c.(*xfer.ErrorCard); ok {
+			t.Errorf("unexpected error: %s", e.Message)
+		}
+	}
+
+	if content.IsPrivate(r.DB(), int64(rid)) {
+		t.Error("blob should no longer be private after public file push")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -947,3 +947,69 @@ func TestHandlerPublicFileClearsPrivate(t *testing.T) {
 		t.Error("blob should no longer be private after public file push")
 	}
 }
+
+func TestEmitIGotsExcludesPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	pubUUID := storeTestBlob(t, r, []byte("public blob"))
+	privData := []byte("private blob for exclusion")
+	privUUID := storeTestBlob(t, r, privData)
+	privRid, _ := blob.Exists(r.DB(), privUUID)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	// Pull without send-private pragma — private blob should be excluded.
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+	)
+
+	igotUUIDs := make(map[string]bool)
+	for _, c := range resp.Cards {
+		if ig, ok := c.(*xfer.IGotCard); ok {
+			igotUUIDs[ig.UUID] = true
+		}
+	}
+	if !igotUUIDs[pubUUID] {
+		t.Error("public blob missing from igots")
+	}
+	if igotUUIDs[privUUID] {
+		t.Error("private blob should be excluded from igots without send-private")
+	}
+}
+
+func TestEmitIGotsIncludesPrivateWhenAuthorized(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	r.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	pubUUID := storeTestBlob(t, r, []byte("public blob auth"))
+	privData := []byte("private blob auth")
+	privUUID := storeTestBlob(t, r, privData)
+	privRid, _ := blob.Exists(r.DB(), privUUID)
+	content.MakePrivate(r.DB(), int64(privRid))
+
+	// Pull WITH send-private pragma and x capability.
+	resp := handleReq(t, r,
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PragmaCard{Name: "send-private"},
+	)
+
+	pubFound := false
+	privFound := false
+	for _, c := range resp.Cards {
+		if ig, ok := c.(*xfer.IGotCard); ok {
+			if ig.UUID == pubUUID {
+				pubFound = true
+			}
+			if ig.UUID == privUUID {
+				if !ig.IsPrivate {
+					t.Error("private blob igot should have IsPrivate=true")
+				}
+				privFound = true
+			}
+		}
+	}
+	if !pubFound {
+		t.Error("public blob missing from igots")
+	}
+	if !privFound {
+		t.Error("private blob should be included when send-private is authorized")
+	}
+}

--- a/go-libfossil/sync/handler_test.go
+++ b/go-libfossil/sync/handler_test.go
@@ -1186,3 +1186,55 @@ func TestEmitCloneBatchIncludesPrivateWhenAuthorized(t *testing.T) {
 		t.Error("expected PrivateCard prefix for private blob in clone batch")
 	}
 }
+
+func TestSendAllClustersExcludesPrivate(t *testing.T) {
+	r := setupSyncTestRepo(t)
+
+	// Store 200 blobs so clustering triggers.
+	for i := 0; i < 200; i++ {
+		data := []byte(fmt.Sprintf("cluster-priv-blob-%04d", i))
+		if _, _, err := blob.Store(r.DB(), data); err != nil {
+			t.Fatalf("Store blob %d: %v", i, err)
+		}
+	}
+
+	n, err := content.GenerateClusters(r.DB())
+	if err != nil {
+		t.Fatalf("GenerateClusters: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected at least 1 cluster")
+	}
+
+	// Mark the cluster artifact itself as private.
+	var clusterRid int
+	err = r.DB().QueryRow(`
+		SELECT tx.rid FROM tagxref tx
+		WHERE tx.tagid = 7
+		LIMIT 1`,
+	).Scan(&clusterRid)
+	if err != nil {
+		t.Fatalf("find cluster rid: %v", err)
+	}
+	content.MakePrivate(r.DB(), int64(clusterRid))
+
+	resp, err := HandleSync(context.Background(), r, &xfer.Message{
+		Cards: []xfer.Card{
+			&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+			&xfer.PragmaCard{Name: "req-clusters"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// The private cluster should not appear in igots.
+	var clusterUUID string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", clusterRid).Scan(&clusterUUID)
+
+	for _, c := range resp.Cards {
+		if ig, ok := c.(*xfer.IGotCard); ok && ig.UUID == clusterUUID {
+			t.Error("private cluster blob should be excluded from sendAllClusters")
+		}
+	}
+}

--- a/go-libfossil/sync/private_test.go
+++ b/go-libfossil/sync/private_test.go
@@ -1,0 +1,284 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/hash"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+	"github.com/dmestas/edgesync/go-libfossil/xfer"
+	_ "github.com/dmestas/edgesync/go-libfossil/internal/testdriver"
+)
+
+// newPrivateTestPair creates a server and client repo with matching project code.
+// The server's nobody user is granted the given capabilities.
+func newPrivateTestPair(t *testing.T, nobodyCaps string) (server, client *repo.Repo) {
+	t.Helper()
+	dir := t.TempDir()
+
+	sPath := filepath.Join(dir, "server.fossil")
+	s, err := repo.Create(sPath, "test", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("server repo: %v", err)
+	}
+
+	cPath := filepath.Join(dir, "client.fossil")
+	c, err := repo.Create(cPath, "test", simio.CryptoRand{})
+	if err != nil {
+		t.Fatalf("client repo: %v", err)
+	}
+
+	// Match project codes so sync works.
+	var projCode string
+	s.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+	c.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	// Set nobody capabilities on server.
+	s.DB().Exec("UPDATE user SET cap=? WHERE login='nobody'", nobodyCaps)
+
+	t.Cleanup(func() {
+		s.Close()
+		c.Close()
+	})
+	return s, c
+}
+
+// syncViaHandler runs sync.Sync using a MockTransport backed by HandleSync.
+func syncViaHandler(t *testing.T, serverRepo, clientRepo *repo.Repo, opts SyncOpts) *SyncResult {
+	t.Helper()
+	transport := &MockTransport{Handler: func(req *xfer.Message) *xfer.Message {
+		resp, err := HandleSync(context.Background(), serverRepo, req)
+		if err != nil {
+			t.Fatalf("HandleSync: %v", err)
+		}
+		return resp
+	}}
+
+	var srvCode string
+	serverRepo.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&srvCode)
+	opts.ServerCode = srvCode
+
+	var projCode string
+	serverRepo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+	opts.ProjectCode = projCode
+
+	result, err := Sync(context.Background(), clientRepo, transport, opts)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	return result
+}
+
+func TestSyncPrivateEndToEnd(t *testing.T) {
+	// Server has 3 public blobs and 2 private blobs.
+	// Client with Private=false gets only public.
+	// Client with Private=true gets all.
+
+	t.Run("without_private_flag", func(t *testing.T) {
+		serverRepo, clientRepo := newPrivateTestPair(t, "oix")
+
+		// Store 3 public blobs.
+		publicUUIDs := make([]string, 3)
+		for i := range 3 {
+			data := []byte(fmt.Sprintf("public-blob-%d", i))
+			_, uuid, err := blob.Store(serverRepo.DB(), data)
+			if err != nil {
+				t.Fatalf("blob.Store public: %v", err)
+			}
+			publicUUIDs[i] = uuid
+		}
+
+		// Store 2 private blobs.
+		privateUUIDs := make([]string, 2)
+		for i := range 2 {
+			data := []byte(fmt.Sprintf("private-blob-%d", i))
+			rid, uuid, err := blob.Store(serverRepo.DB(), data)
+			if err != nil {
+				t.Fatalf("blob.Store private: %v", err)
+			}
+			if err := content.MakePrivate(serverRepo.DB(), int64(rid)); err != nil {
+				t.Fatalf("MakePrivate: %v", err)
+			}
+			privateUUIDs[i] = uuid
+		}
+
+		// Sync WITHOUT Private flag.
+		syncViaHandler(t, serverRepo, clientRepo, SyncOpts{
+			Pull:    true,
+			Push:    true,
+			Private: false,
+		})
+
+		// Public blobs should arrive.
+		for _, uuid := range publicUUIDs {
+			if _, ok := blob.Exists(clientRepo.DB(), uuid); !ok {
+				t.Errorf("client missing public blob %s", uuid)
+			}
+		}
+
+		// Private blobs should NOT arrive.
+		for _, uuid := range privateUUIDs {
+			if _, ok := blob.Exists(clientRepo.DB(), uuid); ok {
+				t.Errorf("client has private blob %s without Private flag", uuid)
+			}
+		}
+	})
+
+	t.Run("with_private_flag", func(t *testing.T) {
+		serverRepo, clientRepo := newPrivateTestPair(t, "oix")
+
+		// Store 3 public blobs.
+		publicUUIDs := make([]string, 3)
+		for i := range 3 {
+			data := []byte(fmt.Sprintf("public-blob-priv-%d", i))
+			_, uuid, err := blob.Store(serverRepo.DB(), data)
+			if err != nil {
+				t.Fatalf("blob.Store public: %v", err)
+			}
+			publicUUIDs[i] = uuid
+		}
+
+		// Store 2 private blobs.
+		privateUUIDs := make([]string, 2)
+		privateRIDs := make([]int64, 2)
+		for i := range 2 {
+			data := []byte(fmt.Sprintf("private-blob-priv-%d", i))
+			rid, uuid, err := blob.Store(serverRepo.DB(), data)
+			if err != nil {
+				t.Fatalf("blob.Store private: %v", err)
+			}
+			if err := content.MakePrivate(serverRepo.DB(), int64(rid)); err != nil {
+				t.Fatalf("MakePrivate: %v", err)
+			}
+			privateUUIDs[i] = uuid
+			privateRIDs[i] = int64(rid)
+		}
+
+		// Sync WITH Private flag.
+		syncViaHandler(t, serverRepo, clientRepo, SyncOpts{
+			Pull:    true,
+			Push:    true,
+			Private: true,
+		})
+
+		// All public blobs should arrive.
+		for _, uuid := range publicUUIDs {
+			if _, ok := blob.Exists(clientRepo.DB(), uuid); !ok {
+				t.Errorf("client missing public blob %s", uuid)
+			}
+		}
+
+		// All private blobs should arrive AND be marked private on client.
+		for _, uuid := range privateUUIDs {
+			rid, ok := blob.Exists(clientRepo.DB(), uuid)
+			if !ok {
+				t.Errorf("client missing private blob %s", uuid)
+				continue
+			}
+			if !content.IsPrivate(clientRepo.DB(), int64(rid)) {
+				t.Errorf("blob %s should be in client's private table", uuid)
+			}
+		}
+
+		// Public blobs should NOT be in private table.
+		for _, uuid := range publicUUIDs {
+			rid, ok := blob.Exists(clientRepo.DB(), uuid)
+			if !ok {
+				continue
+			}
+			if content.IsPrivate(clientRepo.DB(), int64(rid)) {
+				t.Errorf("public blob %s should not be in private table", uuid)
+			}
+		}
+	})
+
+	t.Run("no_x_capability", func(t *testing.T) {
+		// Server's nobody lacks 'x' capability — pragma send-private rejected.
+		serverRepo, clientRepo := newPrivateTestPair(t, "oi") // no 'x'
+
+		// Store a private blob on server.
+		data := []byte("secret-no-cap")
+		rid, uuid, err := blob.Store(serverRepo.DB(), data)
+		if err != nil {
+			t.Fatalf("blob.Store: %v", err)
+		}
+		content.MakePrivate(serverRepo.DB(), int64(rid))
+
+		// Also store a public blob.
+		pubData := []byte("public-no-cap")
+		_, pubUUID, err := blob.Store(serverRepo.DB(), pubData)
+		if err != nil {
+			t.Fatalf("blob.Store public: %v", err)
+		}
+
+		// Sync with Private=true, but server denies it.
+		syncViaHandler(t, serverRepo, clientRepo, SyncOpts{
+			Pull:    true,
+			Push:    true,
+			Private: true,
+		})
+
+		// Public blob should arrive.
+		if _, ok := blob.Exists(clientRepo.DB(), pubUUID); !ok {
+			t.Error("client missing public blob")
+		}
+
+		// Private blob should NOT arrive (server denied send-private).
+		if _, ok := blob.Exists(clientRepo.DB(), uuid); ok {
+			t.Error("client has private blob despite lacking 'x' capability")
+		}
+	})
+}
+
+func TestSyncPrivateArtifactTransition(t *testing.T) {
+	// Server has a private blob. Client syncs with Private=true.
+	// Server makes it public. Client syncs again — private status clears.
+
+	serverRepo, clientRepo := newPrivateTestPair(t, "oix")
+
+	// Store a blob and mark private on server.
+	data := []byte("transitioning-artifact")
+	uuid := hash.SHA1(data)
+	rid, _, err := blob.Store(serverRepo.DB(), data)
+	if err != nil {
+		t.Fatalf("blob.Store: %v", err)
+	}
+	content.MakePrivate(serverRepo.DB(), int64(rid))
+
+	// Phase 1: sync with Private=true — client gets the private blob.
+	syncViaHandler(t, serverRepo, clientRepo, SyncOpts{
+		Pull:    true,
+		Push:    true,
+		Private: true,
+	})
+
+	clientRID, ok := blob.Exists(clientRepo.DB(), uuid)
+	if !ok {
+		t.Fatal("client missing blob after first sync")
+	}
+	if !content.IsPrivate(clientRepo.DB(), int64(clientRID)) {
+		t.Fatal("blob should be private on client after first sync")
+	}
+
+	// Phase 2: server makes blob public.
+	if err := content.MakePublic(serverRepo.DB(), int64(rid)); err != nil {
+		t.Fatalf("MakePublic: %v", err)
+	}
+
+	// Sync again — the server will emit igot without IsPrivate=true,
+	// and the client should clear the private status.
+	syncViaHandler(t, serverRepo, clientRepo, SyncOpts{
+		Pull:    true,
+		Push:    true,
+		Private: true,
+	})
+
+	if content.IsPrivate(clientRepo.DB(), int64(clientRID)) {
+		t.Error("blob should no longer be private on client after transition")
+	}
+}

--- a/go-libfossil/sync/session.go
+++ b/go-libfossil/sync/session.go
@@ -34,6 +34,7 @@ type SyncOpts struct {
 	User, Password          string
 	MaxSend                 int
 	UV                      bool              // enable unversioned file sync
+	Private                 bool              // enable private artifact sync
 	Env                     *simio.Env        // nil defaults to RealEnv
 	Buggify                 BuggifyChecker    // nil in production
 	Observer                Observer          // nil defaults to no-op
@@ -70,6 +71,7 @@ type session struct {
 	nUvGimmeSent        int
 	nUvFileRcvd         int
 	nGimmeRcvd          int // cumulative gimmes received across all rounds
+	nextIsPrivate       bool // true when a PrivateCard precedes the next file/cfile
 	roundStats          RoundStats
 	xTableHashSent map[string]bool            // table -> true if xtable-hash pragma sent
 	xTableGimmes   map[string]map[string]bool // table -> pkHash -> true

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -284,6 +284,7 @@ func (a *Agent) runSync(ctx context.Context) (*sync.SyncResult, error) {
 		Password:    a.config.Password,
 		Buggify:     a.config.Buggify,
 		UV:          a.config.UV,
+		Private:     a.config.Private,
 		Observer:    a.config.Observer,
 	}
 	return sync.Sync(ctx, a.repo, a.transport, opts)

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// UV enables syncing unversioned files (wiki, forum, attachments).
 	UV bool
 
+	// Private enables syncing private artifacts (requires 'x' capability).
+	Private bool
+
 	// PeerID uniquely identifies this agent in the peer registry.
 	// Defaults to hostname if not set.
 	PeerID string

--- a/sim/equivalence_test.go
+++ b/sim/equivalence_test.go
@@ -13,6 +13,8 @@ import (
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/auth"
+	"github.com/dmestas/edgesync/go-libfossil/blob"
+	"github.com/dmestas/edgesync/go-libfossil/content"
 	"github.com/dmestas/edgesync/go-libfossil/manifest"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/simio"
@@ -611,4 +613,158 @@ func testLeafToLeaf(t *testing.T, checkins []checkinFiles, expected map[string]s
 	leafB.Close()
 	leafBWorkDir := fossilCheckout(t, filepath.Join(dir, "leaf-b.fossil"))
 	assertFiles(t, leafBWorkDir, expected)
+}
+
+// TestPrivateSyncAgainstFossilServe verifies that go-libfossil's private sync
+// protocol works over real HTTP. Tests both our own ServeHTTP handler
+// (production code path) and optionally against real `fossil serve`.
+func TestPrivateSyncAgainstFossilServe(t *testing.T) {
+	requireFossil(t)
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	// Test against our own ServeHTTP (the production code path for leaf agents).
+	t.Run("leaf_http", func(t *testing.T) {
+		testPrivateSyncOverHTTP(t)
+	})
+}
+
+// testPrivateSyncOverHTTP creates a leaf repo with public + private blobs,
+// serves it via sync.ServeHTTP, and verifies two clients:
+//   - Private=true client gets all blobs, private ones in private table
+//   - Private=false client gets only public blobs
+func testPrivateSyncOverHTTP(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+
+	// 1. Create server repo with public and private blobs.
+	srcRepo := leafRepo(t, dir, "priv-server.fossil")
+
+	// Commit a file so the repo has real content (manifest + file blob).
+	checkin(t, srcRepo, 0, []manifest.File{
+		{Name: "public.txt", Content: []byte("public content")},
+	}, "public commit")
+	manifest.Crosslink(srcRepo)
+
+	// Grant nobody 'oix' capability for push, pull, private sync.
+	srcRepo.DB().Exec("UPDATE user SET cap='oix' WHERE login='nobody'")
+
+	// Store additional blobs: 2 public, 2 private.
+	var publicUUIDs, privateUUIDs []string
+	for i := range 2 {
+		data := []byte(fmt.Sprintf("extra-public-%d", i))
+		_, uuid, err := blob.Store(srcRepo.DB(), data)
+		if err != nil {
+			t.Fatalf("blob.Store: %v", err)
+		}
+		publicUUIDs = append(publicUUIDs, uuid)
+	}
+	for i := range 2 {
+		data := []byte(fmt.Sprintf("extra-private-%d", i))
+		rid, uuid, err := blob.Store(srcRepo.DB(), data)
+		if err != nil {
+			t.Fatalf("blob.Store: %v", err)
+		}
+		content.MakePrivate(srcRepo.DB(), int64(rid))
+		privateUUIDs = append(privateUUIDs, uuid)
+	}
+
+	var totalBlobs int
+	srcRepo.DB().QueryRow("SELECT count(*) FROM blob WHERE size >= 0").Scan(&totalBlobs)
+	t.Logf("server: %d total blobs, %d extra public, %d extra private",
+		totalBlobs, len(publicUUIDs), len(privateUUIDs))
+
+	// Read codes.
+	var projCode, srvCode string
+	srcRepo.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+	srcRepo.DB().QueryRow("SELECT value FROM config WHERE name='server-code'").Scan(&srvCode)
+
+	// Close and reopen so the HTTP server gets a clean handle.
+	srcRepo.Close()
+	srcReopened, err := repo.Open(filepath.Join(dir, "priv-server.fossil"))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer srcReopened.Close()
+
+	// 2. Serve over HTTP.
+	addr, cancel := serveLeafHTTP(t, srcReopened)
+	defer cancel()
+
+	transport := &sync.HTTPTransport{URL: fmt.Sprintf("http://%s", addr)}
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer ctxCancel()
+
+	// 3. Sync client with Private=true.
+	clientPriv := leafRepo(t, dir, "client-priv.fossil")
+	clientPriv.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	for round := 0; round < 10; round++ {
+		result, err := sync.Sync(ctx, clientPriv, transport, sync.SyncOpts{
+			Pull: true, Push: true, Private: true,
+			ProjectCode: projCode, ServerCode: srvCode,
+		})
+		if err != nil {
+			t.Fatalf("priv sync round %d: %v", round, err)
+		}
+		t.Logf("priv round %d: rounds=%d recv=%d sent=%d errors=%v",
+			round, result.Rounds, result.FilesRecvd, result.FilesSent, result.Errors)
+		if result.FilesSent == 0 && result.FilesRecvd == 0 {
+			break
+		}
+	}
+
+	// Verify private blobs arrived and are in private table.
+	for _, uuid := range privateUUIDs {
+		rid, ok := blob.Exists(clientPriv.DB(), uuid)
+		if !ok {
+			t.Errorf("client-priv missing private blob %s", uuid)
+			continue
+		}
+		if !content.IsPrivate(clientPriv.DB(), int64(rid)) {
+			t.Errorf("blob %s should be in client's private table", uuid)
+		}
+	}
+	for _, uuid := range publicUUIDs {
+		if _, ok := blob.Exists(clientPriv.DB(), uuid); !ok {
+			t.Errorf("client-priv missing public blob %s", uuid)
+		}
+	}
+
+	var privClientCount int
+	clientPriv.DB().QueryRow("SELECT count(*) FROM blob WHERE size >= 0").Scan(&privClientCount)
+	t.Logf("client-priv: %d blobs (server had %d)", privClientCount, totalBlobs)
+
+	// 4. Sync client with Private=false — should NOT get private blobs.
+	clientPub := leafRepo(t, dir, "client-pub.fossil")
+	clientPub.DB().Exec("UPDATE config SET value=? WHERE name='project-code'", projCode)
+
+	for round := 0; round < 10; round++ {
+		result, err := sync.Sync(ctx, clientPub, transport, sync.SyncOpts{
+			Pull: true, Push: true, Private: false,
+			ProjectCode: projCode, ServerCode: srvCode,
+		})
+		if err != nil {
+			t.Fatalf("pub sync round %d: %v", round, err)
+		}
+		if result.FilesSent == 0 && result.FilesRecvd == 0 {
+			break
+		}
+	}
+
+	for _, uuid := range privateUUIDs {
+		if _, ok := blob.Exists(clientPub.DB(), uuid); ok {
+			t.Errorf("client-pub should NOT have private blob %s", uuid)
+		}
+	}
+	for _, uuid := range publicUUIDs {
+		if _, ok := blob.Exists(clientPub.DB(), uuid); !ok {
+			t.Errorf("client-pub missing public blob %s", uuid)
+		}
+	}
+
+	var pubClientCount int
+	clientPub.DB().QueryRow("SELECT count(*) FROM blob WHERE size >= 0").Scan(&pubClientCount)
+	t.Logf("client-pub: %d blobs (server had %d)", pubClientCount, totalBlobs)
 }


### PR DESCRIPTION
## Summary

Port Fossil's private artifact sync to go-libfossil. Private blobs (in the `private` table) are excluded from normal sync and only transferred when both peers have `x` capability and the client opts in via `pragma send-private`.

## Changes

**Foundation:**
- `content.IsPrivate`, `content.MakePrivate`, `content.MakePublic` helpers
- `auth.CanSyncPrivate` for `x` capability
- `SyncOpts.Private` field

**Server (handler.go):**
- `pragma send-private` handling with `x` capability check
- `PrivateCard` dispatch in `handleDataCard` + `MakePrivate`/`MakePublic` in `handleFile`
- `emitIGots` excludes private blobs; `emitPrivateIGots` emits `igot UUID 1` when authorized
- `handleIGot` private-aware: skips gimme for unauthorized private, updates private/public status
- `handleGimme` prepends `PrivateCard` before private files
- `emitCloneBatch` filters private blobs
- `sendAllClusters` excludes private

**Client (client.go):**
- Sends `pragma send-private` every round when `Private: true`
- `sendUnclustered` / `sendAllClusters` exclude private blobs
- New `sendPrivate()` emits `igot UUID 1` for private blobs
- `buildFileCards` / `buildGimmeCards` filter private
- `processResponse` handles `PrivateCard`, `IGotCard.IsPrivate`, `MakePrivate`/`MakePublic`
- Extracted `applyPrivateStatus` helper (DRY for FileCard/CFileCard)

**BUGGIFY (4 new sites):**
- `handler.emitPrivateIGots.truncate` (10%) — multi-round private igot convergence
- `handler.handleGimme.dropPrivateCard` (5%) — client handles missing private card prefix
- `sync.sendPrivate.skip` (10%) — client omits private igots for a round
- `sync.applyPrivateStatus.skipMakePrivate` (3%) — status correction on next round

**TigerStyle hardening:**
- All `MakePrivate`/`MakePublic` errors checked and propagated
- `rid > 0` preconditions on content helpers
- `process()` split into `processDataCards()` (was 83 lines)
- Duplicated FileCard/CFileCard private logic extracted

## Bugs found during implementation

1. `pragma send-private` must be sent every round (handler is stateless per-round)
2. Server `handleIGot` must not let clients modify the server's private table

## Test plan

- [x] 15 new handler unit tests (pragma, private card, igot filtering, gimme prefix, clone batch)
- [x] 4 integration tests (end-to-end, transition, no-x-capability)
- [x] DST scenario: public/private separation with authorized vs unauthorized leaves
- [x] DST seed sweep: 3 private blobs in master, all leaves sync with Private=true
- [x] DST adversarial: BUGGIFY faults on private paths, all recover
- [x] Sim equivalence: private sync via HTTP against go-libfossil ServeHTTP
- [x] `make test` + `make dst` (8 seeds) pass
- [x] TigerStyle audit: all critical/important issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled private artifact synchronization with authorization-based controls
  * Private artifacts excluded from default sync; transferred only when explicitly enabled per session
  * New sync configuration option to include private artifacts in transfers

* **Tests**
  * Added comprehensive end-to-end private synchronization testing and scenario coverage

* **Documentation**
  * Added implementation plan and design specification for private artifact sync

<!-- end of auto-generated comment: release notes by coderabbit.ai -->