### PR TITLE
dx: improve developer inner loop

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,26 +8,33 @@
 
 set -e
 
+# run_test: suppress output on success, show full diagnostics on failure.
+run_test() {
+	label="$1"
+	shift
+	if output=$("$@" 2>&1); then
+		echo "  $label: OK"
+	else
+		echo "  $label: FAILED"
+		echo ""
+		echo "$output"
+		echo ""
+		exit 1
+	fi
+}
+
 echo "=== pre-commit: unit tests ==="
-go test ./go-libfossil/... -short -count=1 -timeout=30s > /dev/null 2>&1
-echo "  go-libfossil (incl handler): OK"
-
-go test ./leaf/agent/ -short -count=1 -timeout=30s > /dev/null 2>&1
-echo "  leaf/agent: OK"
-
-go test ./bridge/bridge/ -short -count=1 -timeout=30s > /dev/null 2>&1
-echo "  bridge/bridge: OK"
+run_test "go-libfossil (incl handler)" go test ./go-libfossil/... -short -count=1 -timeout=30s
+run_test "leaf/agent" go test ./leaf/agent/ -short -count=1 -timeout=30s
+run_test "bridge/bridge" go test ./bridge/bridge/ -short -count=1 -timeout=30s
 
 echo "=== pre-commit: DST quick (1 seed) ==="
-go test ./dst/ -run TestDST -count=1 -timeout=30s > /dev/null 2>&1
-echo "  dst: OK"
+run_test "dst" go test ./dst/ -run TestDST -count=1 -timeout=30s
 
 echo "=== pre-commit: sim unit tests ==="
-go test ./sim/ -run "TestFaultProxy|TestGenerateSchedule|TestBuggify" -count=1 -timeout=30s > /dev/null 2>&1
-echo "  sim (unit): OK"
+run_test "sim (unit)" go test ./sim/ -run "TestFaultProxy|TestGenerateSchedule|TestBuggify" -count=1 -timeout=30s
 
 echo "=== pre-commit: sim serve tests ==="
-go test ./sim/ -run "TestServeHTTP|TestLeafToLeaf|TestAgentServe" -count=1 -timeout=60s > /dev/null 2>&1
-echo "  sim (serve): OK"
+run_test "sim (serve)" go test ./sim/ -run "TestServeHTTP|TestLeafToLeaf|TestAgentServe" -count=1 -timeout=60s
 
 echo "=== pre-commit: all passed (~8s) ==="

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ clean:
 	rm -rf bin/
 
 # --- Test (what CI runs) ---
+# Unit tests run in parallel across modules; sim/dst run sequentially after.
 
 test:
-	go test ./go-libfossil/... -short -count=1
-	go test ./leaf/... -short -count=1
-	go test ./bridge/... -short -count=1
+	@pids=""; fail=0; \
+	go test ./go-libfossil/... -short -count=1 & pids="$$pids $$!"; \
+	go test ./leaf/... -short -count=1 & pids="$$pids $$!"; \
+	go test ./bridge/... -short -count=1 & pids="$$pids $$!"; \
+	for pid in $$pids; do wait $$pid || fail=1; done; \
+	if [ $$fail -ne 0 ]; then echo "FAIL: unit tests"; exit 1; fi
 	go test ./dst/ -run 'TestScenario|TestE2E|TestMockFossil|TestSimulator|TestCheck' -count=1
 	go test ./sim/ -run 'TestFaultProxy|TestGenerateSchedule|TestBuggify' -count=1
 	go test ./sim/ -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe' -count=1 -timeout=120s

--- a/leaf/cmd/leaf/main.go
+++ b/leaf/cmd/leaf/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	libsync "github.com/dmestas/edgesync/go-libfossil/sync"
 	"github.com/dmestas/edgesync/leaf/agent"
 	"github.com/dmestas/edgesync/leaf/telemetry"
 
@@ -28,6 +29,9 @@ func main() {
 	serveHTTP := flag.String("serve-http", envOrDefault("LEAF_SERVE_HTTP", ""), "HTTP listen address (e.g. :8080) to serve fossil clone/sync")
 	serveNATS := flag.Bool("serve-nats", false, "enable NATS request/reply listener for leaf-to-leaf sync")
 	uv := flag.Bool("uv", false, "enable unversioned file sync (wiki, forum, attachments)")
+	var verboseFlag bool
+	flag.BoolVar(&verboseFlag, "verbose", false, "log sync round details to stderr (no OTel required)")
+	flag.BoolVar(&verboseFlag, "v", false, "alias for --verbose")
 	autosyncFlag := flag.String("autosync", "off", "autosync mode: on, off, pullonly")
 	allowFork := flag.Bool("allow-fork", false, "bypass fork and lock checks")
 	overrideLock := flag.Bool("override-lock", false, "ignore lock conflicts (implies allow-fork)")
@@ -59,7 +63,10 @@ func main() {
 	}
 
 	// Create observer (nil-safe: if no endpoint, OTel uses no-op providers)
-	obs := telemetry.NewOTelObserver(nil, nil)
+	var obs libsync.Observer = telemetry.NewOTelObserver(nil, nil)
+	if verboseFlag {
+		obs = telemetry.NewVerboseObserver(os.Stderr, obs)
+	}
 
 	cfg := agent.Config{
 		RepoPath:         *repoPath,

--- a/leaf/telemetry/verbose.go
+++ b/leaf/telemetry/verbose.go
@@ -1,0 +1,111 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	libsync "github.com/dmestas/edgesync/go-libfossil/sync"
+)
+
+// VerboseObserver wraps another Observer and logs human-readable sync
+// lifecycle events to the given writer (typically os.Stderr).
+// The inner observer receives all callbacks unchanged.
+type VerboseObserver struct {
+	inner libsync.Observer
+	w     io.Writer
+}
+
+// NewVerboseObserver returns an observer that logs to w and delegates to inner.
+// If inner is nil, only logging is performed (no telemetry forwarding).
+func NewVerboseObserver(w io.Writer, inner libsync.Observer) *VerboseObserver {
+	return &VerboseObserver{inner: inner, w: w}
+}
+
+func (v *VerboseObserver) Started(ctx context.Context, info libsync.SessionStart) context.Context {
+	fmt.Fprintf(v.w, "[verbose] %s started  push=%t pull=%t uv=%t project=%s\n",
+		info.Operation, info.Push, info.Pull, info.UV, info.ProjectCode)
+	if v.inner != nil {
+		return v.inner.Started(ctx, info)
+	}
+	return ctx
+}
+
+func (v *VerboseObserver) RoundStarted(ctx context.Context, round int) context.Context {
+	fmt.Fprintf(v.w, "[verbose] round %d started\n", round)
+	if v.inner != nil {
+		return v.inner.RoundStarted(ctx, round)
+	}
+	return ctx
+}
+
+func (v *VerboseObserver) RoundCompleted(ctx context.Context, round int, stats libsync.RoundStats) {
+	fmt.Fprintf(v.w, "[verbose] round %d completed  sent=%d recv=%d gimmes=%d igots=%d bytes_out=%d bytes_in=%d\n",
+		round, stats.FilesSent, stats.FilesReceived, stats.GimmesSent, stats.IgotsSent, stats.BytesSent, stats.BytesReceived)
+	if v.inner != nil {
+		v.inner.RoundCompleted(ctx, round, stats)
+	}
+}
+
+func (v *VerboseObserver) Completed(ctx context.Context, info libsync.SessionEnd, err error) {
+	if err != nil {
+		fmt.Fprintf(v.w, "[verbose] %s completed  rounds=%d sent=%d recv=%d uv_sent=%d uv_recv=%d err=%v\n",
+			info.Operation, info.Rounds, info.FilesSent, info.FilesRecvd, info.UVFilesSent, info.UVFilesRecvd, err)
+	} else {
+		fmt.Fprintf(v.w, "[verbose] %s completed  rounds=%d sent=%d recv=%d uv_sent=%d uv_recv=%d\n",
+			info.Operation, info.Rounds, info.FilesSent, info.FilesRecvd, info.UVFilesSent, info.UVFilesRecvd)
+	}
+	if len(info.Errors) > 0 {
+		for _, e := range info.Errors {
+			fmt.Fprintf(v.w, "[verbose]   protocol error: %s\n", e)
+		}
+	}
+	if v.inner != nil {
+		v.inner.Completed(ctx, info, err)
+	}
+}
+
+func (v *VerboseObserver) Error(ctx context.Context, err error) {
+	if err != nil {
+		fmt.Fprintf(v.w, "[verbose] error: %v\n", err)
+	}
+	if v.inner != nil {
+		v.inner.Error(ctx, err)
+	}
+}
+
+func (v *VerboseObserver) HandleStarted(ctx context.Context, info libsync.HandleStart) context.Context {
+	fmt.Fprintf(v.w, "[verbose] handle started  op=%s project=%s remote=%s\n",
+		info.Operation, info.ProjectCode, info.RemoteAddr)
+	if v.inner != nil {
+		return v.inner.HandleStarted(ctx, info)
+	}
+	return ctx
+}
+
+func (v *VerboseObserver) HandleCompleted(ctx context.Context, info libsync.HandleEnd) {
+	if info.Err != nil {
+		fmt.Fprintf(v.w, "[verbose] handle completed  cards=%d sent=%d recv=%d err=%v\n",
+			info.CardsProcessed, info.FilesSent, info.FilesReceived, info.Err)
+	} else {
+		fmt.Fprintf(v.w, "[verbose] handle completed  cards=%d sent=%d recv=%d\n",
+			info.CardsProcessed, info.FilesSent, info.FilesReceived)
+	}
+	if v.inner != nil {
+		v.inner.HandleCompleted(ctx, info)
+	}
+}
+
+func (v *VerboseObserver) TableSyncStarted(ctx context.Context, info libsync.TableSyncStart) {
+	fmt.Fprintf(v.w, "[verbose] table sync started  table=%s local_rows=%d\n", info.Table, info.LocalRows)
+	if v.inner != nil {
+		v.inner.TableSyncStarted(ctx, info)
+	}
+}
+
+func (v *VerboseObserver) TableSyncCompleted(ctx context.Context, info libsync.TableSyncEnd) {
+	fmt.Fprintf(v.w, "[verbose] table sync completed  table=%s sent=%d recv=%d\n", info.Table, info.Sent, info.Received)
+	if v.inner != nil {
+		v.inner.TableSyncCompleted(ctx, info)
+	}
+}

--- a/leaf/telemetry/verbose_test.go
+++ b/leaf/telemetry/verbose_test.go
@@ -1,0 +1,90 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	libsync "github.com/dmestas/edgesync/go-libfossil/sync"
+)
+
+func TestVerboseObserver(t *testing.T) {
+	var buf bytes.Buffer
+	obs := NewVerboseObserver(&buf, nil)
+	ctx := context.Background()
+
+	ctx = obs.Started(ctx, libsync.SessionStart{
+		Operation: "sync", Push: true, Pull: true, UV: false, ProjectCode: "abc123",
+	})
+	ctx = obs.RoundStarted(ctx, 1)
+	obs.RoundCompleted(ctx, 1, libsync.RoundStats{
+		FilesSent: 3, FilesReceived: 2, GimmesSent: 1, BytesSent: 1024,
+	})
+	obs.Completed(ctx, libsync.SessionEnd{
+		Operation: "sync", Rounds: 1, FilesSent: 3, FilesRecvd: 2,
+	}, nil)
+
+	output := buf.String()
+	for _, want := range []string{
+		"sync started",
+		"round 1 started",
+		"round 1 completed",
+		"sent=3",
+		"recv=2",
+		"sync completed",
+		"rounds=1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q\ngot:\n%s", want, output)
+		}
+	}
+}
+
+func TestVerboseObserverError(t *testing.T) {
+	var buf bytes.Buffer
+	obs := NewVerboseObserver(&buf, nil)
+
+	obs.Error(context.Background(), errors.New("test error"))
+	if !strings.Contains(buf.String(), "test error") {
+		t.Errorf("error not logged: %s", buf.String())
+	}
+}
+
+func TestVerboseObserverDelegatesToInner(t *testing.T) {
+	var buf bytes.Buffer
+	var innerCalled bool
+	inner := &mockObserver{onStarted: func() { innerCalled = true }}
+
+	obs := NewVerboseObserver(&buf, inner)
+	obs.Started(context.Background(), libsync.SessionStart{Operation: "sync"})
+
+	if !innerCalled {
+		t.Error("inner observer not called")
+	}
+	if buf.Len() == 0 {
+		t.Error("verbose output empty")
+	}
+}
+
+type mockObserver struct {
+	onStarted func()
+}
+
+func (m *mockObserver) Started(ctx context.Context, _ libsync.SessionStart) context.Context {
+	if m.onStarted != nil {
+		m.onStarted()
+	}
+	return ctx
+}
+func (m *mockObserver) RoundStarted(ctx context.Context, _ int) context.Context { return ctx }
+func (m *mockObserver) RoundCompleted(_ context.Context, _ int, _ libsync.RoundStats) {}
+func (m *mockObserver) Completed(_ context.Context, _ libsync.SessionEnd, _ error)    {}
+func (m *mockObserver) Error(_ context.Context, _ error)                               {}
+func (m *mockObserver) HandleStarted(ctx context.Context, _ libsync.HandleStart) context.Context {
+	return ctx
+}
+func (m *mockObserver) HandleCompleted(_ context.Context, _ libsync.HandleEnd)    {}
+func (m *mockObserver) TableSyncStarted(_ context.Context, _ libsync.TableSyncStart)  {}
+func (m *mockObserver) TableSyncCompleted(_ context.Context, _ libsync.TableSyncEnd)  {}


### PR DESCRIPTION
## Summary

- **Pre-commit diagnostics**: Hook now shows full test output on failure instead of swallowing it with `> /dev/null`. Success path still quiet.
- **Parallel `make test`**: Unit tests for go-libfossil, leaf, and bridge run concurrently. DST/sim remain sequential.
- **`leaf --verbose`**: New `-v`/`--verbose` flag logs sync lifecycle events (session start/end, round stats, errors, handle events) to stderr. No OTel infrastructure required. Wraps existing observer via `VerboseObserver` decorator.

## Test plan

- [x] `make test` passes with parallel unit test execution
- [x] `go test ./leaf/...` passes (includes 3 new VerboseObserver tests)
- [x] `leaf` binary compiles with new `--verbose` flag
- [ ] Manual: break a test, verify pre-commit hook shows diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verbose`/`-v` CLI flag that outputs human-readable telemetry logs displaying sync operation lifecycle, round statistics, metrics, and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->