### PR TITLE
fix(delta): Fossil interop — 4 codec bugs + comprehensive test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ sim-full:
 	done
 	@echo "=== Sim full done ==="
 
-# Fossil interop: Tier 1 + Tier 2 (requires fossil binary, Tier 2 clones fossil-scm.org)
+# Fossil interop: Tier 1 + Tier 2 (requires fossil binary, Tier 2 samples 5K+2K blobs)
 test-interop:
-	go test -buildvcs=false ./sim/ -run TestInterop -timeout=300s -v
+	go test -buildvcs=false ./sim/ -run TestInterop -timeout=10m -v
 
 # --- Driver matrix — run locally ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean leaf bridge edgesync wasm-wasi wasm-browser wasm dst dst-full dst-hostile dst-drivers sim sim-full setup-hooks drivers
+.PHONY: build test clean leaf bridge edgesync wasm-wasi wasm-browser wasm dst dst-full dst-hostile dst-drivers sim sim-full setup-hooks drivers test-interop
 
 # --- Build ---
 
@@ -34,6 +34,7 @@ test:
 	go test ./dst/ -run 'TestScenario|TestE2E|TestMockFossil|TestSimulator|TestCheck' -count=1
 	go test ./sim/ -run 'TestFaultProxy|TestGenerateSchedule|TestBuggify' -count=1
 	go test ./sim/ -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe' -count=1 -timeout=120s
+	go test ./sim/ -run 'TestInterop' -count=1 -short -timeout=60s
 
 # --- Pre-commit hook setup ---
 
@@ -108,6 +109,10 @@ sim-full:
 		done; \
 	done
 	@echo "=== Sim full done ==="
+
+# Fossil interop: Tier 1 + Tier 2 (requires fossil binary, Tier 2 clones fossil-scm.org)
+test-interop:
+	go test -buildvcs=false ./sim/ -run TestInterop -timeout=300s -v
 
 # --- Driver matrix — run locally ---
 

--- a/docs/superpowers/plans/2026-03-25-fossil-interop-test-suite.md
+++ b/docs/superpowers/plans/2026-03-25-fossil-interop-test-suite.md
@@ -1,0 +1,946 @@
+# Fossil Interop Test Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `sim/interop_test.go` — a comprehensive Fossil-as-oracle test suite that cross-checks every codec operation against the real `fossil` binary.
+
+**Architecture:** Single test file with shared helpers. Two tiers: Tier 1 (fast seed tests, always run) and Tier 2 (large Fossil SCM repo, skipped in `-short`). Every test follows the pattern: do X with Go, verify with Fossil CLI (or vice versa). `verifyAllBlobs` is the core invariant — expand every blob, hash it, assert matches UUID.
+
+**Tech Stack:** Go testing, `os/exec` for fossil CLI, existing sim helpers (`fossilInit`, `fossilCommitFiles`, `startFossilServe`, `serveLeafHTTP`, `requireFossil`, `freeAddr`, `waitForAddr`)
+
+**Spec:** `docs/superpowers/specs/2026-03-25-fossil-interop-test-suite-design.md`
+
+---
+
+### Task 1: Shared Helpers
+
+**Files:**
+- Create: `sim/interop_test.go`
+
+The foundation — `verifyAllBlobs`, `verifyWithFossilRebuild`, `fossilExec`, and `cloneFossilSCMRepo`. All subsequent tasks depend on these.
+
+- [ ] **Step 1: Create `sim/interop_test.go` with helpers**
+
+```go
+package sim
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/delta"
+	"github.com/dmestas/edgesync/go-libfossil/hash"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/simio"
+	"github.com/dmestas/edgesync/go-libfossil/sync"
+	"github.com/dmestas/edgesync/go-libfossil/uv"
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
+)
+
+// verifyAllBlobs expands every non-phantom blob in the database, computes its
+// hash, and asserts it matches the stored UUID. This is the single most valuable
+// interop check — it would have caught the delta swap bug, the checksum bug,
+// and any future content corruption.
+func verifyAllBlobs(t *testing.T, d *db.DB) {
+	t.Helper()
+	rows, err := d.Query("SELECT rid, uuid, size FROM blob WHERE size >= 0 AND content IS NOT NULL")
+	if err != nil {
+		t.Fatalf("verifyAllBlobs query: %v", err)
+	}
+	type blobRow struct {
+		rid  libfossil.FslID
+		uuid string
+		size int64
+	}
+	var blobs []blobRow
+	for rows.Next() {
+		var b blobRow
+		rows.Scan(&b.rid, &b.uuid, &b.size)
+		blobs = append(blobs, b)
+	}
+	rows.Close()
+
+	if len(blobs) == 0 {
+		t.Fatal("verifyAllBlobs: no blobs found")
+	}
+
+	var failures []string
+	for _, b := range blobs {
+		expanded, err := content.Expand(d, b.rid)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("rid=%d uuid=%s: expand: %v", b.rid, b.uuid[:16], err))
+			continue
+		}
+		var computed string
+		if len(b.uuid) > 40 {
+			computed = hash.SHA3(expanded)
+		} else {
+			computed = hash.SHA1(expanded)
+		}
+		if computed != b.uuid {
+			failures = append(failures, fmt.Sprintf("rid=%d uuid=%s: hash mismatch: got %s", b.rid, b.uuid[:16], computed[:16]))
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Errorf("verifyAllBlobs: %d/%d blobs failed:\n  %s", len(failures), len(blobs), strings.Join(failures, "\n  "))
+	} else {
+		t.Logf("verifyAllBlobs: all %d blobs verified", len(blobs))
+	}
+}
+
+// verifyWithFossilRebuild runs `fossil rebuild` on a repo file. Fossil's rebuild
+// recomputes every content hash from scratch — the ultimate integrity check.
+func verifyWithFossilRebuild(t *testing.T, repoPath string) {
+	t.Helper()
+	out, err := exec.Command("fossil", "rebuild", repoPath).CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild %s: %v\n%s", filepath.Base(repoPath), err, out)
+	}
+	t.Logf("fossil rebuild OK: %s", filepath.Base(repoPath))
+}
+
+// fossilExec runs a fossil command and returns stdout. Skips the test if
+// fossil is not in PATH. Fails the test on non-zero exit.
+func fossilExec(t *testing.T, args ...string) string {
+	t.Helper()
+	requireFossil(t)
+	cmd := exec.Command("fossil", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// cloneFossilSCMRepo returns the path to testdata/fossil.fossil, cloning from
+// upstream if needed. Skips the test if offline or clone fails.
+func cloneFossilSCMRepo(t *testing.T) string {
+	t.Helper()
+	// Walk up from sim/ to project root.
+	repoPath := filepath.Join("..", "testdata", "fossil.fossil")
+	if abs, err := filepath.Abs(repoPath); err == nil {
+		repoPath = abs
+	}
+
+	if _, err := os.Stat(repoPath); err == nil {
+		return repoPath
+	}
+
+	// Ensure testdata/ exists.
+	dir := filepath.Dir(repoPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Skipf("cannot create testdata dir: %v", err)
+	}
+
+	t.Log("Cloning Fossil SCM repo (first run, ~30s)...")
+	cmd := exec.Command("fossil", "clone", "https://fossil-scm.org/home", repoPath)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Skipf("fossil clone failed (offline?): %v", err)
+	}
+	return repoPath
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build -buildvcs=false ./sim/`
+Expected: clean compile (no tests run yet, just helpers)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop test helpers — verifyAllBlobs, verifyWithFossilRebuild"
+```
+
+---
+
+### Task 2: Delta Codec Tests
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Three subtests that cross-check delta.Create/Apply against `fossil test-delta-create`/`fossil test-delta-apply`.
+
+- [ ] **Step 1: Add `TestInterop/delta_codec` tests**
+
+Append to `sim/interop_test.go`:
+
+```go
+func TestInterop(t *testing.T) {
+	requireFossil(t)
+
+	t.Run("delta_codec", func(t *testing.T) {
+		t.Run("fossil_creates_we_apply", func(t *testing.T) {
+			dir := t.TempDir()
+			source := []byte(strings.Repeat("The quick brown fox jumps over the lazy dog. ", 100))
+			target := make([]byte, len(source))
+			copy(target, source)
+			copy(target[500:], []byte("FOSSIL-CREATED DELTA VERIFIED BY GO"))
+
+			srcFile := filepath.Join(dir, "src.bin")
+			tgtFile := filepath.Join(dir, "tgt.bin")
+			deltaFile := filepath.Join(dir, "delta.bin")
+			os.WriteFile(srcFile, source, 0644)
+			os.WriteFile(tgtFile, target, 0644)
+
+			fossilExec(t, "test-delta-create", srcFile, tgtFile, deltaFile)
+			fossilDelta, err := os.ReadFile(deltaFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := delta.Apply(source, fossilDelta)
+			if err != nil {
+				t.Fatalf("delta.Apply on fossil-created delta: %v", err)
+			}
+			if string(got) != string(target) {
+				t.Fatalf("output mismatch: got %d bytes, want %d", len(got), len(target))
+			}
+		})
+
+		t.Run("we_create_fossil_applies", func(t *testing.T) {
+			dir := t.TempDir()
+			source := []byte(strings.Repeat("abcdefghijklmnop", 500))
+			target := make([]byte, len(source))
+			copy(target, source)
+			copy(target[2000:], []byte("GO-CREATED DELTA VERIFIED BY FOSSIL"))
+
+			srcFile := filepath.Join(dir, "src.bin")
+			deltaFile := filepath.Join(dir, "delta.bin")
+			resultFile := filepath.Join(dir, "result.bin")
+			os.WriteFile(srcFile, source, 0644)
+			os.WriteFile(deltaFile, delta.Create(source, target), 0644)
+
+			fossilExec(t, "test-delta-apply", srcFile, deltaFile, resultFile)
+			got, err := os.ReadFile(resultFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(target) {
+				t.Fatalf("fossil could not apply our delta: got %d bytes, want %d", len(got), len(target))
+			}
+		})
+
+		t.Run("round_trip_large_payload", func(t *testing.T) {
+			dir := t.TempDir()
+			rng := rand.New(rand.NewSource(42))
+
+			// 64KB random-ish data (text-like so delta can find matches)
+			base := make([]byte, 65536)
+			for i := range base {
+				base[i] = byte('A' + rng.Intn(26))
+			}
+			modified := make([]byte, len(base))
+			copy(modified, base)
+			// Change ~5% of content in scattered locations
+			for i := 0; i < 3000; i++ {
+				pos := rng.Intn(len(modified))
+				modified[pos] = byte('a' + rng.Intn(26))
+			}
+
+			srcFile := filepath.Join(dir, "src.bin")
+			tgtFile := filepath.Join(dir, "tgt.bin")
+			os.WriteFile(srcFile, base, 0644)
+			os.WriteFile(tgtFile, modified, 0644)
+
+			// Direction 1: fossil creates, we apply
+			deltaFile1 := filepath.Join(dir, "fossil.delta")
+			fossilExec(t, "test-delta-create", srcFile, tgtFile, deltaFile1)
+			fossilDelta, _ := os.ReadFile(deltaFile1)
+			got1, err := delta.Apply(base, fossilDelta)
+			if err != nil {
+				t.Fatalf("Apply fossil delta (64KB): %v", err)
+			}
+			if string(got1) != string(modified) {
+				t.Fatal("fossil→Go mismatch on 64KB payload")
+			}
+
+			// Direction 2: we create, fossil applies
+			deltaFile2 := filepath.Join(dir, "go.delta")
+			resultFile := filepath.Join(dir, "result.bin")
+			os.WriteFile(deltaFile2, delta.Create(base, modified), 0644)
+			fossilExec(t, "test-delta-apply", srcFile, deltaFile2, resultFile)
+			got2, _ := os.ReadFile(resultFile)
+			if string(got2) != string(modified) {
+				t.Fatal("Go→fossil mismatch on 64KB payload")
+			}
+		})
+	})
+```
+
+**Important:** Close `TestInterop` with a `}` after the `delta_codec` block for now. Each subsequent task replaces this closing brace — insert the new `t.Run` block before it.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/delta_codec' ./sim/ -timeout=60s`
+Expected: 3 PASS subtests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop delta codec tests — bidirectional fossil CLI cross-check"
+```
+
+---
+
+### Task 3: Clone-From-Us Tests
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Tests that `fossil clone` + `fossil rebuild` can consume our Go-served repos.
+
+- [ ] **Step 1: Add `clone_from_us` subtests**
+
+Insert inside `TestInterop` after the `delta_codec` block:
+
+```go
+	t.Run("clone_from_us", func(t *testing.T) {
+		t.Run("single_commit", func(t *testing.T) {
+			dir := t.TempDir()
+			r := leafRepo(t, dir, "src.fossil")
+			checkin(t, r, 0, []manifest.File{
+				{Name: "hello.txt", Content: []byte("hello interop")},
+				{Name: "data.bin", Content: []byte(strings.Repeat("binary-ish content\x00\xff", 200))},
+			}, "initial commit")
+			manifest.Crosslink(r)
+			r.Close()
+
+			r2, _ := repo.Open(filepath.Join(dir, "src.fossil"))
+			defer r2.Close()
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", fmt.Sprintf("http://%s", addr), clonePath)
+			verifyWithFossilRebuild(t, clonePath)
+
+			workDir := fossilCheckout(t, clonePath)
+			assertFiles(t, workDir, map[string]string{"hello.txt": "hello interop"})
+		})
+
+		t.Run("commit_chain", func(t *testing.T) {
+			dir := t.TempDir()
+			r := leafRepo(t, dir, "src.fossil")
+			var parent int64
+			for i := 0; i < 5; i++ {
+				parent = checkin(t, r, parent, []manifest.File{
+					{Name: "counter.txt", Content: []byte(fmt.Sprintf("version %d with enough padding to make deltas interesting %s", i, strings.Repeat(".", 200)))},
+					{Name: fmt.Sprintf("file-%d.txt", i), Content: []byte(fmt.Sprintf("added in commit %d", i))},
+				}, fmt.Sprintf("commit %d", i))
+			}
+			manifest.Crosslink(r)
+			r.Close()
+
+			r2, _ := repo.Open(filepath.Join(dir, "src.fossil"))
+			defer r2.Close()
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", fmt.Sprintf("http://%s", addr), clonePath)
+			verifyWithFossilRebuild(t, clonePath)
+		})
+
+		t.Run("with_uv_files", func(t *testing.T) {
+			dir := t.TempDir()
+			r := leafRepo(t, dir, "src.fossil")
+			checkin(t, r, 0, []manifest.File{
+				{Name: "readme.txt", Content: []byte("repo with UV files")},
+			}, "initial")
+			manifest.Crosslink(r)
+
+			// Store UV files including binary content.
+			rng := rand.New(rand.NewSource(99))
+			binaryContent := make([]byte, 4096)
+			rng.Read(binaryContent)
+			uv.Write(r, "text-file.txt", []byte("hello UV"))
+			uv.Write(r, "binary-file.bin", binaryContent)
+			r.Close()
+
+			r2, _ := repo.Open(filepath.Join(dir, "src.fossil"))
+			defer r2.Close()
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", fmt.Sprintf("http://%s", addr), clonePath)
+
+			// Verify UV files via fossil CLI.
+			uvList := fossilExec(t, "uv", "list", "-R", clonePath)
+			if !strings.Contains(uvList, "text-file.txt") || !strings.Contains(uvList, "binary-file.bin") {
+				t.Fatalf("uv list missing files: %s", uvList)
+			}
+			uvText := fossilExec(t, "uv", "cat", "text-file.txt", "-R", clonePath)
+			if uvText != "hello UV" {
+				t.Fatalf("uv cat text-file.txt = %q, want %q", uvText, "hello UV")
+			}
+		})
+	})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/clone_from_us' ./sim/ -timeout=60s`
+Expected: 3 PASS subtests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop clone-from-us tests — fossil clone + rebuild + UV"
+```
+
+---
+
+### Task 4: Clone-From-Fossil Tests
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Tests that `sync.Clone` from `fossil serve` works, including delta-compressed cfile cards. Uses `verifyAllBlobs` as the primary check.
+
+- [ ] **Step 1: Add `clone_from_fossil` subtests**
+
+Insert inside `TestInterop`:
+
+```go
+	t.Run("clone_from_fossil", func(t *testing.T) {
+		t.Run("single_commit", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			fossilCommitFiles(t, fossilRepo, "", map[string]string{
+				"hello.txt": "hello from fossil",
+			}, "single commit")
+
+			serverURL := startFossilServe(t, fossilRepo)
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			defer leafR.Close()
+
+			verifyAllBlobs(t, leafR.DB())
+		})
+
+		t.Run("commit_chain_with_deltas", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			var workDir string
+			for i := 0; i < 5; i++ {
+				workDir = fossilCommitFiles(t, fossilRepo, workDir, map[string]string{
+					"counter.txt": fmt.Sprintf("version %d with padding %s", i, strings.Repeat("x", 300)),
+					fmt.Sprintf("file-%d.txt", i): fmt.Sprintf("added in commit %d", i),
+				}, fmt.Sprintf("commit %d", i))
+			}
+
+			serverURL := startFossilServe(t, fossilRepo)
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			defer leafR.Close()
+
+			verifyAllBlobs(t, leafR.DB())
+		})
+
+		t.Run("expand_and_verify_all", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			var workDir string
+			// Larger files to force delta creation during fossil rebuild.
+			bigContent := strings.Repeat("The quick brown fox jumps over the lazy dog.\n", 100)
+			for i := 0; i < 5; i++ {
+				workDir = fossilCommitFiles(t, fossilRepo, workDir, map[string]string{
+					"big.txt": fmt.Sprintf("%sVersion %d\n", bigContent, i),
+				}, fmt.Sprintf("commit %d", i))
+			}
+
+			serverURL := startFossilServe(t, fossilRepo)
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			leafR.Close()
+
+			// Also verify fossil itself can read our stored blobs.
+			verifyWithFossilRebuild(t, leafPath)
+
+			// Reopen and verify all blobs.
+			leafR2, err := repo.Open(leafPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer leafR2.Close()
+			verifyAllBlobs(t, leafR2.DB())
+		})
+	})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/clone_from_fossil' ./sim/ -timeout=60s`
+Expected: 3 PASS subtests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop clone-from-fossil tests — verifyAllBlobs on cfile deltas"
+```
+
+---
+
+### Task 5: Incremental Sync Tests
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Tests sync after initial clone — the production steady-state path.
+
+- [ ] **Step 1: Add `incremental_sync` subtests**
+
+Insert inside `TestInterop`:
+
+```go
+	t.Run("incremental_sync", func(t *testing.T) {
+		t.Run("fossil_commits_we_pull", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			workDir := fossilCommitFiles(t, fossilRepo, "", map[string]string{
+				"base.txt": "initial content",
+			}, "initial")
+
+			serverURL := startFossilServe(t, fossilRepo)
+
+			// Clone into leaf.
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("Clone: %v", err)
+			}
+
+			// Fossil makes 3 more commits.
+			for i := 0; i < 3; i++ {
+				workDir = fossilCommitFiles(t, fossilRepo, workDir, map[string]string{
+					"base.txt":                      fmt.Sprintf("updated %d", i),
+					fmt.Sprintf("new-%d.txt", i): fmt.Sprintf("new file %d", i),
+				}, fmt.Sprintf("post-clone commit %d", i))
+			}
+
+			// Sync to pull new artifacts.
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+			for round := 0; round < 10; round++ {
+				result, err := sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+					Pull:        true,
+					ProjectCode: projCode,
+				})
+				if err != nil {
+					t.Fatalf("sync round %d: %v", round, err)
+				}
+				if result.FilesRecvd == 0 {
+					break
+				}
+			}
+			leafR.Close()
+
+			leafR2, _ := repo.Open(leafPath)
+			defer leafR2.Close()
+			verifyAllBlobs(t, leafR2.DB())
+		})
+
+		t.Run("we_push_fossil_pulls", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			fossilCommitFiles(t, fossilRepo, "", map[string]string{
+				"base.txt": "initial",
+			}, "initial")
+
+			serverURL := startFossilServe(t, fossilRepo)
+
+			// Clone into leaf.
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("Clone: %v", err)
+			}
+
+			// Add blobs to the leaf.
+			rng := rand.New(rand.NewSource(77))
+			uuids, err := SeedLeaf(leafR, rng, 3, 2048)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Push to fossil.
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+			for round := 0; round < 10; round++ {
+				result, err := sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+					Push:        true,
+					ProjectCode: projCode,
+				})
+				if err != nil {
+					t.Fatalf("sync round %d: %v", round, err)
+				}
+				if result.FilesSent == 0 {
+					break
+				}
+			}
+			leafR.Close()
+
+			// Verify fossil can read the pushed blobs.
+			for _, uuid := range uuids {
+				fossilExec(t, "artifact", uuid, "-R", fossilRepo)
+			}
+			verifyWithFossilRebuild(t, fossilRepo)
+		})
+
+		t.Run("bidirectional", func(t *testing.T) {
+			dir := t.TempDir()
+			fossilRepo := fossilInit(t, dir, "src.fossil")
+			workDir := fossilCommitFiles(t, fossilRepo, "", map[string]string{
+				"base.txt": "initial",
+			}, "initial")
+
+			serverURL := startFossilServe(t, fossilRepo)
+
+			// Clone into leaf.
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("Clone: %v", err)
+			}
+
+			// Both sides add content.
+			fossilCommitFiles(t, fossilRepo, workDir, map[string]string{
+				"from-fossil.txt": "fossil added this",
+			}, "fossil-side commit")
+
+			rng := rand.New(rand.NewSource(88))
+			SeedLeaf(leafR, rng, 3, 1024)
+
+			// Sync until convergence.
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+			for round := 0; round < 15; round++ {
+				result, err := sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+					Push:        true,
+					Pull:        true,
+					ProjectCode: projCode,
+				})
+				if err != nil {
+					t.Fatalf("sync round %d: %v", round, err)
+				}
+				if result.FilesSent == 0 && result.FilesRecvd == 0 {
+					break
+				}
+			}
+			leafR.Close()
+
+			// Both sides pass integrity checks.
+			verifyWithFossilRebuild(t, fossilRepo)
+			leafR2, _ := repo.Open(leafPath)
+			defer leafR2.Close()
+			verifyAllBlobs(t, leafR2.DB())
+		})
+	})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/incremental_sync' ./sim/ -timeout=120s`
+Expected: 3 PASS subtests
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop incremental sync tests — pull, push, bidirectional"
+```
+
+---
+
+### Task 6: Hash Compat Tests
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Cross-check SHA1 and SHA3 against `fossil sha1sum` / `fossil sha3sum`.
+
+- [ ] **Step 1: Add `hash_compat` subtests**
+
+Insert inside `TestInterop`:
+
+```go
+	t.Run("hash_compat", func(t *testing.T) {
+		t.Run("sha1_vs_fossil", func(t *testing.T) {
+			dir := t.TempDir()
+			rng := rand.New(rand.NewSource(1))
+			sizes := []int{0, 1, 15, 16, 17, 255, 256, 257, 1024, 65536}
+
+			for _, sz := range sizes {
+				data := make([]byte, sz)
+				if sz > 0 {
+					rng.Read(data)
+				}
+				path := filepath.Join(dir, fmt.Sprintf("data_%d.bin", sz))
+				os.WriteFile(path, data, 0644)
+
+				goHash := hash.SHA1(data)
+				fossilOut := strings.TrimSpace(fossilExec(t, "sha1sum", path))
+				// fossil sha1sum outputs: HASH  FILENAME
+				fossilHash := strings.Fields(fossilOut)[0]
+
+				if goHash != fossilHash {
+					t.Errorf("SHA1 mismatch at size %d: go=%s fossil=%s", sz, goHash, fossilHash)
+				}
+			}
+		})
+
+		t.Run("sha3_vs_fossil", func(t *testing.T) {
+			dir := t.TempDir()
+			rng := rand.New(rand.NewSource(2))
+			sizes := []int{0, 1, 15, 16, 17, 255, 256, 257, 1024, 65536}
+
+			for _, sz := range sizes {
+				data := make([]byte, sz)
+				if sz > 0 {
+					rng.Read(data)
+				}
+				path := filepath.Join(dir, fmt.Sprintf("data_%d.bin", sz))
+				os.WriteFile(path, data, 0644)
+
+				goHash := hash.SHA3(data)
+				fossilOut := strings.TrimSpace(fossilExec(t, "sha3sum", path))
+				fossilHash := strings.Fields(fossilOut)[0]
+
+				if goHash != fossilHash {
+					t.Errorf("SHA3 mismatch at size %d: go=%s fossil=%s", sz, goHash, fossilHash)
+				}
+			}
+		})
+	})
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/hash_compat' ./sim/ -timeout=30s`
+Expected: 2 PASS subtests (20 hash comparisons total)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop hash compat tests — SHA1 + SHA3 vs fossil CLI"
+```
+
+---
+
+### Task 7: Large Repo Tests (Tier 2)
+
+**Files:**
+- Modify: `sim/interop_test.go`
+
+Tier 2 tests using the Fossil SCM repo. Skipped in `-short` mode.
+
+- [ ] **Step 1: Add `large_repo` subtests and close `TestInterop`**
+
+Insert inside `TestInterop`, then close the function:
+
+```go
+	t.Run("large_repo", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping large repo tests in -short mode")
+		}
+		requireFossil(t)
+
+		repoPath := cloneFossilSCMRepo(t)
+
+		t.Run("clone_and_expand_all", func(t *testing.T) {
+			d, err := db.Open(repoPath)
+			if err != nil {
+				t.Fatalf("db.Open: %v", err)
+			}
+			defer d.Close()
+
+			verifyAllBlobs(t, d)
+		})
+
+		t.Run("verify_hash_integrity", func(t *testing.T) {
+			d, err := db.Open(repoPath)
+			if err != nil {
+				t.Fatalf("db.Open: %v", err)
+			}
+			defer d.Close()
+
+			// Sample 500 random blobs and compare our Expand output
+			// against `fossil artifact -R` output.
+			rows, err := d.Query("SELECT rid, uuid FROM blob WHERE size >= 0 AND content IS NOT NULL ORDER BY RANDOM() LIMIT 500")
+			if err != nil {
+				t.Fatal(err)
+			}
+			type sample struct {
+				rid  libfossil.FslID
+				uuid string
+			}
+			var samples []sample
+			for rows.Next() {
+				var s sample
+				rows.Scan(&s.rid, &s.uuid)
+				samples = append(samples, s)
+			}
+			rows.Close()
+
+			var mismatches int
+			for _, s := range samples {
+				expanded, err := content.Expand(d, s.rid)
+				if err != nil {
+					t.Errorf("Expand rid=%d: %v", s.rid, err)
+					mismatches++
+					continue
+				}
+
+				cmd := exec.Command("fossil", "artifact", s.uuid, "-R", repoPath)
+				fossilOut, err := cmd.Output()
+				if err != nil {
+					t.Errorf("fossil artifact %s: %v", s.uuid[:16], err)
+					mismatches++
+					continue
+				}
+
+				if string(expanded) != string(fossilOut) {
+					t.Errorf("rid=%d uuid=%s: content mismatch (go=%d bytes, fossil=%d bytes)",
+						s.rid, s.uuid[:16], len(expanded), len(fossilOut))
+					mismatches++
+				}
+			}
+			t.Logf("Compared %d blobs: %d matches, %d mismatches", len(samples), len(samples)-mismatches, mismatches)
+		})
+	})
+} // end TestInterop
+```
+
+- [ ] **Step 2: Run Tier 1 tests (should skip large_repo)**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop' ./sim/ -short -timeout=60s`
+Expected: `large_repo` subtests SKIP, all others PASS
+
+- [ ] **Step 3: Run Tier 2 tests (requires testdata/fossil.fossil)**
+
+Run: `go test -buildvcs=false -v -run 'TestInterop/large_repo' ./sim/ -timeout=300s`
+Expected: 2 PASS subtests (may take 30-60s for 66K blobs)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sim/interop_test.go
+git commit -m "test(sim): add interop large repo tests — Tier 2 Fossil SCM repo verification"
+```
+
+---
+
+### Task 8: Integration with Makefile + Full Verification
+
+**Files:**
+- Modify: `Makefile` (add `test-interop` target)
+
+- [ ] **Step 1: Check current Makefile test targets**
+
+Read `Makefile` and find the existing `test` and `sim` targets.
+
+- [ ] **Step 2: Add `test-interop` target**
+
+Add after the existing `sim-full` target:
+
+```makefile
+.PHONY: test-interop
+test-interop: ## Run Fossil interop tests (Tier 1 + Tier 2)
+	go test -buildvcs=false ./sim/ -run TestInterop -timeout=300s -v
+```
+
+- [ ] **Step 3: Add Tier 1 interop to `make test`**
+
+Ensure the existing `sim` test line includes `TestInterop` with `-short`:
+
+Add a new line to the `test` target (after the existing sim serve tests):
+
+```makefile
+	go test ./sim/ -run 'TestInterop' -count=1 -short -timeout=60s
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `make test`
+Expected: All existing tests pass. New `TestInterop` Tier 1 tests pass. Tier 2 skipped (short mode).
+
+- [ ] **Step 5: Run interop specifically**
+
+Run: `make test-interop`
+Expected: All Tier 1 + Tier 2 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Makefile
+git commit -m "build: add test-interop target, include Tier 1 interop in make test"
+```
+
+---
+
+### Task 9: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+Expected: All green, including new interop Tier 1 tests.
+
+- [ ] **Step 2: Run Tier 2 interop**
+
+Run: `make test-interop`
+Expected: All green including large repo tests.
+
+- [ ] **Step 3: Verify test count**
+
+Run: `go test -buildvcs=false -v -run TestInterop ./sim/ -timeout=300s 2>&1 | grep -c 'PASS:'`
+Expected: 16 (3 delta + 3 clone_from_us + 3 clone_from_fossil + 3 incremental_sync + 2 hash + 2 large_repo)
+
+- [ ] **Step 4: Final commit if any cleanup needed**

--- a/docs/superpowers/specs/2026-03-25-fossil-interop-test-suite-design.md
+++ b/docs/superpowers/specs/2026-03-25-fossil-interop-test-suite-design.md
@@ -1,0 +1,174 @@
+# Fossil Interop Test Suite — Design Spec
+
+**Date:** 2026-03-25
+**Status:** Draft
+**Ticket:** CDG-182 (parent), follow-on hardening
+**Location:** `sim/interop_test.go`
+
+## Problem
+
+EdgeSync's test suite was entirely self-referential — Go-created data verified by Go code. Three bugs survived undetected:
+
+1. **Delta copy command args swapped** (`offset@count` instead of `count@offset`) — Create and Apply matched each other but not Fossil
+2. **Delta checksum wrong algorithm** (Fletcher-like uint16 instead of big-endian uint32 word sum) — only visible on data > 256 bytes
+3. **CFile usize validation rejected delta cards** — `usize` is the fully expanded content size, not the decompressed delta size
+
+All three would have been caught instantly by cross-checking against the real `fossil` binary.
+
+## Solution
+
+A comprehensive interop test suite in `sim/interop_test.go` that uses the Fossil CLI as an oracle. Two tiers:
+
+- **Tier 1 (fast):** Seed repos created per-test. Always runs, CI-safe, <15s total.
+- **Tier 2 (large repo):** Uses the Fossil SCM repo (66K artifacts). Skipped in `-short` mode.
+
+## Test Structure
+
+```
+TestInterop/
+├── delta_codec/
+│   ├── fossil_creates_we_apply
+│   ├── we_create_fossil_applies
+│   └── round_trip_large_payload
+├── clone_from_us/
+│   ├── single_commit
+│   ├── commit_chain
+│   └── with_uv_files
+├── clone_from_fossil/
+│   ├── single_commit
+│   ├── commit_chain_with_deltas
+│   └── expand_and_verify_all
+├── incremental_sync/
+│   ├── fossil_commits_we_pull
+│   ├── we_push_fossil_pulls
+│   └── bidirectional
+├── hash_compat/
+│   ├── sha1_vs_fossil
+│   └── sha3_vs_fossil
+└── large_repo/                     (Tier 2, skipped in -short)
+    ├── clone_and_expand_all
+    └── verify_hash_integrity
+```
+
+## Test Descriptions
+
+### `delta_codec/`
+
+Tests that our delta Create/Apply are bit-compatible with Fossil's delta.c.
+
+**`fossil_creates_we_apply`**: Write source and target files to disk. Run `fossil test-delta-create` to produce a delta. Read the delta bytes, call `delta.Apply(source, fossilDelta)`, assert output == target.
+
+**`we_create_fossil_applies`**: Call `delta.Create(source, target)`, write to disk. Run `fossil test-delta-apply`. Assert Fossil's output == target.
+
+**`round_trip_large_payload`**: Same as above with 64KB+ payloads. Stresses the checksum algorithm (the uint16 bug only manifested above 256 bytes). Test with both directions.
+
+### `clone_from_us/`
+
+Tests that real `fossil clone` can consume our Go-served repos.
+
+**`single_commit`**: Create a Go repo, store a checkin manifest + file blobs via `manifest.Checkin`. Serve with `sync.ServeHTTP`. Run `fossil clone` against it. Run `fossil rebuild` on the clone. Assert zero errors from rebuild. Run `fossil open` + verify file content matches.
+
+**`commit_chain`**: Same but with 5+ sequential commits. Forces Fossil's `content_deltify` during rebuild, creating delta chains. Then `fossil rebuild` — if our blob format is wrong, rebuild catches it.
+
+**`with_uv_files`**: Store UV files including binary content (random 4KB bytes). Clone, then `fossil uv list` + `fossil uv cat` to verify content. Tests UV wire format and binary encoding.
+
+### `clone_from_fossil/`
+
+Tests that our `sync.Clone` can consume real Fossil-served repos. This is where the cfile delta bug lived.
+
+**`single_commit`**: `fossil init` + `fossil commit` + `fossil serve`. `sync.Clone` against it. Call `verifyAllBlobs` on the resulting repo.
+
+**`commit_chain_with_deltas`**: `fossil init` + 5 sequential `fossil commit` calls. `fossil serve`. `sync.Clone`. `verifyAllBlobs`. This exercises the cfile path with delta-compressed artifacts.
+
+**`expand_and_verify_all`**: Same as commit_chain but with larger files (4KB+) to ensure delta chains are created. After clone, expand every blob and verify hash matches UUID. Also run `fossil rebuild -R` on the Go-created repo file to let Fossil itself validate our storage format.
+
+### `incremental_sync/`
+
+Tests sync after initial clone — the production steady-state.
+
+**`fossil_commits_we_pull`**: Clone from Fossil, then make 3 new `fossil commit`s on the Fossil side. Run `fossil sync` against our Go server (which has the clone). Verify the 3 new artifacts arrived and `verifyAllBlobs` passes.
+
+**`we_push_fossil_pulls`**: Clone from Fossil. Store 3 new blobs in the Go repo. Run `fossil sync` from the Fossil side. Verify `fossil artifact` can retrieve the new blobs. Run `fossil rebuild`.
+
+**`bidirectional`**: Both sides commit after initial clone. Sync until convergence. Both sides `fossil rebuild`. `verifyAllBlobs` on Go side.
+
+### `hash_compat/`
+
+Tests that our hash functions produce identical output to Fossil's.
+
+**`sha1_vs_fossil`**: Generate 10 random payloads (various sizes: 0, 1, 255, 256, 1024, 64KB). For each: compute `hash.SHA1(data)`, write data to file, run `fossil sha1sum`, assert match.
+
+**`sha3_vs_fossil`**: Same with `hash.SHA3` and `fossil sha3sum`. This is currently untested — SHA3 was only validated against Go test vectors, never against Fossil.
+
+### `large_repo/`
+
+Tier 2 tests using the real Fossil SCM repo. Skipped in `-short` mode.
+
+**`clone_and_expand_all`**: If `testdata/fossil.fossil` doesn't exist, clone from `fossil-scm.org/home` (skips if network unavailable). Open the repo with `db.Open`. Call `verifyAllBlobs` — expand every non-phantom blob via `content.Expand`, hash it, assert matches UUID. This is 66K blobs including chains up to depth 2547.
+
+**`verify_hash_integrity`**: Same repo. For a random sample of 500 blobs, also compare expanded content against `fossil artifact -R` output. This cross-checks our Expand + Decompress against Fossil's own expansion.
+
+## Shared Helpers
+
+### `verifyAllBlobs(t *testing.T, d *db.DB)`
+
+The most important function in the suite. Opens a repo and verifies every non-phantom blob:
+
+```
+SELECT rid, uuid, size FROM blob WHERE size >= 0 AND content IS NOT NULL
+```
+
+For each row:
+1. `content.Expand(d, rid)` — walks delta chain, decompresses
+2. `hash.SHA1(expanded)` or `hash.SHA3(expanded)` based on UUID length
+3. Assert computed hash == stored UUID
+
+Fails with details: rid, uuid, chain depth, expected vs actual hash.
+
+### `verifyWithFossilRebuild(t *testing.T, repoPath string)`
+
+Runs `fossil rebuild -R <repoPath>` and asserts zero errors. Fossil's rebuild recomputes every content hash from scratch — the ultimate integrity check.
+
+### `fossilExec(t *testing.T, args ...string) string`
+
+Shared helper to run Fossil CLI commands. Skips test if `fossil` not in PATH. Returns stdout, fails test on non-zero exit.
+
+### `cloneFossilSCMRepo(t *testing.T) string`
+
+Returns path to `testdata/fossil.fossil`, cloning from upstream if needed. Skips if offline or clone fails.
+
+## Tier 2 Self-Provisioning
+
+The large repo tests use `testdata/fossil.fossil` (gitignored by `*.fossil` pattern). On first run:
+
+1. Check if file exists
+2. If not, attempt `fossil clone https://fossil-scm.org/home testdata/fossil.fossil`
+3. If clone fails (offline, timeout), skip the test gracefully
+4. File persists across runs (~45MB)
+
+## Integration with CI
+
+- `make test` runs with `-short` — Tier 1 only, <15s additional
+- `make test-full` (or equivalent) runs without `-short` — includes Tier 2
+- Pre-commit hook runs Tier 1 only (keeps the ~8s budget)
+- All tests require `fossil` binary in PATH (skip gracefully if absent)
+
+## What This Catches
+
+| Bug class | How caught |
+|---|---|
+| Delta format mismatch | `delta_codec/fossil_creates_we_apply` |
+| Checksum algorithm wrong | `delta_codec/round_trip_large_payload` + `verifyAllBlobs` |
+| CFile usize for deltas | `clone_from_fossil/commit_chain_with_deltas` |
+| SHA3 hash mismatch | `hash_compat/sha3_vs_fossil` |
+| Blob compression format | `verifyWithFossilRebuild` after every clone |
+| Deep delta chain corruption | `large_repo/clone_and_expand_all` |
+| Incremental sync corruption | `incremental_sync/bidirectional` |
+| UV binary content encoding | `clone_from_us/with_uv_files` |
+
+## Non-Goals
+
+- Performance benchmarking (separate concern, CDG-137)
+- Concurrent/stress testing (covered by DST)
+- Network fault injection (covered by sim fault proxy)
+- WASM compatibility (separate test tier)

--- a/go-libfossil/blob/blob.go
+++ b/go-libfossil/blob/blob.go
@@ -184,12 +184,23 @@ func Load(q db.Querier, rid libfossil.FslID) (result []byte, err error) {
 		return nil, fmt.Errorf("blob.Load: rid %d has NULL content", rid)
 	}
 
-	// Fossil convention: if stored bytes == declared size, content is uncompressed.
-	// If stored bytes < declared size, content is zlib-compressed
-	// (with 4-byte BE size prefix handled by Decompress).
+	// Fossil stores blobs as [4-byte BE uncompressed-size][zlib data].
+	// When the compressed form happens to be the same length as the
+	// uncompressed content (rare but real — ~2 in 66K in the Fossil SCM
+	// repo), we must still decompress. Detect compressed content by
+	// checking for the 4-byte BE prefix matching the declared size
+	// followed by a zlib header (0x78).
+	if len(content) >= 6 {
+		prefixSize := int64(content[0])<<24 | int64(content[1])<<16 | int64(content[2])<<8 | int64(content[3])
+		if prefixSize == size && content[4] == 0x78 {
+			return Decompress(content)
+		}
+	}
+	// No compression prefix — content is stored uncompressed.
 	if int64(len(content)) == size {
 		return content, nil
 	}
+	// Stored bytes < declared size — compressed.
 	return Decompress(content)
 }
 

--- a/go-libfossil/delta/delta.go
+++ b/go-libfossil/delta/delta.go
@@ -103,9 +103,9 @@ func Apply(source, delta []byte) (result []byte, err error) {
 		}
 
 		switch cmd {
-		case '@':
-			offset := cnt
-			cnt, err = r.getInt()
+			case '@':
+			// Fossil delta format: count@offset, (first int = byte count, second = source offset)
+			offset, err := r.getInt()
 			if err != nil {
 				return nil, err
 			}
@@ -157,16 +157,34 @@ func Apply(source, delta []byte) (result []byte, err error) {
 	return nil, fmt.Errorf("%w: missing terminator", ErrInvalidDelta)
 }
 
+// Checksum computes Fossil's delta checksum, matching delta.c's checksum().
+// Sum of 4-byte big-endian words, with trailing bytes in big-endian position.
 func Checksum(data []byte) uint32 {
 	if data == nil {
 		panic("delta.Checksum: data must not be nil")
 	}
-	var sum0, sum1 uint16
-	for _, b := range data {
-		sum0 += uint16(b)
-		sum1 += sum0
+	var sum uint32
+	i := 0
+	n := len(data)
+
+	for n >= 4 {
+		sum += uint32(data[i])<<24 | uint32(data[i+1])<<16 | uint32(data[i+2])<<8 | uint32(data[i+3])
+		i += 4
+		n -= 4
 	}
-	return uint32(sum0) | (uint32(sum1) << 16)
+
+	switch n {
+	case 3:
+		sum += uint32(data[i+2]) << 8
+		fallthrough
+	case 2:
+		sum += uint32(data[i+1]) << 16
+		fallthrough
+	case 1:
+		sum += uint32(data[i]) << 24
+	}
+
+	return sum
 }
 
 const zDigitsEnc = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"
@@ -279,9 +297,10 @@ func emitMatches(source, target []byte, heads []int, entries []hashEntry, mask i
 
 		if bestLen >= nHash {
 			flushInsert()
-			buf = appendInt(buf, uint64(bestOff))
-			buf = append(buf, '@')
+			// Fossil delta format: count@offset,
 			buf = appendInt(buf, uint64(bestLen))
+			buf = append(buf, '@')
+			buf = appendInt(buf, uint64(bestOff))
 			buf = append(buf, ',')
 			tPos += bestLen
 		} else {

--- a/go-libfossil/delta/delta_test.go
+++ b/go-libfossil/delta/delta_test.go
@@ -180,9 +180,10 @@ func manualDelta(targetLen uint64, ops []deltaOp, checksum uint32) []byte {
 	for _, op := range ops {
 		switch op.opType {
 		case '@':
-			writeInt(&buf, op.offset)
-			buf.WriteByte('@')
+			// Fossil format: count@offset,
 			writeInt(&buf, op.length)
+			buf.WriteByte('@')
+			writeInt(&buf, op.offset)
 			buf.WriteByte(',')
 		case ':':
 			writeInt(&buf, uint64(len(op.data)))

--- a/go-libfossil/delta/fossil_compat_test.go
+++ b/go-libfossil/delta/fossil_compat_test.go
@@ -1,0 +1,233 @@
+package delta
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestFossilDeltaFormat_CopyCommand verifies count@offset order (was swapped).
+func TestFossilDeltaFormat_CopyCommand(t *testing.T) {
+	source := []byte("ABCDEFGHIJKLMNOP")
+	target := []byte("EFGHIJKL") // copy 8 from offset 4
+	cs := Checksum(target)
+
+	var d []byte
+	d = append(d, encodeTestInt(uint64(len(target)))...)
+	d = append(d, '\n')
+	d = append(d, encodeTestInt(8)...)
+	d = append(d, '@')
+	d = append(d, encodeTestInt(4)...)
+	d = append(d, ',')
+	d = append(d, encodeTestInt(uint64(cs))...)
+	d = append(d, ';')
+
+	got, err := Apply(source, d)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !bytes.Equal(got, target) {
+		t.Fatalf("Apply = %q, want %q", got, target)
+	}
+}
+
+// TestFossilDeltaFormat_MixedCommands exercises copy + insert interleaving.
+func TestFossilDeltaFormat_MixedCommands(t *testing.T) {
+	source := []byte("The quick brown fox jumps over the lazy dog")
+	target := []byte("The slow brown cat jumps over the lazy dog!")
+	cs := Checksum(target)
+
+	var d []byte
+	d = append(d, encodeTestInt(uint64(len(target)))...)
+	d = append(d, '\n')
+	// copy 4@0, ("The ")
+	d = append(d, encodeTestInt(4)...)
+	d = append(d, '@')
+	d = append(d, encodeTestInt(0)...)
+	d = append(d, ',')
+	// 4:slow
+	d = append(d, encodeTestInt(4)...)
+	d = append(d, ':')
+	d = append(d, "slow"...)
+	// copy 7@9, (" brown ")
+	d = append(d, encodeTestInt(7)...)
+	d = append(d, '@')
+	d = append(d, encodeTestInt(9)...)
+	d = append(d, ',')
+	// 3:cat
+	d = append(d, encodeTestInt(3)...)
+	d = append(d, ':')
+	d = append(d, "cat"...)
+	// copy 24@19,
+	d = append(d, encodeTestInt(24)...)
+	d = append(d, '@')
+	d = append(d, encodeTestInt(19)...)
+	d = append(d, ',')
+	// 1:!
+	d = append(d, encodeTestInt(1)...)
+	d = append(d, ':')
+	d = append(d, '!')
+	// checksum;
+	d = append(d, encodeTestInt(uint64(cs))...)
+	d = append(d, ';')
+
+	got, err := Apply(source, d)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !bytes.Equal(got, target) {
+		t.Fatalf("Apply = %q, want %q", got, target)
+	}
+}
+
+// TestFossilDeltaFormat_Asymmetric catches the count/offset swap bug.
+// With the old bug, count=3 offset=10 would be misread as count=10 offset=3.
+func TestFossilDeltaFormat_Asymmetric(t *testing.T) {
+	source := []byte("0123456789ABCDEF")
+	target := []byte("ABC") // copy 3 from offset 10
+	cs := Checksum(target)
+
+	var d []byte
+	d = append(d, encodeTestInt(uint64(len(target)))...)
+	d = append(d, '\n')
+	d = append(d, encodeTestInt(3)...)
+	d = append(d, '@')
+	d = append(d, encodeTestInt(10)...)
+	d = append(d, ',')
+	d = append(d, encodeTestInt(uint64(cs))...)
+	d = append(d, ';')
+
+	got, err := Apply(source, d)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if string(got) != "ABC" {
+		t.Fatalf("Apply = %q, want %q", got, target)
+	}
+}
+
+// TestFossilCLI_DeltaRoundTrip uses `fossil test-delta-create` and
+// `fossil test-delta-apply` to generate a ground-truth delta, then
+// verifies our Apply produces identical output.
+func TestFossilCLI_DeltaRoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil binary not in PATH")
+	}
+
+	source := bytes.Repeat([]byte("The quick brown fox jumps over the lazy dog. "), 100)
+	target := make([]byte, len(source))
+	copy(target, source)
+	copy(target[500:], []byte("CHANGED CONTENT HERE — verifying delta interop!"))
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.bin")
+	tgtFile := filepath.Join(dir, "tgt.bin")
+	deltaFile := filepath.Join(dir, "delta.bin")
+	resultFile := filepath.Join(dir, "result.bin")
+
+	if err := writeFile(srcFile, source); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFile(tgtFile, target); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create delta with fossil CLI
+	if out, err := exec.Command("fossil", "test-delta-create", srcFile, tgtFile, deltaFile).CombinedOutput(); err != nil {
+		t.Fatalf("fossil test-delta-create: %v\n%s", err, out)
+	}
+
+	fossilDelta, err := readFile(deltaFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Fossil-generated delta: %d bytes (source=%d, target=%d)", len(fossilDelta), len(source), len(target))
+
+	// Apply with our code
+	got, err := Apply(source, fossilDelta)
+	if err != nil {
+		t.Fatalf("Apply fossil delta: %v", err)
+	}
+	if !bytes.Equal(got, target) {
+		t.Fatalf("output mismatch: got %d bytes, want %d", len(got), len(target))
+	}
+
+	// Also verify fossil's own apply produces same result
+	if out, err := exec.Command("fossil", "test-delta-apply", srcFile, deltaFile, resultFile).CombinedOutput(); err != nil {
+		t.Fatalf("fossil test-delta-apply: %v\n%s", err, out)
+	}
+	fossilResult, err := readFile(resultFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, fossilResult) {
+		t.Fatal("our Apply disagrees with fossil test-delta-apply")
+	}
+}
+
+// TestFossilCLI_CreateRoundTrip verifies that deltas we Create can be
+// applied by the fossil CLI.
+func TestFossilCLI_CreateRoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("fossil"); err != nil {
+		t.Skip("fossil binary not in PATH")
+	}
+
+	source := bytes.Repeat([]byte("abcdefghijklmnop"), 500)
+	target := make([]byte, len(source))
+	copy(target, source)
+	copy(target[2000:], []byte("OUR DELTA FORMAT VERIFIED"))
+
+	dir := t.TempDir()
+	srcFile := filepath.Join(dir, "src.bin")
+	deltaFile := filepath.Join(dir, "delta.bin")
+	resultFile := filepath.Join(dir, "result.bin")
+
+	if err := writeFile(srcFile, source); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create delta with our code
+	d := Create(source, target)
+	if err := writeFile(deltaFile, d); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Our delta: %d bytes (source=%d, target=%d)", len(d), len(source), len(target))
+
+	// Apply with fossil CLI
+	if out, err := exec.Command("fossil", "test-delta-apply", srcFile, deltaFile, resultFile).CombinedOutput(); err != nil {
+		t.Fatalf("fossil test-delta-apply: %v\n%s", err, out)
+	}
+
+	fossilResult, err := readFile(resultFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fossilResult, target) {
+		t.Fatalf("fossil couldn't apply our delta: got %d bytes, want %d", len(fossilResult), len(target))
+	}
+}
+
+func encodeTestInt(v uint64) []byte {
+	const enc = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~"
+	if v == 0 {
+		return []byte{'0'}
+	}
+	var tmp [13]byte
+	i := len(tmp)
+	for v > 0 {
+		i--
+		tmp[i] = enc[v&0x3f]
+		v >>= 6
+	}
+	return tmp[i:]
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0644)
+}
+
+func readFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/go-libfossil/xfer/decode.go
+++ b/go-libfossil/xfer/decode.go
@@ -369,7 +369,12 @@ func parseCFile(r *bufio.Reader, args []string) (Card, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(decompressed) != usize {
+	// For non-delta cfiles, decompressed size == usize (full content).
+	// For delta cfiles, decompressed size is the delta payload size, which
+	// is smaller than usize (the fully expanded content size). Fossil's
+	// send_compressed_file sets usize = blob.size (full content) regardless.
+	// Only validate for non-delta cards where the sizes must match.
+	if c.DeltaSrc == "" && len(decompressed) != usize {
 		return nil, fmt.Errorf("xfer: cfile usize mismatch: header says %d, got %d", usize, len(decompressed))
 	}
 	c.USize = usize

--- a/sim/equivalence_test.go
+++ b/sim/equivalence_test.go
@@ -361,7 +361,8 @@ func TestFossilToLeaf(t *testing.T) {
 	})
 
 	t.Run("commit_chain", func(t *testing.T) {
-		t.Skip("KNOWN ISSUE: fossil server sends cfile cards with incorrect usize headers for commit chains")
+		// Was skipped: "KNOWN ISSUE: fossil server sends cfile cards with incorrect usize headers"
+		// Root cause: usize = full expanded content size, not decompressed delta size
 		testFossilToLeaf(t,
 			[]map[string]string{
 				{"base.txt": "base content"},

--- a/sim/interop_test.go
+++ b/sim/interop_test.go
@@ -82,6 +82,56 @@ func verifyAllBlobs(t *testing.T, d *db.DB) {
 	t.Logf("verifyAllBlobs: checked %d blobs, %d errors", count, errors)
 }
 
+// verifySampledBlobs is like verifyAllBlobs but samples N random blobs.
+// Use for large repos where verifying all blobs would be too slow.
+func verifySampledBlobs(t *testing.T, d *db.DB, n int) {
+	t.Helper()
+
+	rows, err := d.Query("SELECT rid, uuid, size FROM blob WHERE size >= 0 AND content IS NOT NULL ORDER BY RANDOM() LIMIT ?", n)
+	if err != nil {
+		t.Fatalf("verifySampledBlobs query: %v", err)
+	}
+	defer rows.Close()
+
+	var count, failures int
+	for rows.Next() {
+		var rid int64
+		var uuid string
+		var size int
+
+		if err := rows.Scan(&rid, &uuid, &size); err != nil {
+			t.Errorf("scan: %v", err)
+			failures++
+			continue
+		}
+
+		expanded, err := content.Expand(d, libfossil.FslID(rid))
+		if err != nil {
+			t.Errorf("rid=%d uuid=%s: expand: %v", rid, uuid[:16], err)
+			failures++
+			continue
+		}
+
+		var computed string
+		if len(uuid) > 40 {
+			computed = hash.SHA3(expanded)
+		} else {
+			computed = hash.SHA1(expanded)
+		}
+		if computed != uuid {
+			t.Errorf("rid=%d uuid=%s: hash mismatch: got %s", rid, uuid[:16], computed[:16])
+			failures++
+		}
+		count++
+	}
+
+	if failures > 0 {
+		t.Errorf("verifySampledBlobs: %d/%d failed", failures, count)
+	} else {
+		t.Logf("verifySampledBlobs: all %d blobs verified", count)
+	}
+}
+
 // verifyWithFossilRebuild runs `fossil rebuild` on the given repo path.
 // Fatals the test if rebuild fails.
 func verifyWithFossilRebuild(t *testing.T, repoPath string) {
@@ -917,7 +967,9 @@ func TestInterop(t *testing.T) {
 			}
 			defer d.Close()
 
-			verifyAllBlobs(t, d)
+			// Sample 2000 random blobs (full 66K takes >5min with deep chains).
+			// Covers diverse chain depths and content types.
+			verifySampledBlobs(t, d, 2000)
 		})
 
 		t.Run("verify_hash_integrity", func(t *testing.T) {

--- a/sim/interop_test.go
+++ b/sim/interop_test.go
@@ -967,9 +967,7 @@ func TestInterop(t *testing.T) {
 			}
 			defer d.Close()
 
-			// Sample 2000 random blobs (full 66K takes >5min with deep chains).
-			// Covers diverse chain depths and content types.
-			verifySampledBlobs(t, d, 2000)
+			verifySampledBlobs(t, d, 5000)
 		})
 
 		t.Run("verify_hash_integrity", func(t *testing.T) {
@@ -981,13 +979,13 @@ func TestInterop(t *testing.T) {
 			}
 			defer d.Close()
 
-			// Sample 500 random blobs
+			// Sample 2000 random blobs and cross-check against fossil artifact
 			rows, err := d.Query(`
 				SELECT rid, uuid
 				FROM blob
 				WHERE size >= 0 AND content IS NOT NULL
 				ORDER BY RANDOM()
-				LIMIT 500
+				LIMIT 2000
 			`)
 			if err != nil {
 				t.Fatalf("query random blobs: %v", err)

--- a/sim/interop_test.go
+++ b/sim/interop_test.go
@@ -1,0 +1,385 @@
+package sim
+
+import (
+	"bytes"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/content"
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/delta"
+	"github.com/dmestas/edgesync/go-libfossil/hash"
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
+)
+
+// verifyAllBlobs queries all non-phantom blobs from the database,
+// expands each blob via content.Expand (handles delta chains),
+// and verifies the hash matches the uuid. Reports failures with rid/uuid details.
+func verifyAllBlobs(t *testing.T, d *db.DB) {
+	t.Helper()
+
+	rows, err := d.Query("SELECT rid, uuid, size FROM blob WHERE size >= 0 AND content IS NOT NULL")
+	if err != nil {
+		t.Fatalf("query blobs: %v", err)
+	}
+	defer rows.Close()
+
+	var count, errors int
+	for rows.Next() {
+		var rid int64
+		var uuid string
+		var size int
+
+		if err := rows.Scan(&rid, &uuid, &size); err != nil {
+			t.Errorf("scan blob row: %v", err)
+			errors++
+			continue
+		}
+
+		// Expand blob content (resolves delta chains).
+		expanded, err := content.Expand(d, libfossil.FslID(rid))
+		if err != nil {
+			t.Errorf("blob rid=%d uuid=%s: expand failed: %v", rid, uuid, err)
+			errors++
+			continue
+		}
+
+		// Compute hash based on uuid length.
+		var computedHash string
+		if len(uuid) > 40 {
+			// SHA3-256
+			computedHash = hash.SHA3(expanded)
+		} else {
+			// SHA1
+			computedHash = hash.SHA1(expanded)
+		}
+
+		if computedHash != uuid {
+			t.Errorf("blob rid=%d: hash mismatch\n  got:  %s\n  want: %s", rid, computedHash, uuid)
+			errors++
+		}
+
+		count++
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Errorf("iterate blobs: %v", err)
+		errors++
+	}
+
+	t.Logf("verifyAllBlobs: checked %d blobs, %d errors", count, errors)
+}
+
+// verifyWithFossilRebuild runs `fossil rebuild` on the given repo path.
+// Fatals the test if rebuild fails.
+func verifyWithFossilRebuild(t *testing.T, repoPath string) {
+	t.Helper()
+
+	cmd := exec.Command("fossil", "rebuild", repoPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil rebuild failed: %v\n%s", err, out)
+	}
+	t.Logf("fossil rebuild passed: %s", strings.TrimSpace(string(out)))
+}
+
+// fossilExec runs `fossil <args>` and returns stdout as a string.
+// Fatals the test if the command fails.
+func fossilExec(t *testing.T, args ...string) string {
+	t.Helper()
+	requireFossil(t)
+
+	cmd := exec.Command("fossil", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("fossil %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// cloneFossilSCMRepo returns the absolute path to testdata/fossil.fossil.
+// If the file does not exist, attempts to clone it from fossil-scm.org.
+// Skips the test if cloning fails.
+func cloneFossilSCMRepo(t *testing.T) string {
+	t.Helper()
+	requireFossil(t)
+
+	// Determine path relative to sim/ directory.
+	// The test is running in the sim/ package, so we go up one level.
+	repoPath, err := filepath.Abs("../testdata/fossil.fossil")
+	if err != nil {
+		t.Fatalf("resolve testdata path: %v", err)
+	}
+
+	// If it exists, return it.
+	if _, err := os.Stat(repoPath); err == nil {
+		return repoPath
+	}
+
+	// Create testdata directory if needed.
+	testdataDir := filepath.Dir(repoPath)
+	if err := os.MkdirAll(testdataDir, 0755); err != nil {
+		t.Fatalf("create testdata dir: %v", err)
+	}
+
+	// Attempt to clone.
+	t.Logf("Cloning fossil-scm.org repo to %s (this may take a minute)...", repoPath)
+	cmd := exec.Command("fossil", "clone", "https://fossil-scm.org/home", repoPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("fossil clone failed, skipping test: %v\n%s", err, out)
+	}
+
+	t.Logf("Successfully cloned fossil.fossil (%d bytes)", func() int64 {
+		info, _ := os.Stat(repoPath)
+		if info != nil {
+			return info.Size()
+		}
+		return 0
+	}())
+
+	return repoPath
+}
+
+// TestInterop contains interoperability tests between our Go implementation
+// and the canonical Fossil C implementation.
+func TestInterop(t *testing.T) {
+	requireFossil(t)
+
+	// Task 2: Delta codec tests
+	t.Run("delta_codec", func(t *testing.T) {
+		t.Run("fossil_creates_we_apply", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create source: 4500 bytes of repeated text
+			source := bytes.Repeat([]byte("The quick brown fox jumps over the lazy dog.\n"), 100)
+			if len(source) < 4500 {
+				source = append(source, bytes.Repeat([]byte("x"), 4500-len(source))...)
+			}
+			source = source[:4500]
+
+			// Create target: modify source at a few positions
+			target := make([]byte, len(source))
+			copy(target, source)
+			copy(target[100:], []byte("MODIFIED SECTION HERE"))
+			copy(target[1000:], []byte("ANOTHER CHANGE"))
+			copy(target[3000:], []byte("YET ANOTHER EDIT"))
+
+			// Write to disk
+			srcPath := filepath.Join(dir, "source.txt")
+			tgtPath := filepath.Join(dir, "target.txt")
+			deltaPath := filepath.Join(dir, "delta.bin")
+
+			if err := os.WriteFile(srcPath, source, 0644); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			if err := os.WriteFile(tgtPath, target, 0644); err != nil {
+				t.Fatalf("write target: %v", err)
+			}
+
+			// Use fossil to create delta
+			cmd := exec.Command("fossil", "test-delta-create", srcPath, tgtPath, deltaPath)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("fossil test-delta-create failed: %v\n%s", err, out)
+			}
+
+			// Read the delta file
+			fossilDelta, err := os.ReadFile(deltaPath)
+			if err != nil {
+				t.Fatalf("read delta: %v", err)
+			}
+
+			t.Logf("Fossil created delta: %d bytes (source=%d, target=%d)",
+				len(fossilDelta), len(source), len(target))
+
+			// Apply delta using our Go implementation
+			result, err := delta.Apply(source, fossilDelta)
+			if err != nil {
+				t.Fatalf("delta.Apply failed: %v", err)
+			}
+
+			if !bytes.Equal(result, target) {
+				t.Errorf("delta.Apply result mismatch\ngot:  %d bytes\nwant: %d bytes",
+					len(result), len(target))
+				// Show first difference
+				for i := 0; i < len(result) && i < len(target); i++ {
+					if result[i] != target[i] {
+						t.Errorf("first difference at byte %d: got %02x want %02x",
+							i, result[i], target[i])
+						break
+					}
+				}
+			} else {
+				t.Logf("SUCCESS: delta.Apply produced correct target")
+			}
+		})
+
+		t.Run("we_create_fossil_applies", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create source: 8000 bytes
+			source := bytes.Repeat([]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"), 150)
+			if len(source) < 8000 {
+				source = append(source, bytes.Repeat([]byte("x"), 8000-len(source))...)
+			}
+			source = source[:8000]
+
+			// Create target: modify source
+			target := make([]byte, len(source))
+			copy(target, source)
+			copy(target[500:], []byte("GOLANG DELTA CREATION TEST"))
+			copy(target[2000:], []byte("MIDDLE MODIFICATION"))
+			copy(target[6000:], []byte("END MODIFICATION"))
+
+			// Create delta using our Go implementation
+			goDelta := delta.Create(source, target)
+
+			t.Logf("Go created delta: %d bytes (source=%d, target=%d)",
+				len(goDelta), len(source), len(target))
+
+			// Write to disk
+			srcPath := filepath.Join(dir, "source.txt")
+			deltaPath := filepath.Join(dir, "delta.bin")
+			resultPath := filepath.Join(dir, "result.txt")
+
+			if err := os.WriteFile(srcPath, source, 0644); err != nil {
+				t.Fatalf("write source: %v", err)
+			}
+			if err := os.WriteFile(deltaPath, goDelta, 0644); err != nil {
+				t.Fatalf("write delta: %v", err)
+			}
+
+			// Use fossil to apply delta
+			cmd := exec.Command("fossil", "test-delta-apply", srcPath, deltaPath, resultPath)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("fossil test-delta-apply failed: %v\n%s", err, out)
+			}
+
+			// Read result
+			result, err := os.ReadFile(resultPath)
+			if err != nil {
+				t.Fatalf("read result: %v", err)
+			}
+
+			if !bytes.Equal(result, target) {
+				t.Errorf("fossil apply result mismatch\ngot:  %d bytes\nwant: %d bytes",
+					len(result), len(target))
+				// Show first difference
+				for i := 0; i < len(result) && i < len(target); i++ {
+					if result[i] != target[i] {
+						t.Errorf("first difference at byte %d: got %02x want %02x",
+							i, result[i], target[i])
+						break
+					}
+				}
+			} else {
+				t.Logf("SUCCESS: fossil test-delta-apply produced correct target")
+			}
+		})
+
+		t.Run("round_trip_large_payload", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create 64KB of random-ish data (seeded for reproducibility)
+			rng := rand.New(rand.NewSource(12345))
+			source := make([]byte, 64*1024)
+			for i := range source {
+				source[i] = byte('A' + rng.Intn(26)) // uppercase letters
+			}
+
+			// Modify ~5% scattered positions
+			target := make([]byte, len(source))
+			copy(target, source)
+			modifyCount := len(source) / 20 // ~5%
+			for i := 0; i < modifyCount; i++ {
+				pos := rng.Intn(len(target))
+				target[pos] = byte('a' + rng.Intn(26)) // lowercase = modified
+			}
+
+			t.Logf("Testing round trip with %d byte payload, %d modifications",
+				len(source), modifyCount)
+
+			// Test 1: Fossil creates, we apply
+			t.Run("fossil_creates", func(t *testing.T) {
+				srcPath := filepath.Join(dir, "rt_source1.txt")
+				tgtPath := filepath.Join(dir, "rt_target1.txt")
+				deltaPath := filepath.Join(dir, "rt_delta1.bin")
+
+				if err := os.WriteFile(srcPath, source, 0644); err != nil {
+					t.Fatalf("write source: %v", err)
+				}
+				if err := os.WriteFile(tgtPath, target, 0644); err != nil {
+					t.Fatalf("write target: %v", err)
+				}
+
+				cmd := exec.Command("fossil", "test-delta-create", srcPath, tgtPath, deltaPath)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("fossil test-delta-create failed: %v\n%s", err, out)
+				}
+
+				fossilDelta, err := os.ReadFile(deltaPath)
+				if err != nil {
+					t.Fatalf("read delta: %v", err)
+				}
+
+				t.Logf("Fossil delta: %d bytes (%.1f%% of source)",
+					len(fossilDelta), 100*float64(len(fossilDelta))/float64(len(source)))
+
+				result, err := delta.Apply(source, fossilDelta)
+				if err != nil {
+					t.Fatalf("delta.Apply failed: %v", err)
+				}
+
+				if !bytes.Equal(result, target) {
+					t.Errorf("round trip mismatch (fossil creates, we apply)")
+				} else {
+					t.Logf("SUCCESS: fossil→go round trip")
+				}
+			})
+
+			// Test 2: We create, fossil applies
+			t.Run("go_creates", func(t *testing.T) {
+				goDelta := delta.Create(source, target)
+
+				t.Logf("Go delta: %d bytes (%.1f%% of source)",
+					len(goDelta), 100*float64(len(goDelta))/float64(len(source)))
+
+				srcPath := filepath.Join(dir, "rt_source2.txt")
+				deltaPath := filepath.Join(dir, "rt_delta2.bin")
+				resultPath := filepath.Join(dir, "rt_result2.txt")
+
+				if err := os.WriteFile(srcPath, source, 0644); err != nil {
+					t.Fatalf("write source: %v", err)
+				}
+				if err := os.WriteFile(deltaPath, goDelta, 0644); err != nil {
+					t.Fatalf("write delta: %v", err)
+				}
+
+				cmd := exec.Command("fossil", "test-delta-apply", srcPath, deltaPath, resultPath)
+				out, err := cmd.CombinedOutput()
+				if err != nil {
+					t.Fatalf("fossil test-delta-apply failed: %v\n%s", err, out)
+				}
+
+				result, err := os.ReadFile(resultPath)
+				if err != nil {
+					t.Fatalf("read result: %v", err)
+				}
+
+				if !bytes.Equal(result, target) {
+					t.Errorf("round trip mismatch (we create, fossil applies)")
+				} else {
+					t.Logf("SUCCESS: go→fossil round trip")
+				}
+			})
+		})
+	})
+}

--- a/sim/interop_test.go
+++ b/sim/interop_test.go
@@ -2,19 +2,26 @@ package sim
 
 import (
 	"bytes"
+	"context"
+	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/content"
 	"github.com/dmestas/edgesync/go-libfossil/db"
+	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
 	"github.com/dmestas/edgesync/go-libfossil/delta"
 	"github.com/dmestas/edgesync/go-libfossil/hash"
-	_ "github.com/dmestas/edgesync/go-libfossil/db/driver/modernc"
+	"github.com/dmestas/edgesync/go-libfossil/manifest"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+	"github.com/dmestas/edgesync/go-libfossil/sync"
+	"github.com/dmestas/edgesync/go-libfossil/uv"
 )
 
 // verifyAllBlobs queries all non-phantom blobs from the database,
@@ -380,6 +387,596 @@ func TestInterop(t *testing.T) {
 					t.Logf("SUCCESS: go→fossil round trip")
 				}
 			})
+		})
+	})
+
+	// Task 3: Clone from us (Go serves, fossil clones)
+	t.Run("clone_from_us", func(t *testing.T) {
+		t.Run("single_commit", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create Go repo with one checkin
+			r := leafRepo(t, dir, "test-repo")
+			defer r.Close()
+
+			files := []manifest.File{
+				{Name: "README.md", Content: []byte("# Test Repository\n\nThis is a test.")},
+				{Name: "main.go", Content: []byte("package main\n\nfunc main() {}\n")},
+			}
+			checkin(t, r, 0, files, "Initial commit")
+
+			// Crosslink before serving
+			if _, err := manifest.Crosslink(r); err != nil {
+				t.Fatalf("crosslink: %v", err)
+			}
+			r.Close()
+
+			// Reopen and serve
+			r2, err := repo.Open(r.Path())
+			if err != nil {
+				t.Fatalf("reopen repo: %v", err)
+			}
+			defer r2.Close()
+
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			// Fossil clone from our HTTP server
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", "http://"+addr, clonePath)
+
+			// Verify with fossil rebuild
+			verifyWithFossilRebuild(t, clonePath)
+
+			// Checkout and verify files
+			workDir := fossilCheckout(t, clonePath)
+			assertFiles(t, workDir, map[string]string{
+				"README.md": "# Test Repository\n\nThis is a test.",
+				"main.go":   "package main\n\nfunc main() {}\n",
+			})
+		})
+
+		t.Run("commit_chain", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create repo with 5 sequential commits (large enough to trigger deltas)
+			r := leafRepo(t, dir, "chain-repo")
+			defer r.Close()
+
+			var parent int64
+			for i := 1; i <= 5; i++ {
+				// Pad content to 200+ bytes to encourage delta formation
+				var files []manifest.File
+				// Keep all previous files plus new one
+				for j := 1; j <= i; j++ {
+					fileContent := fmt.Sprintf("Commit %d\n%s", j, strings.Repeat("x", 200))
+					files = append(files, manifest.File{
+						Name:    fmt.Sprintf("file%d.txt", j),
+						Content: []byte(fileContent),
+					})
+				}
+				parent = checkin(t, r, parent, files, fmt.Sprintf("Commit %d", i))
+			}
+
+			if _, err := manifest.Crosslink(r); err != nil {
+				t.Fatalf("crosslink: %v", err)
+			}
+			r.Close()
+
+			// Reopen and serve
+			r2, err := repo.Open(r.Path())
+			if err != nil {
+				t.Fatalf("reopen repo: %v", err)
+			}
+			defer r2.Close()
+
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			// Clone and rebuild
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", "http://"+addr, clonePath)
+			verifyWithFossilRebuild(t, clonePath)
+		})
+
+		t.Run("with_uv_files", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create repo with checkin and UV files
+			r := leafRepo(t, dir, "uv-repo")
+			defer r.Close()
+
+			files := []manifest.File{
+				{Name: "README.md", Content: []byte("# UV Test\n")},
+			}
+			checkin(t, r, 0, files, "Initial commit")
+
+			// Ensure UV schema exists
+			if err := uv.EnsureSchema(r.DB()); err != nil {
+				t.Fatalf("ensure UV schema: %v", err)
+			}
+
+			// Write UV files
+			textContent := []byte("This is an unversioned text file.\n")
+			if err := uv.Write(r.DB(), "text-file.txt", textContent, 0); err != nil {
+				t.Fatalf("write UV text file: %v", err)
+			}
+
+			// Write 4KB binary UV file
+			binaryContent := make([]byte, 4096)
+			rng := rand.New(rand.NewSource(42))
+			rng.Read(binaryContent)
+			if err := uv.Write(r.DB(), "binary-file.bin", binaryContent, 0); err != nil {
+				t.Fatalf("write UV binary file: %v", err)
+			}
+
+			if _, err := manifest.Crosslink(r); err != nil {
+				t.Fatalf("crosslink: %v", err)
+			}
+			r.Close()
+
+			// Reopen and serve
+			r2, err := repo.Open(r.Path())
+			if err != nil {
+				t.Fatalf("reopen repo: %v", err)
+			}
+			defer r2.Close()
+
+			addr, cancel := serveLeafHTTP(t, r2)
+			defer cancel()
+
+			// Clone with --unversioned flag to pull UV files
+			clonePath := filepath.Join(dir, "clone.fossil")
+			fossilExec(t, "clone", "--unversioned", "http://"+addr, clonePath)
+			verifyWithFossilRebuild(t, clonePath)
+
+			// Verify UV files
+			uvList := fossilExec(t, "uv", "list", "-R", clonePath)
+			if !strings.Contains(uvList, "text-file.txt") {
+				t.Errorf("UV list missing text-file.txt: %s", uvList)
+			}
+			if !strings.Contains(uvList, "binary-file.bin") {
+				t.Errorf("UV list missing binary-file.bin: %s", uvList)
+			}
+
+			uvText := fossilExec(t, "uv", "cat", "text-file.txt", "-R", clonePath)
+			if uvText != string(textContent) {
+				t.Errorf("UV text content mismatch:\ngot:  %q\nwant: %q", uvText, string(textContent))
+			}
+		})
+	})
+
+	// Task 4: Clone from fossil (fossil serves, we clone)
+	t.Run("clone_from_fossil", func(t *testing.T) {
+		t.Run("single_commit", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create fossil repo
+			fossilPath := fossilInit(t, dir, "fossil-repo")
+			workDir := fossilCheckout(t, fossilPath)
+
+			files := map[string]string{
+				"hello.txt": "Hello, Fossil!\n",
+			}
+			fossilCommitFiles(t, fossilPath, workDir, files, "Initial commit")
+
+			// Serve fossil
+			serverURL := startFossilServe(t, fossilPath)
+
+			// Clone with our Go implementation
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			defer leafR.Close()
+
+			// Verify all blobs
+			verifyAllBlobs(t, leafR.DB())
+		})
+
+		t.Run("commit_chain_with_deltas", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create fossil repo with 5 commits
+			fossilPath := fossilInit(t, dir, "fossil-chain")
+			workDir := fossilCheckout(t, fossilPath)
+
+			for i := 1; i <= 5; i++ {
+				content := fmt.Sprintf("Commit %d\n%s", i, strings.Repeat("y", 300))
+				files := map[string]string{
+					fmt.Sprintf("file%d.txt", i): content,
+				}
+				fossilCommitFiles(t, fossilPath, workDir, files, fmt.Sprintf("Commit %d", i))
+			}
+
+			serverURL := startFossilServe(t, fossilPath)
+
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			defer leafR.Close()
+
+			verifyAllBlobs(t, leafR.DB())
+		})
+
+		t.Run("expand_and_verify_all", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create fossil repo with larger files (add new files each iteration to avoid detection issues)
+			fossilPath := fossilInit(t, dir, "fossil-large")
+			workDir := fossilCheckout(t, fossilPath)
+
+			for i := 1; i <= 3; i++ {
+				// Create unique file for each commit (4KB+ each)
+				content := strings.Repeat(fmt.Sprintf("=== File %d line %%d ===\n", i), 300)
+				files := map[string]string{
+					fmt.Sprintf("file%d.txt", i): fmt.Sprintf(content, i),
+				}
+				fossilCommitFiles(t, fossilPath, workDir, files, fmt.Sprintf("Commit %d", i))
+			}
+
+			serverURL := startFossilServe(t, fossilPath)
+
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			defer leafR.Close()
+
+			verifyAllBlobs(t, leafR.DB())
+			// Note: Not running fossil rebuild on leaf repo - it was created by sync.Clone,
+			// and verifyAllBlobs already ensures all content expands correctly.
+		})
+	})
+
+	// Task 5: Incremental sync (bidirectional sync with fossil)
+	t.Run("incremental_sync", func(t *testing.T) {
+		t.Run("fossil_commits_we_pull", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create and clone from fossil
+			fossilPath := fossilInit(t, dir, "fossil-pull")
+			workDir := fossilCheckout(t, fossilPath)
+
+			files := map[string]string{"initial.txt": "Initial\n"}
+			fossilCommitFiles(t, fossilPath, workDir, files, "Initial")
+
+			serverURL := startFossilServe(t, fossilPath)
+
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+			leafR.Close()
+
+			// Fossil makes 3 more commits
+			for i := 1; i <= 3; i++ {
+				files := map[string]string{
+					fmt.Sprintf("file%d.txt", i): fmt.Sprintf("Content %d\n", i),
+				}
+				fossilCommitFiles(t, fossilPath, workDir, files, fmt.Sprintf("Commit %d", i))
+			}
+
+			// Pull changes
+			leafR, err = repo.Open(leafPath)
+			if err != nil {
+				t.Fatalf("reopen leaf: %v", err)
+			}
+			defer leafR.Close()
+
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+
+			_, err = sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+				ProjectCode: projCode,
+				Pull:        true,
+			})
+			if err != nil {
+				t.Fatalf("sync.Sync pull: %v", err)
+			}
+
+			verifyAllBlobs(t, leafR.DB())
+		})
+
+		t.Run("we_push_fossil_pulls", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Clone from fossil
+			fossilPath := fossilInit(t, dir, "fossil-push")
+			workDir := fossilCheckout(t, fossilPath)
+
+			files := map[string]string{"base.txt": "Base\n"}
+			fossilCommitFiles(t, fossilPath, workDir, files, "Base")
+
+			serverURL := startFossilServe(t, fossilPath)
+
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+
+			// Add content to leaf
+			rng := rand.New(rand.NewSource(99))
+			_, err = SeedLeaf(leafR, rng, 3, 1024)
+			if err != nil {
+				t.Fatalf("SeedLeaf: %v", err)
+			}
+
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+
+			// Push to fossil
+			_, err = sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+				ProjectCode: projCode,
+				Push:        true,
+			})
+			if err != nil {
+				t.Fatalf("sync.Sync push: %v", err)
+			}
+			leafR.Close()
+
+			// Verify fossil can read with rebuild
+			verifyWithFossilRebuild(t, fossilPath)
+
+			// Sample one artifact from leaf
+			d, err := db.Open(leafPath)
+			if err != nil {
+				t.Fatalf("open leaf db: %v", err)
+			}
+			defer d.Close()
+
+			var uuid string
+			err = d.QueryRow("SELECT uuid FROM blob WHERE size >= 0 LIMIT 1").Scan(&uuid)
+			if err != nil {
+				t.Fatalf("query uuid: %v", err)
+			}
+
+			artifactOut := fossilExec(t, "artifact", uuid, "-R", fossilPath)
+			if len(artifactOut) == 0 {
+				t.Errorf("fossil artifact returned empty for uuid=%s", uuid)
+			}
+		})
+
+		t.Run("bidirectional", func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Initial setup
+			fossilPath := fossilInit(t, dir, "fossil-bidir")
+			workDir := fossilCheckout(t, fossilPath)
+
+			files := map[string]string{"start.txt": "Start\n"}
+			fossilCommitFiles(t, fossilPath, workDir, files, "Start")
+
+			serverURL := startFossilServe(t, fossilPath)
+
+			leafPath := filepath.Join(dir, "leaf.fossil")
+			ctx := context.Background()
+			transport := &sync.HTTPTransport{URL: serverURL}
+			leafR, _, err := sync.Clone(ctx, leafPath, transport, sync.CloneOpts{})
+			if err != nil {
+				t.Fatalf("sync.Clone: %v", err)
+			}
+
+			// Both sides add content
+			// Fossil side
+			for i := 1; i <= 2; i++ {
+				files := map[string]string{
+					fmt.Sprintf("fossil%d.txt", i): fmt.Sprintf("From fossil %d\n", i),
+				}
+				fossilCommitFiles(t, fossilPath, workDir, files, fmt.Sprintf("Fossil %d", i))
+			}
+
+			// Leaf side
+			rng := rand.New(rand.NewSource(123))
+			_, err = SeedLeaf(leafR, rng, 2, 512)
+			if err != nil {
+				t.Fatalf("SeedLeaf: %v", err)
+			}
+
+			var projCode string
+			leafR.DB().QueryRow("SELECT value FROM config WHERE name='project-code'").Scan(&projCode)
+
+			// Sync until convergence
+			maxRounds := 5
+			for round := 0; round < maxRounds; round++ {
+				result, err := sync.Sync(ctx, leafR, transport, sync.SyncOpts{
+					ProjectCode: projCode,
+					Push:        true,
+					Pull:        true,
+				})
+				if err != nil {
+					t.Fatalf("sync round %d: %v", round, err)
+				}
+
+				t.Logf("Round %d: sent=%d received=%d", round, result.FilesSent, result.FilesRecvd)
+
+				if result.FilesSent == 0 && result.FilesRecvd == 0 {
+					t.Logf("Converged after %d rounds", round+1)
+					break
+				}
+
+				if round == maxRounds-1 {
+					t.Errorf("Did not converge after %d rounds", maxRounds)
+				}
+			}
+
+			verifyAllBlobs(t, leafR.DB())
+			leafR.Close()
+
+			verifyWithFossilRebuild(t, fossilPath)
+		})
+	})
+
+	// Task 6: Hash compatibility
+	t.Run("hash_compat", func(t *testing.T) {
+		t.Run("sha1_vs_fossil", func(t *testing.T) {
+			dir := t.TempDir()
+			sizes := []int{0, 1, 15, 16, 17, 255, 256, 257, 1024, 65536}
+
+			rng := rand.New(rand.NewSource(54321))
+
+			for _, size := range sizes {
+				t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+					data := make([]byte, size)
+					rng.Read(data)
+
+					// Our hash
+					ourHash := hash.SHA1(data)
+
+					// Fossil hash
+					filePath := filepath.Join(dir, fmt.Sprintf("data_%d.bin", size))
+					if err := os.WriteFile(filePath, data, 0644); err != nil {
+						t.Fatalf("write file: %v", err)
+					}
+
+					fossilOut := fossilExec(t, "sha1sum", filePath)
+					fields := strings.Fields(fossilOut)
+					if len(fields) == 0 {
+						t.Fatalf("fossil sha1sum returned empty")
+					}
+					fossilHash := fields[0]
+
+					if ourHash != fossilHash {
+						t.Errorf("SHA1 mismatch for size %d:\nours:   %s\nfossil: %s",
+							size, ourHash, fossilHash)
+					}
+				})
+			}
+		})
+
+		t.Run("sha3_vs_fossil", func(t *testing.T) {
+			dir := t.TempDir()
+			sizes := []int{0, 1, 15, 16, 17, 255, 256, 257, 1024, 65536}
+
+			rng := rand.New(rand.NewSource(98765))
+
+			for _, size := range sizes {
+				t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+					data := make([]byte, size)
+					rng.Read(data)
+
+					// Our hash
+					ourHash := hash.SHA3(data)
+
+					// Fossil hash
+					filePath := filepath.Join(dir, fmt.Sprintf("data_%d.bin", size))
+					if err := os.WriteFile(filePath, data, 0644); err != nil {
+						t.Fatalf("write file: %v", err)
+					}
+
+					fossilOut := fossilExec(t, "sha3sum", filePath)
+					fields := strings.Fields(fossilOut)
+					if len(fields) == 0 {
+						t.Fatalf("fossil sha3sum returned empty")
+					}
+					fossilHash := fields[0]
+
+					if ourHash != fossilHash {
+						t.Errorf("SHA3 mismatch for size %d:\nours:   %s\nfossil: %s",
+							size, ourHash, fossilHash)
+					}
+				})
+			}
+		})
+	})
+
+	// Task 7: Large repo (Tier 2)
+	t.Run("large_repo", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("Skipping large repo tests in short mode")
+		}
+
+		t.Run("clone_and_expand_all", func(t *testing.T) {
+			repoPath := cloneFossilSCMRepo(t)
+
+			d, err := db.Open(repoPath)
+			if err != nil {
+				t.Fatalf("open fossil.fossil: %v", err)
+			}
+			defer d.Close()
+
+			verifyAllBlobs(t, d)
+		})
+
+		t.Run("verify_hash_integrity", func(t *testing.T) {
+			repoPath := cloneFossilSCMRepo(t)
+
+			d, err := db.Open(repoPath)
+			if err != nil {
+				t.Fatalf("open fossil.fossil: %v", err)
+			}
+			defer d.Close()
+
+			// Sample 500 random blobs
+			rows, err := d.Query(`
+				SELECT rid, uuid
+				FROM blob
+				WHERE size >= 0 AND content IS NOT NULL
+				ORDER BY RANDOM()
+				LIMIT 500
+			`)
+			if err != nil {
+				t.Fatalf("query random blobs: %v", err)
+			}
+			defer rows.Close()
+
+			var count, errors int
+			for rows.Next() {
+				var rid int64
+				var uuid string
+				if err := rows.Scan(&rid, &uuid); err != nil {
+					t.Errorf("scan: %v", err)
+					errors++
+					continue
+				}
+
+				// Expand with our implementation
+				ourContent, err := content.Expand(d, libfossil.FslID(rid))
+				if err != nil {
+					t.Errorf("expand rid=%d uuid=%s: %v", rid, uuid, err)
+					errors++
+					continue
+				}
+
+				// Get from fossil
+				fossilContent := fossilExec(t, "artifact", uuid, "-R", repoPath)
+
+				if !bytes.Equal(ourContent, []byte(fossilContent)) {
+					t.Errorf("content mismatch for rid=%d uuid=%s:\nour size: %d\nfossil size: %d",
+						rid, uuid, len(ourContent), len(fossilContent))
+					errors++
+				}
+
+				count++
+			}
+
+			if err := rows.Err(); err != nil {
+				t.Errorf("iterate: %v", err)
+			}
+
+			t.Logf("Verified %d random blobs, %d errors", count, errors)
 		})
 	})
 }


### PR DESCRIPTION
## Summary

- **fix(delta):** copy command args swapped (`offset@count` → `count@offset`) + checksum algorithm wrong (uint16 Fletcher → big-endian uint32 word sum) — 0% → 100% expand success on Fossil SCM repo (66K blobs)
- **fix(xfer):** cfile usize validation rejected delta cards — usize is full content size, not decompressed delta size. Unskips `TestFossilToLeaf/commit_chain`
- **fix(blob):** `Load` returned raw compressed bytes when `len(content) == size` — rare (2/66K blobs) but real when compressed form matches uncompressed size
- **test(sim):** comprehensive Fossil-as-oracle interop test suite (`sim/interop_test.go`) — delta codec, clone, sync, hash, UV, large repo verification

## What was wrong

All tests were self-referential — Go-created data verified by Go code. `delta.Create` and `delta.Apply` were swapped in the same direction, so round-trip tests passed but real Fossil deltas failed. The checksum used the wrong algorithm entirely. Discovered by benchmarking `content.Expand` against the upstream Fossil SCM repo.

## Interop test suite

| Test Group | Subtests | What it Proves |
|---|---|---|
| `delta_codec` | 5 | Bidirectional delta Create/Apply vs `fossil test-delta-*` |
| `clone_from_us` | 3 | `fossil clone` + `fossil rebuild` on Go-served repos (+ UV) |
| `clone_from_fossil` | 3 | `sync.Clone` from `fossil serve` + `verifyAllBlobs` |
| `incremental_sync` | 3 | Pull, push, bidirectional sync convergence |
| `hash_compat` | 20 | SHA1 + SHA3 vs `fossil sha1sum`/`sha3sum` at 10 sizes |
| `large_repo` (Tier 2) | 2 | 5K expanded + 2K cross-checked against Fossil SCM repo |

Tier 1: 34 tests, ~1.1s (in `make test`). Tier 2: 7K blobs, ~3min (`make test-interop`).

## Test plan

- [x] `make test` passes (all existing + Tier 1 interop)
- [x] `make test-interop` passes (Tier 1 + Tier 2 large repo)
- [x] All equivalence tests pass including previously-skipped `commit_chain`
- [x] Delta codec cross-validated with `fossil test-delta-create/apply`
- [x] SHA1 + SHA3 cross-validated with `fossil sha1sum/sha3sum`
- [x] 5000 blobs expanded + hash-verified from real Fossil SCM repo
- [x] 2000 blobs byte-compared against `fossil artifact` output

Closes CDG-182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delta codec compatibility issues affecting data synchronization with Fossil repositories.
  * Improved blob decompression detection for more reliable content handling.
  * Resolved data size validation issues for compressed content in file transfers.

* **Tests**
  * Added comprehensive interoperability test suite validating compatibility with Fossil CLI across delta operations, cloning, syncing, hashing, and large repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->