### PR TITLE
fix(ci): skip TestFossilBinary when fossil not in PATH

### DIFF
--- a/go-libfossil/testutil/testutil_test.go
+++ b/go-libfossil/testutil/testutil_test.go
@@ -28,7 +28,7 @@ func TestFossilSQL(t *testing.T) {
 func TestFossilBinary(t *testing.T) {
 	path := FossilBinary()
 	if path == "" {
-		t.Fatal("FossilBinary() returned empty string")
+		t.Skip("fossil binary not found in PATH")
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("fossil binary not found at %q: %v", path, err)


### PR DESCRIPTION
## Summary

- `TestFossilBinary` was the only fossil-dependent test that hard-failed (`t.Fatal`) instead of skipping when fossil isn't installed. The Unit & DST CI job doesn't install fossil, causing the job to fail.
- Changed to `t.Skip` to match every other fossil-dependent test in the codebase.

## Test plan

- [x] `go test ./go-libfossil/testutil/ -v` passes locally (with fossil)
- [ ] CI Unit & DST job passes (without fossil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test reliability by gracefully skipping tests when required binary tools are unavailable, rather than causing test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->