### PR TITLE
dx: improve onboarding and telemetry visibility

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# Dual VCS (Git + Fossil) confuses Go's VCS stamping.
+# This disables it project-wide so bare `go build` works.
+export GOFLAGS="-buildvcs=false"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean leaf bridge edgesync wasm-wasi wasm-browser wasm dst dst-full dst-hostile dst-drivers sim sim-full setup-hooks drivers test-interop
+.PHONY: build test clean leaf bridge edgesync wasm-wasi wasm-browser wasm dst dst-full dst-hostile dst-drivers sim sim-full setup-hooks setup drivers test-interop
 
 # --- Build ---
 
@@ -40,7 +40,13 @@ test:
 	go test ./sim/ -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe' -count=1 -timeout=120s
 	go test ./sim/ -run 'TestInterop' -count=1 -short -timeout=60s
 
-# --- Pre-commit hook setup ---
+# --- Setup (first-time onboarding) ---
+
+setup: setup-hooks build test
+	@echo ""
+	@echo "Setup complete. Binaries in bin/. Try:"
+	@echo "  bin/edgesync repo info"
+	@echo "  bin/leaf --help"
 
 setup-hooks:
 	git config core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -29,14 +29,41 @@ graph LR
 ## Quick Start
 
 ```bash
-# Build everything
-make build
+# One command: install hooks + build + test
+make setup
 
-# Run tests (what CI runs)
-make test
+# Run the leaf agent
+bin/leaf --repo my.fossil --nats nats://localhost:4222 --serve-http :8080
 
-# Install pre-commit hook (~8s of tests before each commit)
-make setup-hooks
+# Run the edgesync CLI
+bin/edgesync repo info
+```
+
+### Dual VCS Note
+
+This repo is tracked by both Git and Fossil. Go's VCS stamping gets confused by this, so **all `go build` commands need `-buildvcs=false`**. The Makefile handles this automatically. If you run `go build` directly:
+
+```bash
+# Either pass the flag every time:
+go build -buildvcs=false ./cmd/edgesync/
+
+# Or set it once per shell session:
+export GOFLAGS="-buildvcs=false"
+go build ./cmd/edgesync/   # works without the flag now
+```
+
+If you use [direnv](https://direnv.net/), the included `.envrc` sets this for you automatically.
+
+### Telemetry (Optional)
+
+Traces, metrics, and structured logs via OpenTelemetry. Zero overhead when disabled — the leaf agent logs whether telemetry is active at startup.
+
+```bash
+# With Doppler (manages OTel secrets):
+doppler run -- bin/leaf --repo my.fossil --nats nats://localhost:4222
+
+# Or set the endpoint directly:
+OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318 bin/leaf --repo my.fossil --nats nats://localhost:4222
 ```
 
 ## Project Layout

--- a/leaf/cmd/leaf/main.go
+++ b/leaf/cmd/leaf/main.go
@@ -62,6 +62,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *otelEndpoint == "" {
+		slog.Info("telemetry disabled: no OTEL_EXPORTER_OTLP_ENDPOINT or --otel-endpoint set")
+	} else {
+		slog.Info("telemetry enabled", "endpoint", *otelEndpoint, "service", *otelServiceName)
+	}
+
 	// Create observer (nil-safe: if no endpoint, OTel uses no-op providers)
 	var obs libsync.Observer = telemetry.NewOTelObserver(nil, nil)
 	if verboseFlag {


### PR DESCRIPTION
## Summary
- Add `make setup` one-liner that chains hooks + build + test for first-time onboarding
- Add `.envrc` so direnv users automatically get `-buildvcs=false` (fixes the #1 DX papercut with bare `go build`)
- Update README quickstart with `make setup`, dual VCS note, and telemetry section
- Log telemetry status at leaf agent startup — no more silent degradation when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset

## Test plan
- [ ] `make setup` runs hooks + build + test successfully
- [ ] `direnv allow` in project root sets `GOFLAGS`; `go build ./cmd/edgesync/` works without `-buildvcs=false`
- [ ] `bin/leaf --repo test.fossil` logs "telemetry disabled" at startup
- [ ] `OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318 bin/leaf --repo test.fossil` logs "telemetry enabled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)