### PR TITLE
feat(manifest): file history and FileAt for change tracking (EDG-5)

### DIFF
--- a/docs/architecture/core-library.md
+++ b/docs/architecture/core-library.md
@@ -129,6 +129,16 @@ Hard limit: 70 lines. 10 functions were split into same-file private helpers (la
 - `\r\n` normalized to `\n` before comparison
 - Side-by-side deferred until a consumer needs it (architecture supports adding formatters)
 
+## File History (finfo)
+
+`manifest.FileHistory()` — walks the `mlink` table to return a file's change history across checkins, ordered by date descending.
+
+- **Query**: `mlink JOIN event JOIN blob` by `fnid`, with `COALESCE` for nullable `pid`/`pfnid` columns
+- **Action classification**: `fid=0` → deleted, `pid=0` → added, `pfnid != fnid` → renamed, `fid=pid` → unchanged (filtered out), else → modified
+- **Unchanged filtering**: `insertMlinks` (in `Checkin`) creates rows for all files in a commit, not just changes. `FileHistory` skips entries where `fid == pid` so consumers only see actual modifications.
+- **`FileAt(r, checkinRID, path)`**: convenience function resolving a file's blob RID at a specific checkin via `mlink`. Enables diff-between-versions (`content.Expand` both sides, pipe through `diff.Unified`).
+- **Rename tracking**: `pfnid` column is in the schema but not yet populated by `Checkin` or `crosslink`. When wired, `FileHistory` will automatically surface renames via the existing `pfnid != fnid` check.
+
 ## Content Cache
 
 `content.Cache` — concurrency-safe LRU cache for `content.Expand` results, keyed by `FslID`. Eliminates redundant delta-chain walks (SQLite queries + zlib decompress + delta apply per chain link).

--- a/go-libfossil/manifest/finfo.go
+++ b/go-libfossil/manifest/finfo.go
@@ -1,0 +1,204 @@
+package manifest
+
+import (
+	"fmt"
+	"time"
+
+	libfossil "github.com/dmestas/edgesync/go-libfossil"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// FileAction describes what happened to a file in a given checkin.
+type FileAction int
+
+const (
+	FileAdded    FileAction = iota // file first appears (no parent file blob)
+	FileModified                   // file content changed from parent
+	FileDeleted                    // file removed (fid = 0)
+	FileRenamed                    // filename changed (pfnid != fnid)
+)
+
+func (a FileAction) String() string {
+	switch a {
+	case FileAdded:
+		return "added"
+	case FileModified:
+		return "modified"
+	case FileDeleted:
+		return "deleted"
+	case FileRenamed:
+		return "renamed"
+	default:
+		return "unknown"
+	}
+}
+
+// FileVersion represents one entry in a file's history across checkins.
+type FileVersion struct {
+	CheckinRID  libfossil.FslID // rid of the checkin manifest
+	CheckinUUID string          // UUID of the checkin
+	FileRID     libfossil.FslID // rid of the file blob (0 if deleted)
+	FileUUID    string          // UUID of the file blob ("" if deleted)
+	Action      FileAction
+	User        string
+	Comment     string
+	Date        time.Time
+	PrevName    string // non-empty if renamed (previous filename)
+}
+
+// FileHistoryOpts controls the file history query.
+type FileHistoryOpts struct {
+	// Path is the filename to trace (required).
+	Path string
+	// Limit caps the number of results (0 = unlimited).
+	Limit int
+}
+
+// FileHistory returns the change history of a file across checkins,
+// ordered by date descending (most recent first). It queries the mlink
+// table directly, which is populated during crosslink/rebuild.
+//
+// Each returned FileVersion represents a checkin where the file was
+// added, modified, deleted, or renamed.
+func FileHistory(r *repo.Repo, opts FileHistoryOpts) ([]FileVersion, error) {
+	if r == nil {
+		panic("manifest.FileHistory: r must not be nil")
+	}
+	if opts.Path == "" {
+		return nil, fmt.Errorf("manifest.FileHistory: Path is required")
+	}
+
+	// Look up fnid for the given filename.
+	var fnid int64
+	err := r.DB().QueryRow("SELECT fnid FROM filename WHERE name=?", opts.Path).Scan(&fnid)
+	if err != nil {
+		return nil, fmt.Errorf("manifest.FileHistory: file %q not found in filename table: %w", opts.Path, err)
+	}
+
+	return fileHistoryByFnid(r, fnid, opts)
+}
+
+func fileHistoryByFnid(r *repo.Repo, fnid int64, opts FileHistoryOpts) ([]FileVersion, error) {
+	limitClause := ""
+	if opts.Limit > 0 {
+		limitClause = fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	query := `
+		SELECT
+			m.mid,
+			cb.uuid,
+			m.fid,
+			COALESCE(fb.uuid, ''),
+			COALESCE(m.pid, 0),
+			COALESCE(m.pfnid, 0),
+			e.user,
+			e.comment,
+			e.mtime
+		FROM mlink m
+		JOIN blob cb ON cb.rid = m.mid
+		JOIN event e ON e.objid = m.mid
+		LEFT JOIN blob fb ON fb.rid = m.fid
+		WHERE m.fnid = ?
+		ORDER BY e.mtime DESC` + limitClause
+
+	rows, err := r.DB().Query(query, fnid)
+	if err != nil {
+		return nil, fmt.Errorf("manifest.FileHistory: query: %w", err)
+	}
+	defer rows.Close()
+
+	var versions []FileVersion
+	for rows.Next() {
+		var v FileVersion
+		var pid, pfnid int64
+		var mtimeRaw any
+		if err := rows.Scan(
+			&v.CheckinRID, &v.CheckinUUID,
+			&v.FileRID, &v.FileUUID,
+			&pid, &pfnid,
+			&v.User, &v.Comment, &mtimeRaw,
+		); err != nil {
+			return nil, fmt.Errorf("manifest.FileHistory: scan: %w", err)
+		}
+
+		v.Date = parseMtime(mtimeRaw)
+		action, changed := classifyAction(v.FileRID, pid, pfnid, fnid)
+		if !changed {
+			continue // skip unchanged files
+		}
+		v.Action = action
+
+		if pfnid != 0 && pfnid != fnid {
+			var prevName string
+			if err := r.DB().QueryRow("SELECT name FROM filename WHERE fnid=?", pfnid).Scan(&prevName); err == nil {
+				v.PrevName = prevName
+			}
+		}
+
+		versions = append(versions, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("manifest.FileHistory: rows: %w", err)
+	}
+
+	return versions, nil
+}
+
+// classifyAction returns the action and whether this entry represents a real change.
+// unchanged returns false when fid == pid (file listed in commit but not actually modified).
+func classifyAction(fileRID libfossil.FslID, pid, pfnid, fnid int64) (FileAction, bool) {
+	if fileRID == 0 {
+		return FileDeleted, true
+	}
+	if pfnid != 0 && pfnid != fnid {
+		return FileRenamed, true
+	}
+	if pid == 0 {
+		return FileAdded, true
+	}
+	if int64(fileRID) == pid {
+		return FileModified, false // unchanged — same blob as parent
+	}
+	return FileModified, true
+}
+
+func parseMtime(raw any) time.Time {
+	switch v := raw.(type) {
+	case float64:
+		return libfossil.JulianToTime(v)
+	case time.Time:
+		return v
+	case int64:
+		return libfossil.JulianToTime(float64(v))
+	default:
+		return time.Time{}
+	}
+}
+
+// FileAt returns the file blob RID for a given filename at a specific checkin.
+// Returns 0, false if the file does not exist in that checkin.
+// This is a convenience wrapper for diff-between-versions use cases.
+func FileAt(r *repo.Repo, checkinRID libfossil.FslID, path string) (libfossil.FslID, bool) {
+	if r == nil {
+		panic("manifest.FileAt: r must not be nil")
+	}
+	if checkinRID <= 0 {
+		panic("manifest.FileAt: checkinRID must be positive")
+	}
+	if path == "" {
+		panic("manifest.FileAt: path must not be empty")
+	}
+
+	var fid int64
+	err := r.DB().QueryRow(`
+		SELECT m.fid FROM mlink m
+		JOIN filename f ON f.fnid = m.fnid
+		WHERE m.mid = ? AND f.name = ? AND m.fid > 0`,
+		checkinRID, path,
+	).Scan(&fid)
+	if err != nil {
+		return 0, false
+	}
+	return libfossil.FslID(fid), true
+}

--- a/go-libfossil/manifest/finfo_test.go
+++ b/go-libfossil/manifest/finfo_test.go
@@ -1,0 +1,224 @@
+package manifest
+
+import (
+	"testing"
+	"time"
+
+	_ "github.com/dmestas/edgesync/go-libfossil/internal/testdriver"
+)
+
+func TestFileHistory_Basic(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	// Commit 1: add hello.txt
+	rid1, _, err := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "hello.txt", Content: []byte("v1")}},
+		Comment: "add hello",
+		User:    "alice",
+		Time:    ts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit 2: modify hello.txt
+	_, _, err = Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "hello.txt", Content: []byte("v2")}},
+		Comment: "update hello",
+		User:    "bob",
+		Time:    ts.Add(time.Hour),
+		Parent:  rid1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versions, err := FileHistory(r, FileHistoryOpts{Path: "hello.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(versions))
+	}
+
+	// Most recent first
+	if versions[0].Action != FileModified {
+		t.Errorf("v[0] action = %v, want Modified", versions[0].Action)
+	}
+	if versions[0].User != "bob" {
+		t.Errorf("v[0] user = %q, want bob", versions[0].User)
+	}
+	if versions[1].Action != FileAdded {
+		t.Errorf("v[1] action = %v, want Added", versions[1].Action)
+	}
+	if versions[1].User != "alice" {
+		t.Errorf("v[1] user = %q, want alice", versions[1].User)
+	}
+}
+
+func TestFileHistory_MultipleFiles(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	rid1, _, _ := Checkin(r, CheckinOpts{
+		Files: []File{
+			{Name: "a.txt", Content: []byte("a1")},
+			{Name: "b.txt", Content: []byte("b1")},
+		},
+		Comment: "add both",
+		User:    "alice",
+		Time:    ts,
+	})
+
+	// Only modify a.txt
+	Checkin(r, CheckinOpts{
+		Files: []File{
+			{Name: "a.txt", Content: []byte("a2")},
+			{Name: "b.txt", Content: []byte("b1")},
+		},
+		Comment: "update a only",
+		User:    "bob",
+		Time:    ts.Add(time.Hour),
+		Parent:  rid1,
+	})
+
+	histA, _ := FileHistory(r, FileHistoryOpts{Path: "a.txt"})
+	histB, _ := FileHistory(r, FileHistoryOpts{Path: "b.txt"})
+
+	if len(histA) != 2 {
+		t.Fatalf("a.txt: expected 2 versions, got %d", len(histA))
+	}
+	// b.txt should only show the initial add — mlink only records changes
+	if len(histB) != 1 {
+		t.Fatalf("b.txt: expected 1 version (add only, no change in commit 2), got %d", len(histB))
+	}
+}
+
+func TestFileHistory_Limit(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	rid1, _, _ := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "f.txt", Content: []byte("v1")}},
+		Comment: "c1",
+		User:    "u",
+		Time:    ts,
+	})
+
+	rid2, _, _ := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "f.txt", Content: []byte("v2")}},
+		Comment: "c2",
+		User:    "u",
+		Time:    ts.Add(time.Hour),
+		Parent:  rid1,
+	})
+
+	Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "f.txt", Content: []byte("v3")}},
+		Comment: "c3",
+		User:    "u",
+		Time:    ts.Add(2 * time.Hour),
+		Parent:  rid2,
+	})
+
+	versions, _ := FileHistory(r, FileHistoryOpts{Path: "f.txt", Limit: 2})
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions with limit, got %d", len(versions))
+	}
+}
+
+func TestFileHistory_NotFound(t *testing.T) {
+	r := setupTestRepo(t)
+
+	_, err := FileHistory(r, FileHistoryOpts{Path: "nonexistent.txt"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestFileHistory_EmptyPath(t *testing.T) {
+	r := setupTestRepo(t)
+
+	_, err := FileHistory(r, FileHistoryOpts{Path: ""})
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestFileHistory_FileUUID(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "data.txt", Content: []byte("content")}},
+		Comment: "add data",
+		User:    "u",
+		Time:    ts,
+	})
+
+	versions, _ := FileHistory(r, FileHistoryOpts{Path: "data.txt"})
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 version, got %d", len(versions))
+	}
+	if versions[0].FileUUID == "" {
+		t.Error("FileUUID should be set for non-deleted file")
+	}
+	if versions[0].CheckinUUID == "" {
+		t.Error("CheckinUUID should be set")
+	}
+	if versions[0].FileRID <= 0 {
+		t.Error("FileRID should be positive")
+	}
+}
+
+func TestFileAt_Basic(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	rid1, _, _ := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "hello.txt", Content: []byte("v1")}},
+		Comment: "c1",
+		User:    "u",
+		Time:    ts,
+	})
+
+	rid2, _, _ := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "hello.txt", Content: []byte("v2")}},
+		Comment: "c2",
+		User:    "u",
+		Time:    ts.Add(time.Hour),
+		Parent:  rid1,
+	})
+
+	fid1, ok1 := FileAt(r, rid1, "hello.txt")
+	fid2, ok2 := FileAt(r, rid2, "hello.txt")
+
+	if !ok1 || fid1 <= 0 {
+		t.Fatal("expected file at commit 1")
+	}
+	if !ok2 || fid2 <= 0 {
+		t.Fatal("expected file at commit 2")
+	}
+	if fid1 == fid2 {
+		t.Fatal("file rids should differ between versions")
+	}
+}
+
+func TestFileAt_NotFound(t *testing.T) {
+	r := setupTestRepo(t)
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	rid1, _, _ := Checkin(r, CheckinOpts{
+		Files:   []File{{Name: "hello.txt", Content: []byte("v1")}},
+		Comment: "c1",
+		User:    "u",
+		Time:    ts,
+	})
+
+	_, ok := FileAt(r, rid1, "nonexistent.txt")
+	if ok {
+		t.Fatal("expected false for nonexistent file")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `manifest.FileHistory()` — walks `mlink` to return a file's change history across checkins (added/modified/deleted/renamed), ordered by date descending
- Add `manifest.FileAt()` — resolves a file's blob RID at a specific checkin, enabling diff-between-versions
- Unchanged files filtered out (where `fid == pid`) so consumers only see actual modifications
- ADR added to `docs/architecture/core-library.md`

## Test plan

- [x] 8 unit tests: basic history, multi-file (unchanged filtering), limit, not-found, empty path, file UUID presence, FileAt basic + not-found
- [x] Full test suite passes (go-libfossil, leaf, bridge, DST, sim, interop)

Closes EDG-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Track file version history with metadata including user, timestamp, and action classification
  * Query file content at specific points in project history
  * Detect file operations including creation, modification, deletion, and renaming

* **Documentation**
  * Added architecture documentation for file history functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->