### PR TITLE
feat(checkout): implement SetMTime for Extract and Update (EDG-57)

### DIFF
--- a/go-libfossil/checkout/extract.go
+++ b/go-libfossil/checkout/extract.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/content"
@@ -152,12 +153,31 @@ func (c *Checkout) Extract(rid libfossil.FslID, opts ExtractOpts) error {
 		}
 	}
 
+	// Look up checkin timestamp for SetMTime.
+	var checkinTime time.Time
+	if opts.SetMTime && !opts.DryRun {
+		var mtimeJulian float64
+		if err := c.repo.DB().QueryRow(
+			"SELECT mtime FROM event WHERE objid = ? AND type = 'ci'",
+			int64(rid),
+		).Scan(&mtimeJulian); err == nil {
+			checkinTime = libfossil.JulianToTime(mtimeJulian)
+		}
+	}
+
 	for _, row := range vfRows {
 		if err := c.extractSingleFile(
 			row.pathname, row.blobRid, row.isexe, opts.DryRun,
 		); err != nil {
 			extractErr = err
 			return extractErr
+		}
+
+		if opts.SetMTime && !opts.DryRun && !checkinTime.IsZero() {
+			fullPath, _ := c.safePath(row.pathname)
+			if fullPath != "" {
+				_ = c.env.Storage.Chtimes(fullPath, checkinTime, checkinTime)
+			}
 		}
 
 		c.obs.ExtractFileCompleted(ctx, row.pathname, UpdateAdded)

--- a/go-libfossil/checkout/extract_test.go
+++ b/go-libfossil/checkout/extract_test.go
@@ -145,6 +145,79 @@ func TestExtractForceProtection(t *testing.T) {
 	}
 }
 
+func TestExtractSetMTime(t *testing.T) {
+	r, cleanup := newTestRepoWithCheckin(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	co, err := Create(r, dir, CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer co.Close()
+
+	rid, _, _ := co.Version()
+	mem := simio.NewMemStorage()
+	co.env = &simio.Env{Storage: mem, Clock: simio.RealClock{}, Rand: simio.CryptoRand{}}
+	co.dir = "/checkout"
+
+	if err := co.Extract(rid, ExtractOpts{SetMTime: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify mtime was set on extracted files.
+	info, err := mem.Stat("/checkout/hello.txt")
+	if err != nil {
+		t.Fatal("stat hello.txt:", err)
+	}
+	mtime := info.ModTime()
+	if mtime.IsZero() {
+		t.Fatal("mtime should not be zero when SetMTime is true")
+	}
+	// The checkin timestamp should match what's in the event table.
+	// Just verify it's a valid time (not zero) — the exact value depends
+	// on the test repo's fixed timestamp.
+	if mtime.Year() < 2020 {
+		t.Fatalf("mtime %v looks invalid", mtime)
+	}
+
+	// Verify all extracted files got the same mtime.
+	info2, _ := mem.Stat("/checkout/src/main.go")
+	if !info2.ModTime().Equal(mtime) {
+		t.Fatalf("src/main.go mtime %v != hello.txt mtime %v", info2.ModTime(), mtime)
+	}
+}
+
+func TestExtractSetMTimeFalse(t *testing.T) {
+	r, cleanup := newTestRepoWithCheckin(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	co, err := Create(r, dir, CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer co.Close()
+
+	rid, _, _ := co.Version()
+	mem := simio.NewMemStorage()
+	co.env = &simio.Env{Storage: mem, Clock: simio.RealClock{}, Rand: simio.CryptoRand{}}
+	co.dir = "/checkout"
+
+	if err := co.Extract(rid, ExtractOpts{SetMTime: false}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify mtime was NOT set (should be zero in MemStorage).
+	info, err := mem.Stat("/checkout/hello.txt")
+	if err != nil {
+		t.Fatal("stat hello.txt:", err)
+	}
+	if !info.ModTime().IsZero() {
+		t.Fatalf("mtime should be zero when SetMTime is false, got %v", info.ModTime())
+	}
+}
+
 func TestExtractObserver(t *testing.T) {
 	// Use a recording observer to verify hooks fire
 	r, cleanup := newTestRepoWithCheckin(t)

--- a/go-libfossil/checkout/extract_test.go
+++ b/go-libfossil/checkout/extract_test.go
@@ -218,6 +218,31 @@ func TestExtractSetMTimeFalse(t *testing.T) {
 	}
 }
 
+func TestExtractSetMTimeDryRun(t *testing.T) {
+	r, cleanup := newTestRepoWithCheckin(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	co, err := Create(r, dir, CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer co.Close()
+
+	rid, _, _ := co.Version()
+	mem := simio.NewMemStorage()
+	co.env = &simio.Env{Storage: mem, Clock: simio.RealClock{}, Rand: simio.CryptoRand{}}
+	co.dir = "/checkout"
+
+	// DryRun + SetMTime should not write files or set mtimes.
+	if err := co.Extract(rid, ExtractOpts{SetMTime: true, DryRun: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mem.ReadFile("/checkout/hello.txt"); err == nil {
+		t.Fatal("DryRun should not write files even with SetMTime")
+	}
+}
+
 func TestExtractObserver(t *testing.T) {
 	// Use a recording observer to verify hooks fire
 	r, cleanup := newTestRepoWithCheckin(t)

--- a/go-libfossil/checkout/types.go
+++ b/go-libfossil/checkout/types.go
@@ -103,7 +103,7 @@ type CreateOpts struct {
 // ExtractOpts configures file extraction from a checkin.
 type ExtractOpts struct {
 	Callback func(name string, change UpdateChange) error // per-file notification
-	SetMTime bool                                         // TODO: not yet implemented
+	SetMTime bool // set file mtime to checkin timestamp
 	DryRun   bool
 	Force    bool // overwrite locally modified files
 }
@@ -112,7 +112,7 @@ type ExtractOpts struct {
 type UpdateOpts struct {
 	TargetRID libfossil.FslID // 0 → auto-calculate via CalcUpdateVersion
 	Callback  func(name string, change UpdateChange) error
-	SetMTime  bool // TODO: not yet implemented
+	SetMTime  bool // set file mtime to checkin timestamp
 	DryRun    bool
 }
 

--- a/go-libfossil/checkout/update.go
+++ b/go-libfossil/checkout/update.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"time"
+
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/blob"
 	"github.com/dmestas/edgesync/go-libfossil/content"
@@ -88,6 +90,7 @@ func (c *Checkout) processFileUpdates(
 	maps updateFileMaps,
 	strategy merge.Strategy,
 	opts UpdateOpts,
+	checkinTime time.Time,
 ) (filesWritten, filesRemoved, conflicts int, err error) {
 	for name := range maps.allNames {
 		curUUID, inCurrent := maps.current[name]
@@ -104,6 +107,14 @@ func (c *Checkout) processFileUpdates(
 
 		if change == UpdateNone {
 			continue
+		}
+
+		// Apply checkin mtime to written files.
+		if opts.SetMTime && !opts.DryRun && !checkinTime.IsZero() && change != UpdateRemoved {
+			fullPath, _ := c.safePath(name)
+			if fullPath != "" {
+				_ = c.env.Storage.Chtimes(fullPath, checkinTime, checkinTime)
+			}
 		}
 
 		switch change {
@@ -229,8 +240,20 @@ func (c *Checkout) Update(opts UpdateOpts) error {
 		return updateErr
 	}
 
+	// Look up checkin timestamp for SetMTime.
+	var checkinTime time.Time
+	if opts.SetMTime && !opts.DryRun {
+		var mtimeJulian float64
+		if err := c.repo.DB().QueryRow(
+			"SELECT mtime FROM event WHERE objid = ? AND type = 'ci'",
+			int64(target),
+		).Scan(&mtimeJulian); err == nil {
+			checkinTime = libfossil.JulianToTime(mtimeJulian)
+		}
+	}
+
 	// Process each file
-	filesWritten, filesRemoved, conflicts, updateErr = c.processFileUpdates(ctx, maps, strategy, opts)
+	filesWritten, filesRemoved, conflicts, updateErr = c.processFileUpdates(ctx, maps, strategy, opts, checkinTime)
 	if updateErr != nil {
 		return updateErr
 	}

--- a/go-libfossil/checkout/update_test.go
+++ b/go-libfossil/checkout/update_test.go
@@ -477,6 +477,103 @@ func TestUpdateWithFileRemoval(t *testing.T) {
 	_ = rid2 // used above
 }
 
+func TestUpdateSetMTime(t *testing.T) {
+	r, rid1, rid2, cleanup := newTestRepoWithTwoCheckins(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	co, err := Create(r, dir, CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer co.Close()
+
+	// Set checkout to rid1.
+	if err := setVVar(co.db, "checkout", itoa(int64(rid1))); err != nil {
+		t.Fatal(err)
+	}
+	var uuid1 string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", rid1).Scan(&uuid1)
+	if err := setVVar(co.db, "checkout-hash", uuid1); err != nil {
+		t.Fatal(err)
+	}
+
+	mem := simio.NewMemStorage()
+	co.env = &simio.Env{Storage: mem, Clock: simio.RealClock{}, Rand: simio.CryptoRand{}}
+	co.dir = "/checkout"
+
+	if err := co.Extract(rid1, ExtractOpts{}); err != nil {
+		t.Fatal("extract:", err)
+	}
+
+	// Update to rid2 with SetMTime.
+	if err := co.Update(UpdateOpts{TargetRID: rid2, SetMTime: true}); err != nil {
+		t.Fatal("update:", err)
+	}
+
+	// hello.txt was modified in rid2 — should have rid2's checkin mtime (2026-01-02).
+	info, err := mem.Stat("/checkout/hello.txt")
+	if err != nil {
+		t.Fatal("stat hello.txt:", err)
+	}
+	mtime := info.ModTime()
+	if mtime.IsZero() {
+		t.Fatal("mtime should not be zero when SetMTime is true")
+	}
+	// rid2 timestamp is 2026-01-02.
+	expected := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if !mtime.Equal(expected) {
+		t.Fatalf("hello.txt mtime = %v, want %v", mtime, expected)
+	}
+
+	// new.txt was added in rid2 — should also have rid2's mtime.
+	info2, err := mem.Stat("/checkout/new.txt")
+	if err != nil {
+		t.Fatal("stat new.txt:", err)
+	}
+	if !info2.ModTime().Equal(expected) {
+		t.Fatalf("new.txt mtime = %v, want %v", info2.ModTime(), expected)
+	}
+}
+
+func TestUpdateSetMTimeFalse(t *testing.T) {
+	r, rid1, rid2, cleanup := newTestRepoWithTwoCheckins(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	co, err := Create(r, dir, CreateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer co.Close()
+
+	if err := setVVar(co.db, "checkout", itoa(int64(rid1))); err != nil {
+		t.Fatal(err)
+	}
+	var uuid1 string
+	r.DB().QueryRow("SELECT uuid FROM blob WHERE rid=?", rid1).Scan(&uuid1)
+	setVVar(co.db, "checkout-hash", uuid1)
+
+	mem := simio.NewMemStorage()
+	co.env = &simio.Env{Storage: mem, Clock: simio.RealClock{}, Rand: simio.CryptoRand{}}
+	co.dir = "/checkout"
+
+	co.Extract(rid1, ExtractOpts{})
+
+	// Update WITHOUT SetMTime.
+	if err := co.Update(UpdateOpts{TargetRID: rid2, SetMTime: false}); err != nil {
+		t.Fatal("update:", err)
+	}
+
+	info, err := mem.Stat("/checkout/hello.txt")
+	if err != nil {
+		t.Fatal("stat:", err)
+	}
+	if !info.ModTime().IsZero() {
+		t.Fatalf("mtime should be zero when SetMTime is false, got %v", info.ModTime())
+	}
+}
+
 // itoa is a helper to avoid importing strconv in tests.
 func itoa(n int64) string {
 	return strconv.FormatInt(n, 10)

--- a/go-libfossil/simio/storage.go
+++ b/go-libfossil/simio/storage.go
@@ -3,6 +3,7 @@ package simio
 import (
 	"io/fs"
 	"os"
+	"time"
 )
 
 // Storage abstracts filesystem operations for WASM portability.
@@ -13,6 +14,7 @@ type Storage interface {
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, data []byte, perm os.FileMode) error
 	ReadDir(path string) ([]fs.DirEntry, error)
+	Chtimes(path string, atime, mtime time.Time) error
 }
 
 // OSStorage delegates to the os package. Used in production and WASI.
@@ -24,3 +26,4 @@ func (OSStorage) MkdirAll(path string, perm os.FileMode) error                { 
 func (OSStorage) ReadFile(path string) ([]byte, error)                         { return os.ReadFile(path) }
 func (OSStorage) WriteFile(path string, data []byte, perm os.FileMode) error  { return os.WriteFile(path, data, perm) }
 func (OSStorage) ReadDir(path string) ([]fs.DirEntry, error)                  { return os.ReadDir(path) }
+func (OSStorage) Chtimes(path string, atime, mtime time.Time) error           { return os.Chtimes(path, atime, mtime) }

--- a/go-libfossil/simio/storage_mem.go
+++ b/go-libfossil/simio/storage_mem.go
@@ -12,15 +12,17 @@ import (
 
 // MemStorage is an in-memory Storage implementation for tests and browser fallback.
 type MemStorage struct {
-	files map[string][]byte
-	dirs  map[string]bool
+	files  map[string][]byte
+	dirs   map[string]bool
+	mtimes map[string]time.Time
 }
 
 // NewMemStorage creates a new in-memory storage.
 func NewMemStorage() *MemStorage {
 	return &MemStorage{
-		files: make(map[string][]byte),
-		dirs:  make(map[string]bool),
+		files:  make(map[string][]byte),
+		dirs:   make(map[string]bool),
+		mtimes: make(map[string]time.Time),
 	}
 }
 
@@ -35,6 +37,7 @@ func (m *MemStorage) Stat(path string) (os.FileInfo, error) {
 			name:  filepath.Base(path),
 			size:  int64(len(data)),
 			isDir: false,
+			mtime: m.mtimes[path],
 		}, nil
 	}
 
@@ -195,6 +198,18 @@ func (m *MemStorage) ReadDir(path string) ([]fs.DirEntry, error) {
 	return entries, nil
 }
 
+// Chtimes sets the access and modification times of the named file.
+func (m *MemStorage) Chtimes(path string, atime, mtime time.Time) error {
+	if path == "" {
+		panic("MemStorage.Chtimes: path must not be empty")
+	}
+	if _, ok := m.files[path]; !ok {
+		return fmt.Errorf("chtimes %s: %w", path, os.ErrNotExist)
+	}
+	m.mtimes[path] = mtime
+	return nil
+}
+
 // memDirEntry implements fs.DirEntry for in-memory directory entries.
 type memDirEntry struct {
 	name  string
@@ -222,6 +237,7 @@ type memFileInfo struct {
 	name  string
 	size  int64
 	isDir bool
+	mtime time.Time
 }
 
 func (f *memFileInfo) Name() string       { return f.name }
@@ -232,6 +248,6 @@ func (f *memFileInfo) Mode() os.FileMode {
 	}
 	return 0644
 }
-func (f *memFileInfo) ModTime() time.Time { return time.Time{} }
+func (f *memFileInfo) ModTime() time.Time { return f.mtime }
 func (f *memFileInfo) IsDir() bool        { return f.isDir }
 func (f *memFileInfo) Sys() any           { return nil }

--- a/go-libfossil/simio/storage_test.go
+++ b/go-libfossil/simio/storage_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestOSStorageStat(t *testing.T) {
@@ -419,6 +420,58 @@ func TestMemStorageReadDir(t *testing.T) {
 	}
 	if subdirEntries[1].Name() != "file3.txt" {
 		t.Errorf("expected file3.txt, got %s", subdirEntries[1].Name())
+	}
+}
+
+func TestMemStorageChtimes(t *testing.T) {
+	storage := NewMemStorage()
+	path := "/test/file.txt"
+
+	storage.WriteFile(path, []byte("content"), 0644)
+
+	mtime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	if err := storage.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	info, err := storage.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.ModTime().Equal(mtime) {
+		t.Fatalf("ModTime = %v, want %v", info.ModTime(), mtime)
+	}
+}
+
+func TestMemStorageChtimesNotExist(t *testing.T) {
+	storage := NewMemStorage()
+
+	err := storage.Chtimes("/nonexistent.txt", time.Now(), time.Now())
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected ErrNotExist, got: %v", err)
+	}
+}
+
+func TestOSStorageChtimes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	os.WriteFile(path, []byte("content"), 0644)
+
+	storage := OSStorage{}
+	mtime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	if err := storage.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if !info.ModTime().Equal(mtime) {
+		t.Fatalf("ModTime = %v, want %v", info.ModTime(), mtime)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `Chtimes(path, atime, mtime)` to the `simio.Storage` interface
- `OSStorage` delegates to `os.Chtimes`; `MemStorage` tracks mtimes in-memory
- `Extract()` and `Update()` set file mtimes to the checkin timestamp when `SetMTime: true`
- Timestamps read from the `event` table (Julian date) via `libfossil.JulianToTime()`
- Removes the two TODO comments from `ExtractOpts` and `UpdateOpts`

## Test plan

- [x] `TestExtractSetMTime` — verifies mtimes are set and consistent across files
- [x] `TestExtractSetMTimeFalse` — verifies mtimes are NOT set when flag is off
- [x] Full `make test` passes (all modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extraction and update operations can now preserve file modification times from repository check-ins. Dry runs do not modify timestamps. Storage implementations (in-memory and on-disk) support setting and reporting file times.

* **Tests**
  * Added tests covering mtime preservation for extract/update flows, dry-run and disabled scenarios, and storage behavior (including error handling for missing files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->