### PR TITLE
feat: table sync row deletion (xdelete) and PK hash fix

### DIFF
--- a/docs/superpowers/plans/2026-04-02-table-sync-deletion.md
+++ b/docs/superpowers/plans/2026-04-02-table-sync-deletion.md
@@ -1,0 +1,1572 @@
+# Table Sync Deletion & PK Hash Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add row deletion support (xdelete card) and fix PK hash type coercion in the remote schema sync feature.
+
+**Architecture:** Two changes to go-libfossil's table sync: (1) type-aware PK hash normalization replacing `json.Marshal`-based hashing, and (2) a new `xdelete` card type with UV-style in-place tombstones (all non-PK value columns set to NULL). Both changes are in `go-libfossil/` (repo, xfer, sync packages) with DST coverage in `dst/`.
+
+**Tech Stack:** Go, SQLite, SHA1 hashing, xfer card protocol
+
+**Spec:** `docs/superpowers/specs/2026-04-02-table-sync-deletion-and-pk-hash-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `go-libfossil/repo/tablesync.go` | `PKHash` signature change, `DeleteXRow`, tombstone detection, nullable columns in DDL, catalog hash exclusion |
+| Modify | `go-libfossil/repo/tablesync_test.go` | PK hash tests, DeleteXRow tests, catalog hash tombstone exclusion |
+| Modify | `go-libfossil/xfer/card.go:33` | Add `CardXDelete = 24` |
+| Modify | `go-libfossil/xfer/card_tablesync.go` | Add `XDeleteCard` struct |
+| Modify | `go-libfossil/xfer/card_tablesync_test.go` | XDeleteCard type + round-trip tests, fuzz test |
+| Modify | `go-libfossil/xfer/encode.go:282` | Add `encodeXDelete` |
+| Modify | `go-libfossil/xfer/decode.go:143` | Add `"xdelete"` case + `parseXDelete` |
+| Modify | `go-libfossil/sync/handler_tablesync.go` | `handleXDelete`, tombstone-aware `handleXIGot`, `sendXDelete` |
+| Modify | `go-libfossil/sync/handler.go:323` | Add `*xfer.XDeleteCard` case to `handleDataCard` |
+| Modify | `go-libfossil/sync/client_tablesync.go` | `processXTableCard` dispatch for XDeleteCard, `handleXDeleteResponse`, tombstone-aware `buildTableSendCards` |
+| Modify | `go-libfossil/sync/client.go:551` | Add `*xfer.XDeleteCard` to the table sync dispatch case |
+| Modify | `go-libfossil/sync/handler_tablesync_test.go` | Handler-level xdelete tests |
+| Modify | `go-libfossil/sync/client_tablesync_test.go` | End-to-end xdelete convergence |
+| Modify | `dst/tablesync_test.go` | DST: multi-peer deletion, resurrection, integer PK convergence |
+
+---
+
+### Task 1: Fix PK hash — type-aware normalization
+
+**Files:**
+- Modify: `go-libfossil/repo/tablesync.go:228-240`
+- Modify: `go-libfossil/repo/tablesync_test.go:36-49`
+
+- [ ] **Step 1: Write failing tests for type-aware PKHash**
+
+Add to `go-libfossil/repo/tablesync_test.go`:
+
+```go
+func TestPKHashTypeAware(t *testing.T) {
+	pkCols := []ColumnDef{{Name: "id", Type: "integer", PK: true}}
+
+	// int64 and float64 of same value must produce identical hashes.
+	h1 := PKHash(pkCols, map[string]any{"id": int64(42)})
+	h2 := PKHash(pkCols, map[string]any{"id": float64(42)})
+	if h1 != h2 {
+		t.Fatalf("int64 vs float64: %q != %q", h1, h2)
+	}
+
+	// Large integer (>2^53) must not lose precision.
+	big := int64(1<<53 + 1) // 9007199254740993
+	h3 := PKHash(pkCols, map[string]any{"id": big})
+	h4 := PKHash(pkCols, map[string]any{"id": float64(big)})
+	// float64 loses precision at 2^53+1, so these should still match
+	// because we normalize float64 → int64 before formatting.
+	if h3 != h4 {
+		t.Fatalf("large int: %q != %q", h3, h4)
+	}
+
+	// Composite PK with mixed types.
+	mixedCols := []ColumnDef{
+		{Name: "org", Type: "text", PK: true},
+		{Name: "seq", Type: "integer", PK: true},
+	}
+	h5 := PKHash(mixedCols, map[string]any{"org": "acme", "seq": int64(7)})
+	h6 := PKHash(mixedCols, map[string]any{"org": "acme", "seq": float64(7)})
+	if h5 != h6 {
+		t.Fatalf("composite mixed types: %q != %q", h5, h6)
+	}
+
+	// Text PK must still work.
+	textCols := []ColumnDef{{Name: "name", Type: "text", PK: true}}
+	h7 := PKHash(textCols, map[string]any{"name": "hello"})
+	if h7 == "" {
+		t.Fatal("text PK hash is empty")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run TestPKHashTypeAware -v`
+Expected: FAIL — `PKHash` doesn't accept `[]ColumnDef` parameter.
+
+- [ ] **Step 3: Implement type-aware PKHash**
+
+Replace `PKHash` in `go-libfossil/repo/tablesync.go:228-240` with:
+
+```go
+// normalizeValue converts a value to its canonical string representation
+// based on the declared column type. This ensures PK hashes are identical
+// regardless of how the value arrived (JSON unmarshal, SQLite scan, etc.).
+func normalizeValue(colType string, v any) string {
+	switch colType {
+	case "integer":
+		switch n := v.(type) {
+		case int64:
+			return strconv.FormatInt(n, 10)
+		case float64:
+			return strconv.FormatInt(int64(n), 10)
+		case int:
+			return strconv.FormatInt(int64(n), 10)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	case "real":
+		switch n := v.(type) {
+		case float64:
+			return strconv.FormatFloat(n, 'f', -1, 64)
+		case int64:
+			return strconv.FormatFloat(float64(n), 'f', -1, 64)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	case "text":
+		s, _ := v.(string)
+		return s
+	case "blob":
+		b, _ := v.([]byte)
+		return hex.EncodeToString(b)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// PKHash computes a deterministic SHA1 hash of the primary key values.
+// Values are normalized to canonical strings based on declared column types
+// to avoid JSON round-trip coercion issues (e.g., int64 → float64).
+func PKHash(pkCols []ColumnDef, pkValues map[string]any) string {
+	if pkCols == nil {
+		panic("repo.PKHash: pkCols must not be nil")
+	}
+	if pkValues == nil {
+		panic("repo.PKHash: pkValues must not be nil")
+	}
+
+	// Sort PK columns lexicographically for determinism.
+	sorted := make([]ColumnDef, len(pkCols))
+	copy(sorted, pkCols)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	// Build canonical representation: name=normalizedValue joined by \x00.
+	var parts []string
+	for _, col := range sorted {
+		v := pkValues[col.Name]
+		parts = append(parts, col.Name+"="+normalizeValue(col.Type, v))
+	}
+	canonical := strings.Join(parts, "\x00")
+	return hash.SHA1([]byte(canonical))
+}
+```
+
+Add `"encoding/hex"` and `"strconv"` to the imports in `tablesync.go`.
+
+- [ ] **Step 4: Update existing TestPKHash to use new signature**
+
+Update `go-libfossil/repo/tablesync_test.go:36-49`:
+
+```go
+func TestPKHash(t *testing.T) {
+	pkCols := []ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	h := PKHash(pkCols, map[string]any{"peer_id": "leaf-01"})
+	if h == "" {
+		t.Fatal("PKHash returned empty")
+	}
+	h2 := PKHash(pkCols, map[string]any{"peer_id": "leaf-01"})
+	if h != h2 {
+		t.Fatalf("PKHash not deterministic: %q vs %q", h, h2)
+	}
+	h3 := PKHash(pkCols, map[string]any{"peer_id": "leaf-02"})
+	if h == h3 {
+		t.Fatal("different inputs produced same hash")
+	}
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run TestPKHash -v`
+Expected: PASS for both `TestPKHash` and `TestPKHashTypeAware`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/repo/tablesync.go go-libfossil/repo/tablesync_test.go
+git commit -m "fix(repo): type-aware PK hash normalization (CDG-171)
+
+Replace json.Marshal-based PKHash with canonical string normalization
+per declared column type. Prevents hash divergence on JSON round-trip
+(int64 → float64 coercion) for integer PKs."
+```
+
+---
+
+### Task 2: Update all PKHash callers
+
+**Files:**
+- Modify: `go-libfossil/repo/tablesync.go:337-440` (LookupXRow, CatalogHash)
+- Modify: `go-libfossil/sync/handler_tablesync.go:246-260,375-391` (verifyXRowPKHash, emitXIGotsForTable)
+- Modify: `go-libfossil/sync/client_tablesync.go:83-104` (buildTableXIGotCards)
+- Modify: `dst/tablesync_test.go:101-115` (assertRowValue)
+
+- [ ] **Step 1: Add helper to extract PK ColumnDefs (not just names)**
+
+Add to `go-libfossil/sync/client_tablesync.go`, replacing the existing `extractPKColumns` at line 276:
+
+```go
+// extractPKColumns returns the names of all primary key columns from a TableDef.
+// This is a package-level function shared by both client and handler.
+func extractPKColumns(def repo.TableDef) []string {
+	var pkCols []string
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col.Name)
+		}
+	}
+	return pkCols
+}
+
+// extractPKColumnDefs returns the ColumnDef of all PK columns from a TableDef.
+func extractPKColumnDefs(def repo.TableDef) []repo.ColumnDef {
+	var pkCols []repo.ColumnDef
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col)
+		}
+	}
+	return pkCols
+}
+```
+
+- [ ] **Step 2: Update LookupXRow to pass pkCols**
+
+In `go-libfossil/repo/tablesync.go`, update `LookupXRow` (lines 352-382). Replace the two `PKHash(pkValues)` calls at lines 367 and 376 with:
+
+```go
+		computed := PKHash(pkColDefs, pkValues)
+```
+
+And change the PK extraction at lines 354-358 to:
+
+```go
+	// Extract PK column definitions (not just names — needed for type-aware hash).
+	var pkColDefs []ColumnDef
+	var pkNames []string
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+			pkNames = append(pkNames, col.Name)
+		}
+	}
+```
+
+And update the `pkValues` loop to use `pkNames`:
+
+```go
+		pkValues := make(map[string]any)
+		for _, pk := range pkNames {
+			pkValues[pk] = row[pk]
+		}
+		computed := PKHash(pkColDefs, pkValues)
+```
+
+Apply the same for the verify block at lines 370-377:
+
+```go
+			verifyPK := make(map[string]any)
+			for _, pk := range pkNames {
+				verifyPK[pk] = row[pk]
+			}
+			if PKHash(pkColDefs, verifyPK) != pkHash {
+```
+
+- [ ] **Step 3: Update CatalogHash to pass pkCols**
+
+In `go-libfossil/repo/tablesync.go`, update `CatalogHash` (lines 400-406 and 414-422):
+
+```go
+	// Extract PK column definitions.
+	var pkColDefs []ColumnDef
+	var pkNames []string
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+			pkNames = append(pkNames, col.Name)
+		}
+	}
+```
+
+And update the hash computation:
+
+```go
+		pkValues := make(map[string]any)
+		for _, pk := range pkNames {
+			pkValues[pk] = row[pk]
+		}
+		entries = append(entries, entry{
+			pkHash: PKHash(pkColDefs, pkValues),
+			mtime:  mtimes[i],
+		})
+```
+
+- [ ] **Step 4: Update handler_tablesync.go callers**
+
+In `go-libfossil/sync/handler_tablesync.go`:
+
+Update `verifyXRowPKHash` (line 251):
+```go
+	pkColDefs := extractPKColumnDefs(st.Def)
+	pkCols := extractPKColumns(st.Def)
+	pkValues := make(map[string]any)
+	for _, col := range pkCols {
+		pkValues[col] = row[col]
+	}
+	computedPK := repo.PKHash(pkColDefs, pkValues)
+```
+
+Update `emitXIGotsForTable` (lines 375-382):
+```go
+	pkCols := extractPKColumns(st.Def)
+	pkColDefs := extractPKColumnDefs(st.Def)
+
+	for i, row := range rows {
+		pkValues := make(map[string]any)
+		for _, col := range pkCols {
+			pkValues[col] = row[col]
+		}
+		pkHash := repo.PKHash(pkColDefs, pkValues)
+```
+
+- [ ] **Step 5: Update client_tablesync.go callers**
+
+In `go-libfossil/sync/client_tablesync.go`, update `buildTableXIGotCards` (lines 83-90):
+```go
+	pkCols := extractPKColumns(info.Def)
+	pkColDefs := extractPKColumnDefs(info.Def)
+	var cards []xfer.Card
+	for i, row := range rows {
+		pkValues := make(map[string]any)
+		for _, col := range pkCols {
+			pkValues[col] = row[col]
+		}
+		pkHash := repo.PKHash(pkColDefs, pkValues)
+```
+
+- [ ] **Step 6: Update DST test helpers**
+
+In `dst/tablesync_test.go`, update `assertRowValue` (line 103):
+```go
+	var pkColDefs []repo.ColumnDef
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+		}
+	}
+	pkHash := repo.PKHash(pkColDefs, pk)
+```
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/... ./dst/ -v -count=1 2>&1 | tail -30`
+Expected: All existing tests pass with the new PKHash signature.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/repo/tablesync.go go-libfossil/sync/handler_tablesync.go go-libfossil/sync/client_tablesync.go dst/tablesync_test.go
+git commit -m "refactor(sync): update all PKHash callers to pass ColumnDefs
+
+Thread PK ColumnDefs through LookupXRow, CatalogHash, handler, client,
+and DST helpers. Adds extractPKColumnDefs() shared helper."
+```
+
+---
+
+### Task 3: Make non-PK columns nullable in extension tables
+
+**Files:**
+- Modify: `go-libfossil/repo/tablesync.go:152-192`
+- Modify: `go-libfossil/repo/tablesync_test.go`
+
+- [ ] **Step 1: Write failing test for nullable columns**
+
+Add to `go-libfossil/repo/tablesync_test.go`:
+
+```go
+func TestExtensionTableNullableValueColumns(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	if err := RegisterSyncedTable(r.DB(), "nullable_test", def, 1000); err != nil {
+		t.Fatal(err)
+	}
+	// Insert row with NULL value column — should succeed for tombstone support.
+	_, err := r.DB().Exec("INSERT INTO x_nullable_test(id, data, mtime) VALUES('k1', NULL, 1000)")
+	if err != nil {
+		t.Fatalf("insert with NULL value column should succeed: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run TestExtensionTableNullableValueColumns -v`
+Expected: FAIL — `NOT NULL constraint failed: x_nullable_test.data`
+
+- [ ] **Step 3: Change createExtensionTable to only enforce NOT NULL on PK columns**
+
+In `go-libfossil/repo/tablesync.go`, update `createExtensionTable` (line 165):
+
+```go
+		// PK columns are NOT NULL; value columns are nullable (for tombstone support).
+		if col.PK {
+			cols = append(cols, fmt.Sprintf("%s %s NOT NULL", col.Name, sqlType))
+		} else {
+			cols = append(cols, fmt.Sprintf("%s %s", col.Name, sqlType))
+		}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run TestExtensionTableNullableValueColumns -v`
+Expected: PASS
+
+Note: existing repos with `NOT NULL` columns created before this change will need `ALTER TABLE` or re-creation. Since table sync is still pre-production, this is acceptable — no migration needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/repo/tablesync.go go-libfossil/repo/tablesync_test.go
+git commit -m "fix(repo): make non-PK extension table columns nullable
+
+Required for UV-style tombstones where deleted rows have all value
+columns set to NULL. PK columns remain NOT NULL."
+```
+
+---
+
+### Task 4: Add tombstone helpers — IsTombstone, DeleteXRow, catalog hash exclusion
+
+**Files:**
+- Modify: `go-libfossil/repo/tablesync.go`
+- Modify: `go-libfossil/repo/tablesync_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `go-libfossil/repo/tablesync_test.go`:
+
+```go
+func TestIsTombstone(t *testing.T) {
+	def := TableDef{
+		Columns: []ColumnDef{
+			{Name: "id", Type: "text", PK: true},
+			{Name: "data", Type: "text"},
+			{Name: "count", Type: "integer"},
+		},
+		Conflict: "mtime-wins",
+	}
+	// Live row — not a tombstone.
+	if IsTombstone(def, map[string]any{"id": "k1", "data": "hello", "count": int64(5)}) {
+		t.Error("live row should not be tombstone")
+	}
+	// Tombstone — all non-PK value columns are nil.
+	if !IsTombstone(def, map[string]any{"id": "k1", "data": nil, "count": nil}) {
+		t.Error("row with all nil values should be tombstone")
+	}
+	// Partial nil — not a tombstone.
+	if IsTombstone(def, map[string]any{"id": "k1", "data": nil, "count": int64(5)}) {
+		t.Error("partial nil should not be tombstone")
+	}
+}
+
+func TestDeleteXRow(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	RegisterSyncedTable(r.DB(), "del_test", def, 1000)
+
+	// Seed a live row.
+	UpsertXRow(r.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+
+	// Delete with newer mtime.
+	deleted, err := DeleteXRow(r.DB(), "del_test", def, "k1", 2000)
+	if err != nil {
+		t.Fatalf("DeleteXRow: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deletion to apply")
+	}
+
+	// Verify tombstone.
+	pkColDefs := []ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := PKHash(pkColDefs, map[string]any{"id": "k1"})
+	row, mtime, err := LookupXRow(r.DB(), "del_test", def, pkHash)
+	if err != nil {
+		t.Fatalf("LookupXRow: %v", err)
+	}
+	if row == nil {
+		t.Fatal("tombstone row should still exist")
+	}
+	if mtime != 2000 {
+		t.Errorf("mtime = %d, want 2000", mtime)
+	}
+	if !IsTombstone(def, row) {
+		t.Error("row should be tombstone after deletion")
+	}
+
+	// Delete with older mtime — should be rejected.
+	deleted, err = DeleteXRow(r.DB(), "del_test", def, "k1", 1500)
+	if err != nil {
+		t.Fatalf("DeleteXRow (older): %v", err)
+	}
+	if deleted {
+		t.Error("older delete should be rejected")
+	}
+
+	// Resurrection — UpsertXRow with newer mtime.
+	UpsertXRow(r.DB(), "del_test", map[string]any{"id": "k1", "data": "revived"}, 3000)
+	row, _, _ = LookupXRow(r.DB(), "del_test", def, pkHash)
+	if IsTombstone(def, row) {
+		t.Error("row should be live after resurrection")
+	}
+}
+
+func TestCatalogHashExcludesTombstones(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	RegisterSyncedTable(r.DB(), "cat_test", def, 1000)
+
+	// Seed two rows.
+	UpsertXRow(r.DB(), "cat_test", map[string]any{"id": "k1", "data": "a"}, 1000)
+	UpsertXRow(r.DB(), "cat_test", map[string]any{"id": "k2", "data": "b"}, 1000)
+	hashBefore, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	// Delete k1.
+	DeleteXRow(r.DB(), "cat_test", def, "k1", 2000)
+	hashAfter, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	if hashBefore == hashAfter {
+		t.Error("catalog hash should change after deletion")
+	}
+
+	// Delete k2 — catalog should now match a fresh empty table.
+	DeleteXRow(r.DB(), "cat_test", def, "k2", 2000)
+	hashEmpty, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	// Register a fresh empty table for comparison.
+	RegisterSyncedTable(r.DB(), "cat_empty", def, 1000)
+	hashFresh, _ := CatalogHash(r.DB(), "cat_empty", def)
+	if hashEmpty != hashFresh {
+		t.Errorf("all-tombstone table hash %q != empty table hash %q", hashEmpty, hashFresh)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run "TestIsTombstone|TestDeleteXRow|TestCatalogHashExcludesTombstones" -v`
+Expected: FAIL — `IsTombstone` and `DeleteXRow` not defined.
+
+- [ ] **Step 3: Implement IsTombstone**
+
+Add to `go-libfossil/repo/tablesync.go`:
+
+```go
+// IsTombstone returns true if all non-PK, non-mtime, non-_owner value columns
+// in the row are nil. A tombstone represents a deleted row.
+func IsTombstone(def TableDef, row map[string]any) bool {
+	for _, col := range def.Columns {
+		if col.PK {
+			continue
+		}
+		if row[col.Name] != nil {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Implement DeleteXRow**
+
+Add to `go-libfossil/repo/tablesync.go`:
+
+```go
+// DeleteXRow tombstones a row by setting all non-PK value columns to NULL
+// and updating mtime. Returns true if the deletion was applied, false if
+// the local row has a newer mtime. Uses pkValue (a single PK column value
+// for simple PKs) to look up the row by primary key name directly.
+func DeleteXRow(d *db.DB, tableName string, def TableDef, pkValue string, mtime int64) (bool, error) {
+	if d == nil {
+		panic("repo.DeleteXRow: d must not be nil")
+	}
+
+	// Find PK column names.
+	var pkCols []string
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col.Name)
+		}
+	}
+	if len(pkCols) != 1 {
+		return false, fmt.Errorf("repo.DeleteXRow: simple API only supports single-PK tables, got %d PK cols", len(pkCols))
+	}
+
+	// Check current mtime.
+	var currentMtime int64
+	err := d.QueryRow(
+		fmt.Sprintf("SELECT mtime FROM x_%s WHERE %s = ?", tableName, pkCols[0]),
+		pkValue,
+	).Scan(&currentMtime)
+	if err == sql.ErrNoRows {
+		return false, nil // row doesn't exist locally — caller handles via PKData
+	}
+	if err != nil {
+		return false, fmt.Errorf("repo.DeleteXRow: lookup mtime: %w", err)
+	}
+
+	// mtime-wins: reject if local is newer.
+	if currentMtime > mtime {
+		return false, nil
+	}
+
+	// Build SET clause: NULL all non-PK, non-mtime value columns.
+	var setClauses []string
+	for _, col := range def.Columns {
+		if col.PK {
+			continue
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = NULL", col.Name))
+	}
+	setClauses = append(setClauses, "mtime = ?")
+
+	sql := fmt.Sprintf(
+		"UPDATE x_%s SET %s WHERE %s = ?",
+		tableName,
+		strings.Join(setClauses, ", "),
+		pkCols[0],
+	)
+	_, err = d.Exec(sql, mtime, pkValue)
+	if err != nil {
+		return false, fmt.Errorf("repo.DeleteXRow: update: %w", err)
+	}
+	return true, nil
+}
+
+// DeleteXRowByPKHash tombstones a row identified by PK hash. Falls back to
+// scanning all rows to find the match (same as LookupXRow). Returns true
+// if the deletion was applied.
+func DeleteXRowByPKHash(d *db.DB, tableName string, def TableDef, pkHash string, mtime int64) (bool, error) {
+	if d == nil {
+		panic("repo.DeleteXRowByPKHash: d must not be nil")
+	}
+
+	// Find the row's PK values by scanning (same strategy as LookupXRow).
+	row, currentMtime, err := LookupXRow(d, tableName, def, pkHash)
+	if err != nil {
+		return false, err
+	}
+	if row == nil {
+		return false, nil // row doesn't exist locally
+	}
+
+	// mtime-wins: reject if local is newer.
+	if currentMtime > mtime {
+		return false, nil
+	}
+
+	// Extract PK column names for WHERE clause.
+	var pkCols []string
+	var pkValues []any
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col.Name)
+			pkValues = append(pkValues, row[col.Name])
+		}
+	}
+
+	// Build SET clause: NULL all non-PK value columns, update mtime.
+	var setClauses []string
+	for _, col := range def.Columns {
+		if col.PK {
+			continue
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = NULL", col.Name))
+	}
+	setClauses = append(setClauses, "mtime = ?")
+
+	// Build WHERE clause.
+	var whereClauses []string
+	for _, pk := range pkCols {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = ?", pk))
+	}
+
+	args := []any{mtime}
+	args = append(args, pkValues...)
+
+	sqlStr := fmt.Sprintf(
+		"UPDATE x_%s SET %s WHERE %s",
+		tableName,
+		strings.Join(setClauses, ", "),
+		strings.Join(whereClauses, " AND "),
+	)
+	_, err = d.Exec(sqlStr, args...)
+	if err != nil {
+		return false, fmt.Errorf("repo.DeleteXRowByPKHash: update: %w", err)
+	}
+	return true, nil
+}
+```
+
+- [ ] **Step 5: Update CatalogHash to exclude tombstones**
+
+In `go-libfossil/repo/tablesync.go`, update `CatalogHash` (around line 414) to skip tombstone rows:
+
+```go
+	for i, row := range rows {
+		// Exclude tombstones from catalog hash (UV convention).
+		if IsTombstone(def, row) {
+			continue
+		}
+		pkValues := make(map[string]any)
+		for _, pk := range pkNames {
+			pkValues[pk] = row[pk]
+		}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/repo/ -run "TestIsTombstone|TestDeleteXRow|TestCatalogHashExcludesTombstones" -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/repo/tablesync.go go-libfossil/repo/tablesync_test.go
+git commit -m "feat(repo): add IsTombstone, DeleteXRow, tombstone-aware CatalogHash
+
+UV-style tombstones: deleted rows keep PK columns, NULL all value
+columns, update mtime. CatalogHash excludes tombstone rows."
+```
+
+---
+
+### Task 5: Add XDeleteCard to xfer protocol
+
+**Files:**
+- Modify: `go-libfossil/xfer/card.go:33`
+- Modify: `go-libfossil/xfer/card_tablesync.go`
+- Modify: `go-libfossil/xfer/card_tablesync_test.go`
+- Modify: `go-libfossil/xfer/encode.go`
+- Modify: `go-libfossil/xfer/decode.go`
+
+- [ ] **Step 1: Write failing round-trip test**
+
+Add to `go-libfossil/xfer/card_tablesync_test.go`:
+
+```go
+func TestXDeleteCardType(t *testing.T) {
+	c := &XDeleteCard{Table: "devices", PKHash: "abc123", MTime: 2000, PKData: []byte(`{"device_id":"d1"}`)}
+	if c.Type() != CardXDelete {
+		t.Fatalf("got %v, want CardXDelete", c.Type())
+	}
+}
+
+func TestXDeleteCard_RoundTrip(t *testing.T) {
+	original := &XDeleteCard{
+		Table:  "devices",
+		PKHash: "abc123def456",
+		MTime:  1711300000,
+		PKData: []byte(`{"device_id":"d1"}`),
+	}
+	var buf bytes.Buffer
+	if err := EncodeCard(&buf, original); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r := bufio.NewReader(&buf)
+	got, err := DecodeCard(r)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	xd, ok := got.(*XDeleteCard)
+	if !ok {
+		t.Fatalf("got %T, want *XDeleteCard", got)
+	}
+	if xd.Table != original.Table || xd.PKHash != original.PKHash || xd.MTime != original.MTime {
+		t.Errorf("fields mismatch: got %+v", xd)
+	}
+	if string(xd.PKData) != string(original.PKData) {
+		t.Errorf("PKData = %q, want %q", xd.PKData, original.PKData)
+	}
+}
+
+func FuzzParseXDelete(f *testing.F) {
+	f.Add("devices abc123 1711300000 18\n{\"device_id\":\"d1\"}\n")
+	f.Add("t a 0 0\n\n")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, input string) {
+		r := bufio.NewReader(bytes.NewReader([]byte("xdelete " + input)))
+		_, _ = DecodeCard(r) // must not panic
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/xfer/ -run "TestXDeleteCard" -v`
+Expected: FAIL — `XDeleteCard` not defined.
+
+- [ ] **Step 3: Add CardXDelete constant**
+
+In `go-libfossil/xfer/card.go`, after line 33 (`CardXRow`), add:
+
+```go
+	CardXDelete                    // 24 — xdelete (table sync row deletion)
+```
+
+- [ ] **Step 4: Add XDeleteCard struct**
+
+In `go-libfossil/xfer/card_tablesync.go`, add after the XRowCard definition:
+
+```go
+// XDeleteCard marks a table sync row as deleted (tombstone).
+// Wire: xdelete TABLE PK_HASH MTIME SIZE\nJSON_PK_DATA
+type XDeleteCard struct {
+	Table  string
+	PKHash string
+	MTime  int64
+	PKData []byte // JSON-encoded PK column values
+}
+
+func (c *XDeleteCard) Type() CardType { return CardXDelete }
+```
+
+- [ ] **Step 5: Add encoder**
+
+In `go-libfossil/xfer/encode.go`, add after `encodeXRow` (after line 282), and add the case to `EncodeCard`:
+
+```go
+func encodeXDelete(w *bytes.Buffer, c *XDeleteCard) error {
+	fmt.Fprintf(w, "xdelete %s %s %d %d\n", c.Table, c.PKHash, c.MTime, len(c.PKData))
+	w.Write(c.PKData)
+	w.WriteByte('\n')
+	return nil
+}
+```
+
+Add the case to the `EncodeCard` switch (find the existing `*XRowCard` case and add after it):
+
+```go
+	case *XDeleteCard:
+		return encodeXDelete(w, c)
+```
+
+- [ ] **Step 6: Add decoder**
+
+In `go-libfossil/xfer/decode.go`, add `parseXDelete` after `parseXRow`:
+
+```go
+func parseXDelete(r *bufio.Reader, args []string) (Card, error) {
+	if len(args) != 4 {
+		return nil, fmt.Errorf("xfer: xdelete requires 4 args, got %d", len(args))
+	}
+	mtime, err := strconv.ParseInt(args[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete mtime: %w", err)
+	}
+	size, err := strconv.Atoi(args[3])
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete size: %w", err)
+	}
+	pkData, err := readPayloadWithTrailingNewline(r, size)
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete payload: %w", err)
+	}
+	return &XDeleteCard{Table: args[0], PKHash: args[1], MTime: mtime, PKData: pkData}, nil
+}
+```
+
+Add the case to the decode switch (after the `"xrow"` case, around line 143):
+
+```go
+	case "xdelete":
+		return parseXDelete(r, args)
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/xfer/ -run "TestXDeleteCard" -v`
+Expected: PASS
+
+Run fuzz briefly: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/xfer/ -fuzz FuzzParseXDelete -fuzztime 10s`
+Expected: No panics found.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/xfer/card.go go-libfossil/xfer/card_tablesync.go go-libfossil/xfer/card_tablesync_test.go go-libfossil/xfer/encode.go go-libfossil/xfer/decode.go
+git commit -m "feat(xfer): add XDeleteCard for table sync row deletion (CDG-168)
+
+Wire format: xdelete TABLE PK_HASH MTIME SIZE followed by JSON PK data.
+Includes round-trip test and fuzz test for the parser."
+```
+
+---
+
+### Task 6: Server-side xdelete handling
+
+**Files:**
+- Modify: `go-libfossil/sync/handler.go:290-326`
+- Modify: `go-libfossil/sync/handler_tablesync.go`
+- Modify: `go-libfossil/sync/handler_tablesync_test.go`
+
+- [ ] **Step 1: Write failing handler test**
+
+Add to `go-libfossil/sync/handler_tablesync_test.go`:
+
+```go
+func TestHandleXDelete(t *testing.T) {
+	// Setup: two repos, register table, seed a row on server.
+	serverRepo := createTestRepo(t)
+	clientRepo := createTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	repo.EnsureSyncSchema(serverRepo.DB())
+	repo.RegisterSyncedTable(serverRepo.DB(), "del_test", def, 1000)
+	repo.UpsertXRow(serverRepo.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+
+	// Client sends xdelete with newer mtime.
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "k1"})
+	msg := &xfer.Message{
+		Cards: []xfer.Card{
+			&xfer.PushCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.XDeleteCard{
+				Table:  "del_test",
+				PKHash: pkHash,
+				MTime:  2000,
+				PKData: []byte(`{"id":"k1"}`),
+			},
+		},
+	}
+
+	resp, err := HandleSync(serverRepo, msg)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Verify server tombstoned the row.
+	row, mtime, _ := repo.LookupXRow(serverRepo.DB(), "del_test", def, pkHash)
+	if row == nil {
+		t.Fatal("row should still exist as tombstone")
+	}
+	if !repo.IsTombstone(def, row) {
+		t.Error("row should be tombstone")
+	}
+	if mtime != 2000 {
+		t.Errorf("mtime = %d, want 2000", mtime)
+	}
+
+	// Verify no error cards in response.
+	for _, card := range resp.Cards {
+		if ec, ok := card.(*xfer.ErrorCard); ok {
+			t.Errorf("unexpected error card: %s", ec.Message)
+		}
+	}
+}
+
+func TestHandleXIGotEmitsXDeleteForTombstone(t *testing.T) {
+	serverRepo := createTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	repo.EnsureSyncSchema(serverRepo.DB())
+	repo.RegisterSyncedTable(serverRepo.DB(), "del_test", def, 1000)
+
+	// Seed a row then delete it (tombstone).
+	repo.UpsertXRow(serverRepo.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "k1"})
+	repo.DeleteXRowByPKHash(serverRepo.DB(), "del_test", def, pkHash, 2000)
+
+	// Client sends xigot for same row with older mtime.
+	msg := &xfer.Message{
+		Cards: []xfer.Card{
+			&xfer.PushCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.XIGotCard{Table: "del_test", PKHash: pkHash, MTime: 1000},
+		},
+	}
+
+	resp, err := HandleSync(serverRepo, msg)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Server should emit xdelete (not xrow) since its row is a tombstone.
+	var foundXDelete bool
+	for _, card := range resp.Cards {
+		if xd, ok := card.(*xfer.XDeleteCard); ok && xd.Table == "del_test" && xd.PKHash == pkHash {
+			foundXDelete = true
+			if xd.MTime != 2000 {
+				t.Errorf("xdelete mtime = %d, want 2000", xd.MTime)
+			}
+		}
+		if xr, ok := card.(*xfer.XRowCard); ok && xr.Table == "del_test" {
+			t.Error("server should emit xdelete, not xrow, for tombstone")
+		}
+	}
+	if !foundXDelete {
+		t.Error("server should emit xdelete for tombstone row")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/sync/ -run "TestHandleXDelete" -v`
+Expected: FAIL — no `handleXDelete` method, no `XDeleteCard` dispatch.
+
+- [ ] **Step 3: Add handleXDelete to handler_tablesync.go**
+
+Add to `go-libfossil/sync/handler_tablesync.go`:
+
+```go
+// handleXDelete processes a table sync deletion card.
+func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
+	if c == nil {
+		panic("handler.handleXDelete: c must not be nil")
+	}
+	if !h.pushOK {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("xdelete %s/%s rejected: no push card", c.Table, c.PKHash),
+		})
+		return nil
+	}
+
+	st, ok := h.syncedTables[c.Table]
+	if !ok {
+		return nil
+	}
+
+	deleted, err := repo.DeleteXRowByPKHash(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime)
+	if err != nil {
+		return fmt.Errorf("handler.handleXDelete: %w", err)
+	}
+
+	// If row didn't exist locally, insert tombstone using PKData.
+	if !deleted {
+		// Check if row exists at all.
+		existingRow, _, lookupErr := repo.LookupXRow(h.repo.DB(), c.Table, st.Def, c.PKHash)
+		if lookupErr != nil {
+			return fmt.Errorf("handler.handleXDelete: lookup: %w", lookupErr)
+		}
+		if existingRow == nil && len(c.PKData) > 0 {
+			// Insert tombstone from PKData.
+			var pkValues map[string]any
+			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+				h.resp = append(h.resp, &xfer.ErrorCard{
+					Message: fmt.Sprintf("xdelete %s/%s: bad PKData: %v", c.Table, c.PKHash, err),
+				})
+				return nil
+			}
+			if err := repo.UpsertXRow(h.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
+				return fmt.Errorf("handler.handleXDelete: insert tombstone: %w", err)
+			}
+		}
+		// If row exists with newer mtime, deleted==false is correct — no-op.
+	}
+
+	return nil
+}
+
+// sendXDelete sends a tombstone deletion card to the client.
+func (h *handler) sendXDelete(table string, st *SyncedTable, pkHash string, mtime int64, row map[string]any) {
+	// Build PKData from the row's PK values.
+	pkCols := extractPKColumns(st.Def)
+	pkValues := make(map[string]any)
+	for _, col := range pkCols {
+		pkValues[col] = row[col]
+	}
+	pkData, err := json.Marshal(pkValues)
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("xdelete %s/%s: marshal PKData: %v", table, pkHash, err),
+		})
+		return
+	}
+
+	h.resp = append(h.resp, &xfer.XDeleteCard{
+		Table:  table,
+		PKHash: pkHash,
+		MTime:  mtime,
+		PKData: pkData,
+	})
+}
+```
+
+- [ ] **Step 4: Update handleXIGot to emit xdelete for tombstones**
+
+In `go-libfossil/sync/handler_tablesync.go`, update `handleXIGot` (around line 149-152). Replace the existing `localMtime > c.MTime` block:
+
+```go
+	// Compare mtimes: if local is newer, push it (or send xdelete if tombstone).
+	if localMtime > c.MTime {
+		if repo.IsTombstone(st.Def, localRow) {
+			h.sendXDelete(c.Table, st, c.PKHash, localMtime, localRow)
+			return nil
+		}
+		return h.sendXRow(c.Table, st, c.PKHash)
+	}
+```
+
+- [ ] **Step 5: Add XDeleteCard dispatch to handleDataCard**
+
+In `go-libfossil/sync/handler.go`, add to the `handleDataCard` switch (after the `*xfer.XRowCard` case at line 323):
+
+```go
+	case *xfer.XDeleteCard:
+		return h.handleXDelete(c)
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/sync/ -run "TestHandleXDelete" -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/sync/handler.go go-libfossil/sync/handler_tablesync.go go-libfossil/sync/handler_tablesync_test.go
+git commit -m "feat(sync): server-side xdelete handling and tombstone-aware xigot
+
+handleXDelete applies mtime-wins deletion or inserts tombstone via PKData.
+handleXIGot emits xdelete (not xrow) when server has a tombstone."
+```
+
+---
+
+### Task 7: Client-side xdelete handling
+
+**Files:**
+- Modify: `go-libfossil/sync/client_tablesync.go`
+- Modify: `go-libfossil/sync/client.go:551`
+- Modify: `go-libfossil/sync/client_tablesync_test.go`
+
+- [ ] **Step 1: Write failing end-to-end test**
+
+Add to `go-libfossil/sync/client_tablesync_test.go`:
+
+```go
+func TestTableSyncDeletion(t *testing.T) {
+	// Setup: server has a tombstoned row, client has the live row.
+	serverRepo := createTestRepo(t)
+	clientRepo := createTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+
+	// Register on both.
+	repo.EnsureSyncSchema(serverRepo.DB())
+	repo.RegisterSyncedTable(serverRepo.DB(), "del_test", def, 1000)
+	repo.EnsureSyncSchema(clientRepo.DB())
+	repo.RegisterSyncedTable(clientRepo.DB(), "del_test", def, 1000)
+
+	// Both start with the row.
+	repo.UpsertXRow(serverRepo.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+	repo.UpsertXRow(clientRepo.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+
+	// Server deletes the row.
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "k1"})
+	repo.DeleteXRowByPKHash(serverRepo.DB(), "del_test", def, pkHash, 2000)
+
+	// Sync client → server.
+	transport := &MockTransport{Server: serverRepo}
+	result, err := Sync(clientRepo, SyncOpts{
+		Transport: transport,
+		Push:      true,
+		Pull:      true,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	_ = result
+
+	// Verify client's row is now a tombstone.
+	row, mtime, _ := repo.LookupXRow(clientRepo.DB(), "del_test", def, pkHash)
+	if row == nil {
+		t.Fatal("row should still exist as tombstone on client")
+	}
+	if !repo.IsTombstone(def, row) {
+		t.Error("client row should be tombstone after sync")
+	}
+	if mtime != 2000 {
+		t.Errorf("client mtime = %d, want 2000", mtime)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/sync/ -run TestTableSyncDeletion -v`
+Expected: FAIL — client doesn't process XDeleteCard.
+
+- [ ] **Step 3: Add handleXDeleteResponse to client_tablesync.go**
+
+Add to `go-libfossil/sync/client_tablesync.go`:
+
+```go
+// handleXDeleteResponse processes an xdelete from the server response.
+func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
+	if c == nil {
+		panic("session.handleXDeleteResponse: c must not be nil")
+	}
+
+	if err := repo.EnsureSyncSchema(s.repo.DB()); err != nil {
+		return fmt.Errorf("handleXDeleteResponse: ensure schema: %w", err)
+	}
+
+	def, err := s.getXTableDef(c.Table)
+	if err != nil {
+		return fmt.Errorf("handleXDeleteResponse: get table def %s: %w", c.Table, err)
+	}
+	if def == nil {
+		return nil
+	}
+
+	deleted, err := repo.DeleteXRowByPKHash(s.repo.DB(), c.Table, *def, c.PKHash, c.MTime)
+	if err != nil {
+		return fmt.Errorf("handleXDeleteResponse: delete %s/%s: %w", c.Table, c.PKHash, err)
+	}
+
+	// If row didn't exist locally, insert tombstone using PKData.
+	if !deleted {
+		existingRow, _, lookupErr := repo.LookupXRow(s.repo.DB(), c.Table, *def, c.PKHash)
+		if lookupErr != nil {
+			return fmt.Errorf("handleXDeleteResponse: lookup: %w", lookupErr)
+		}
+		if existingRow == nil && len(c.PKData) > 0 {
+			var pkValues map[string]any
+			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+				return fmt.Errorf("handleXDeleteResponse: bad PKData: %w", err)
+			}
+			if err := repo.UpsertXRow(s.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
+				return fmt.Errorf("handleXDeleteResponse: insert tombstone: %w", err)
+			}
+		}
+	}
+
+	// Remove from gimmes if present.
+	if gimmes, ok := s.xTableGimmes[c.Table]; ok {
+		delete(gimmes, c.PKHash)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Add XDeleteCard dispatch to processXTableCard**
+
+In `go-libfossil/sync/client_tablesync.go`, update `processXTableCard` (around line 150):
+
+```go
+func (s *session) processXTableCard(card xfer.Card) error {
+	switch c := card.(type) {
+	case *xfer.SchemaCard:
+		return s.handleXSchemaCard(c)
+	case *xfer.XIGotCard:
+		return s.handleXIGotResponse(c)
+	case *xfer.XGimmeCard:
+		return s.handleXGimmeResponse(c)
+	case *xfer.XRowCard:
+		return s.handleXRowResponse(c)
+	case *xfer.XDeleteCard:
+		return s.handleXDeleteResponse(c)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Add XDeleteCard to client.go dispatch**
+
+In `go-libfossil/sync/client.go`, update the type switch at line 551:
+
+```go
+		case *xfer.SchemaCard, *xfer.XIGotCard, *xfer.XGimmeCard, *xfer.XRowCard, *xfer.XDeleteCard:
+```
+
+- [ ] **Step 6: Update buildTableSendCards to emit xdelete for local tombstones**
+
+In `go-libfossil/sync/client_tablesync.go`, update `buildTableSendCards` (around line 121-143). Add tombstone detection before emitting xrow:
+
+```go
+	// Emit xrow or xdelete for rows queued to send.
+	if sends, ok := s.xTableToSend[info.Name]; ok {
+		pkColDefs := extractPKColumnDefs(info.Def)
+		for pkHash := range sends {
+			row, mtime, err := repo.LookupXRow(s.repo.DB(), info.Name, info.Def, pkHash)
+			if err != nil {
+				return nil, fmt.Errorf("buildTableSendCards: lookup %s/%s: %w", info.Name, pkHash, err)
+			}
+			if row == nil {
+				delete(sends, pkHash)
+				continue
+			}
+			if repo.IsTombstone(info.Def, row) {
+				// Send xdelete with PK data.
+				pkCols := extractPKColumns(info.Def)
+				pkValues := make(map[string]any)
+				for _, col := range pkCols {
+					pkValues[col] = row[col]
+				}
+				pkData, err := json.Marshal(pkValues)
+				if err != nil {
+					return nil, fmt.Errorf("buildTableSendCards: marshal pk %s/%s: %w", info.Name, pkHash, err)
+				}
+				cards = append(cards, &xfer.XDeleteCard{
+					Table:  info.Name,
+					PKHash: pkHash,
+					MTime:  mtime,
+					PKData: pkData,
+				})
+			} else {
+				rowJSON, err := json.Marshal(row)
+				if err != nil {
+					return nil, fmt.Errorf("buildTableSendCards: marshal row %s/%s: %w", info.Name, pkHash, err)
+				}
+				cards = append(cards, &xfer.XRowCard{
+					Table:   info.Name,
+					PKHash:  pkHash,
+					MTime:   mtime,
+					Content: rowJSON,
+				})
+			}
+			delete(sends, pkHash)
+		}
+	}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/sync/ -run "TestTableSyncDeletion|TestTableSyncEndToEnd|TestTableSyncSchemaDeployment" -v`
+Expected: All PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add go-libfossil/sync/client.go go-libfossil/sync/client_tablesync.go go-libfossil/sync/client_tablesync_test.go
+git commit -m "feat(sync): client-side xdelete handling and tombstone-aware sends
+
+Client processes incoming xdelete cards with mtime-wins. buildTableSendCards
+emits xdelete (not xrow) for tombstoned rows."
+```
+
+---
+
+### Task 8: DST tests — multi-peer deletion, resurrection, integer PKs
+
+**Files:**
+- Modify: `dst/tablesync_test.go`
+
+- [ ] **Step 1: Write multi-peer deletion test**
+
+Add to `dst/tablesync_test.go`:
+
+```go
+func TestTableSync_Deletion_Convergence(t *testing.T) {
+	sim, masterRepo, mf := newTableSyncSim(t, 42, 3, false)
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed a row on all peers via master.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "d1", "hostname": "alpha", "status": "online",
+	}, 1000)
+
+	// Sync so all leaves have the row.
+	for i := 0; i < 3; i++ {
+		sim.RunRound(t, mf)
+	}
+	for _, leafID := range sim.LeafIDs() {
+		assertRowCount(t, sim.Leaf(leafID).Repo(), leafID, "devices", def, 1)
+	}
+
+	// Delete on master with newer mtime.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "d1"})
+	deleted, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000)
+	if err != nil || !deleted {
+		t.Fatalf("master delete: deleted=%v err=%v", deleted, err)
+	}
+
+	// Sync until convergence.
+	for i := 0; i < 5; i++ {
+		sim.RunRound(t, mf)
+	}
+
+	// All leaves should have a tombstone.
+	for _, leafID := range sim.LeafIDs() {
+		row, mtime, _ := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if row == nil {
+			t.Errorf("%s: row should exist as tombstone", leafID)
+			continue
+		}
+		if !repo.IsTombstone(def, row) {
+			t.Errorf("%s: row should be tombstone", leafID)
+		}
+		if mtime != 2000 {
+			t.Errorf("%s: mtime=%d, want 2000", leafID, mtime)
+		}
+	}
+}
+
+func TestTableSync_Deletion_Resurrection(t *testing.T) {
+	sim, masterRepo, mf := newTableSyncSim(t, 99, 2, false)
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed and sync.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "d1", "hostname": "alpha", "status": "online",
+	}, 1000)
+	for i := 0; i < 3; i++ {
+		sim.RunRound(t, mf)
+	}
+
+	// Delete on master.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "d1"})
+	repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000)
+
+	// Sync deletion.
+	for i := 0; i < 3; i++ {
+		sim.RunRound(t, mf)
+	}
+
+	// Resurrect on a leaf with newer mtime.
+	leaf0 := sim.Leaf(sim.LeafIDs()[0]).Repo()
+	upsertRow(t, leaf0, "devices", map[string]any{
+		"device_id": "d1", "hostname": "beta", "status": "active",
+	}, 3000)
+
+	// Sync resurrection.
+	for i := 0; i < 5; i++ {
+		sim.RunRound(t, mf)
+	}
+
+	// All peers should have the live row with mtime 3000.
+	for _, leafID := range sim.LeafIDs() {
+		row, mtime, _ := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if row == nil {
+			t.Errorf("%s: row missing after resurrection", leafID)
+			continue
+		}
+		if repo.IsTombstone(def, row) {
+			t.Errorf("%s: row should be live after resurrection", leafID)
+		}
+		if mtime != 3000 {
+			t.Errorf("%s: mtime=%d, want 3000", leafID, mtime)
+		}
+	}
+	// Master too.
+	row, mtime, _ := repo.LookupXRow(masterRepo.DB(), "devices", def, pkHash)
+	if row == nil || repo.IsTombstone(def, row) || mtime != 3000 {
+		t.Errorf("master: row=%v tombstone=%v mtime=%d", row != nil, row != nil && repo.IsTombstone(def, row), mtime)
+	}
+}
+
+func TestTableSync_IntegerPK_Convergence(t *testing.T) {
+	sim, masterRepo, mf := newTableSyncSim(t, 77, 2, false)
+	def := repo.TableDef{
+		Columns: []repo.ColumnDef{
+			{Name: "seq", Type: "integer", PK: true},
+			{Name: "payload", Type: "text"},
+		},
+		Conflict: "mtime-wins",
+	}
+	registerTableAll(t, sim, masterRepo, "events", def, 1000)
+
+	// Seed rows with large integer PKs (>2^53).
+	bigPK := int64(1<<53 + 1)
+	upsertRow(t, masterRepo, "events", map[string]any{
+		"seq": bigPK, "payload": "event-data",
+	}, 1000)
+
+	// Sync.
+	for i := 0; i < 3; i++ {
+		sim.RunRound(t, mf)
+	}
+
+	// Verify all peers have matching catalog hashes.
+	masterHash, _ := repo.CatalogHash(masterRepo.DB(), "events", def)
+	for _, leafID := range sim.LeafIDs() {
+		leafHash, _ := repo.CatalogHash(sim.Leaf(leafID).Repo().DB(), "events", def)
+		if leafHash != masterHash {
+			t.Errorf("%s: catalog hash %q != master %q", leafID, leafHash, masterHash)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run DST tests**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./dst/ -run "TestTableSync_Deletion|TestTableSync_IntegerPK" -v -count=1`
+Expected: All PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./go-libfossil/... ./dst/ -count=1 2>&1 | tail -20`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/dmestas/projects/EdgeSync-tablesync-deletion
+git add dst/tablesync_test.go
+git commit -m "test(dst): add deletion convergence, resurrection, and integer PK tests
+
+Multi-peer deletion propagation, delete-then-resurrect via newer mtime,
+and large integer PK (>2^53) convergence across peers."
+```
+
+---
+
+### Task 9: Final validation — run all tests and sim
+
+- [ ] **Step 1: Run full test suite including sim**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && make test`
+Expected: All pass.
+
+- [ ] **Step 2: Run existing DST table sync tests to check for regressions**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && go test ./dst/ -run TestTableSync -v -count=1 2>&1 | tail -40`
+Expected: All existing table sync DST tests pass alongside new ones.
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd /Users/dmestas/projects/EdgeSync-tablesync-deletion && make build`
+Expected: Clean build of edgesync, leaf, bridge binaries.

--- a/docs/superpowers/specs/2026-04-02-table-sync-deletion-and-pk-hash-design.md
+++ b/docs/superpowers/specs/2026-04-02-table-sync-deletion-and-pk-hash-design.md
@@ -1,0 +1,161 @@
+# Table Sync: Row Deletion & PK Hash Fix
+
+**Date**: 2026-04-02  
+**Tickets**: CDG-168 (xdelete card), CDG-171 (PK hash coercion)  
+**Branch**: `feature/table-sync-deletion`
+
+## Problem
+
+Two related issues in the remote schema sync feature:
+
+1. **No deletion support** (CDG-168): Once a row is synced to extension tables (`x_<name>`), it persists forever across all peers. Tables are effectively append-only. This limits use cases like feature flags (can't remove a flag), peer registry (can't deregister a peer), etc.
+
+2. **PK hash type coercion risk** (CDG-171): `PKHash()` uses `json.Marshal(pkValues)` to serialize primary key values before hashing. JSON round-trips coerce `int64` to `float64` via `json.Unmarshal` into `map[string]any`. For values >2^53, `json.Marshal` of `float64` loses precision, producing different hashes on sender vs receiver.
+
+## Design Decisions
+
+### Deletion: UV-style in-place tombstone
+
+Following Fossil's established pattern for mutable synced data (UV files use `hash=NULL`, attachments use `src=NULL`), deleted rows remain in `x_<table>` with all non-PK, non-mtime value columns set to NULL.
+
+**Convention**: A row where all value columns are NULL is a tombstone. This is a documented schema contract. Extension table schemas should have at least one value column that is meaningfully non-NULL for live rows.
+
+**Why not a `_deleted` column**: Defensive engineering for a scenario (all-NULL as legitimate row state) that won't materialize in practice. Every current and likely future table has columns that are meaningfully non-NULL. Follow Fossil's precedent over speculative safety.
+
+**Why not a separate `_sync_tombstones` table**: Fossil uses separate tracking tables only for admin/policy data (shun table). Mutable synced data uses in-place tombstones. Extension tables are mutable synced data.
+
+### PK hash: Type-aware canonical normalization
+
+Following Fossil's philosophy of canonical string representation at the storage boundary (ticket fields stored as TEXT regardless of semantic type), `PKHash` normalizes values to canonical strings based on declared column type before hashing. No JSON dependency in the hash path.
+
+**Why not `json.Decoder.UseNumber()`**: Fixes the symptom (JSON coercion) but leaves `PKHash` fragile — still depends on `json.Marshal` rendering `int64` and `json.Number` identically. Type-aware normalization makes the hash self-contained and deterministic by construction.
+
+## PK Hash Changes (CDG-171)
+
+### New `PKHash` signature
+
+```go
+// Before:
+func PKHash(pkValues map[string]any) string
+
+// After:
+func PKHash(pkCols []ColumnDef, pkValues map[string]any) string
+```
+
+### Canonical normalization rules
+
+| Column type | Normalization | Example |
+|-------------|--------------|---------|
+| `"integer"` | `strconv.FormatInt(toInt64(v), 10)` | `42` → `"42"`, `float64(42)` → `"42"` |
+| `"real"` | `strconv.FormatFloat(toFloat64(v), 'f', -1, 64)` | `3.14` → `"3.14"` |
+| `"text"` | `v.(string)` | `"hello"` → `"hello"` |
+| `"blob"` | `hex.EncodeToString(v.([]byte))` | `[]byte{0xDE,0xAD}` → `"dead"` |
+
+### Hash computation
+
+1. Sort PK column names lexicographically
+2. For each column, normalize the value to canonical string
+3. Concatenate as `name=normalizedValue` pairs joined by `\x00` (null byte separator)
+4. SHA1 the result
+
+### Callers to update
+
+All callers already have access to `TableDef`:
+- `client_tablesync.go`: `buildTableXIGotCards`, `extractPKColumns`
+- `handler_tablesync.go`: `handleXRow`, `handleXIGot`, `sendXRow`
+- `repo/tablesync.go`: `CatalogHash`
+
+## xdelete Card (CDG-168)
+
+### Wire protocol
+
+New card type `CardXDelete = 24` in `card.go`.
+
+```go
+type XDeleteCard struct {
+    Table   string // table name (without x_ prefix)
+    PKHash  string // SHA1 of primary key values
+    MTime   int64  // deletion timestamp
+    PKData  []byte // JSON-encoded PK column values
+}
+```
+
+Wire format: `xdelete TABLE PK_HASH MTIME SIZE\n<SIZE bytes of JSON PK data>\n` — same payload pattern as xrow, but the payload only contains PK column values (not all columns). The PK data is needed so receivers that have never seen the row can insert a tombstone, preventing them from requesting it via xgimme in future rounds.
+
+### Tombstone storage
+
+`DeleteXRow(d *db.DB, table string, def TableDef, pkHash string, mtime int64) error`:
+- If row exists with lower mtime: UPDATE all non-PK, non-mtime value columns to NULL, set mtime to deletion timestamp
+- If row exists with higher mtime: no-op (local is newer)
+- If row doesn't exist: INSERT tombstone using PK values from `PKData`, all value columns NULL, mtime set. This prevents the peer from requesting the row via xgimme in future sync rounds.
+
+### Conflict resolution
+
+Extends existing `resolveXRowConflict()`:
+
+| Incoming | Local state | Local mtime vs incoming | Result |
+|----------|------------|------------------------|--------|
+| xdelete | live row | incoming newer | apply tombstone |
+| xdelete | live row | incoming older | ignore |
+| xdelete | tombstone | incoming newer | update mtime |
+| xdelete | tombstone | incoming older | ignore |
+| xdelete | missing | — | insert tombstone (using PKData) |
+| xrow | tombstone | incoming newer | resurrect (overwrite NULLs) |
+| xrow | tombstone | incoming older | ignore |
+| mtime tie | — | equal | incoming wins (existing behavior) |
+
+### Catalog hash
+
+Exclude tombstone rows from catalog hash computation. A tombstone is detected by checking that all value columns (non-PK, non-mtime, non-`_owner`) are NULL.
+
+### Sync flow
+
+**Client-side**:
+- `buildTableXIGotCards()`: emits xigot for all rows including tombstones — remote needs to know about deletions
+- New `buildTableXDeleteCards()`: emits xdelete for locally tombstoned rows queued in `xTableToSend`
+- Receiving xrow for a tombstoned row resurrects it if mtime is newer (handled by existing conflict resolution)
+
+**Server-side**:
+- New `handleXDelete()` in `handleDataCard()` dispatch: looks up local row, applies mtime-wins, calls `DeleteXRow()`
+- `handleXIGot()`: when server has tombstone and client's mtime is older, server emits xdelete (not xrow)
+- `emitXIGotsForTable()`: tombstones naturally included since they remain in the table
+
+**Convergence**: Same round-based convergence as today. Deletions propagate because tombstone rows participate in xigot exchange, and xdelete cards flow when a peer discovers the other hasn't deleted yet.
+
+## Testing
+
+### CDG-171 — PK hash tests
+
+- **Unit** (`repo/tablesync_test.go`):
+  - `PKHash` produces identical hashes for int64 vs float64 inputs of same logical value
+  - Large integers (>2^53) that would diverge under old `json.Marshal` approach
+  - Composite PK with mixed types (text + integer)
+
+### CDG-168 — xdelete tests
+
+- **xfer round-trip** (`xfer/`):
+  - Encode/decode `XDeleteCard`, verify fidelity
+  - Fuzz test: `parseXDelete` with garbage input (new network-facing parser)
+
+- **Repo layer** (`repo/tablesync_test.go`):
+  - `DeleteXRow` tombstones correctly (value cols NULL, mtime updated)
+  - `DeleteXRow` with lower mtime than existing row is rejected
+  - Resurrection: `UpsertXRow` overwrites tombstone when mtime is newer
+  - Catalog hash excludes tombstones
+
+- **Handler** (`sync/handler_tablesync_test.go`):
+  - xdelete card processed correctly (mtime-wins)
+  - Server emits xdelete when it has tombstone and client's xigot is older
+  - Conflict: xdelete vs xrow with competing mtimes
+
+- **DST** (`dst/tablesync_test.go`):
+  - Multi-peer: peer A deletes row, peers B and C converge to tombstone
+  - Delete-then-resurrect: peer A deletes, peer B updates with newer mtime, all converge to live row
+  - Integer PK convergence: peers with large integer PKs reach identical catalog hashes
+
+## Non-goals
+
+- Tombstone garbage collection / TTL expiry
+- Schema evolution (DROP COLUMN, RENAME)
+- Bloom filter / Merkle optimization for large tables
+- `_deleted` column or separate tombstone table

--- a/dst/invariants.go
+++ b/dst/invariants.go
@@ -367,9 +367,11 @@ func CheckTableSyncIntegrity(nodeID string, r *repo.Repo) error {
 		}
 		// Extract PK columns.
 		var pkCols []string
+		var pkColDefs []repo.ColumnDef
 		for _, col := range tbl.Def.Columns {
 			if col.PK {
 				pkCols = append(pkCols, col.Name)
+				pkColDefs = append(pkColDefs, col)
 			}
 		}
 		for i, row := range rows {
@@ -378,7 +380,7 @@ func CheckTableSyncIntegrity(nodeID string, r *repo.Repo) error {
 			for _, col := range pkCols {
 				pk[col] = row[col]
 			}
-			h := repo.PKHash(pk)
+			h := repo.PKHash(pkColDefs, pk)
 			if h == "" {
 				return &InvariantError{Invariant: "tablesync-integrity", NodeID: nodeID,
 					Detail: fmt.Sprintf("table %s row %d: empty PK hash", tbl.Name, i)}

--- a/dst/invariants.go
+++ b/dst/invariants.go
@@ -3,6 +3,7 @@ package dst
 import (
 	"fmt"
 	"sort"
+	"testing"
 
 	libfossil "github.com/dmestas/edgesync/go-libfossil"
 	"github.com/dmestas/edgesync/go-libfossil/blob"
@@ -457,6 +458,68 @@ func CheckTableSyncConvergence(repos map[string]*repo.Repo) error {
 		}
 	}
 	return nil
+}
+
+// --- Tombstone convergence invariant ---
+
+// CheckTombstoneConvergence verifies that all nodes agree on which rows are
+// tombstones for each synced table. Two nodes may have different catalog hashes
+// during convergence, but once converged, their tombstone sets must match.
+func (s *Simulator) CheckTombstoneConvergence(t *testing.T, masterRepo *repo.Repo, tableName string, def repo.TableDef) {
+	t.Helper()
+
+	// Collect tombstone pk_hashes from master.
+	masterTombstones := collectTombstones(t, masterRepo, tableName, def)
+
+	// Compare each leaf's tombstones to master.
+	for _, leafID := range s.LeafIDs() {
+		leafRepo := s.Leaf(leafID).Repo()
+		leafTombstones := collectTombstones(t, leafRepo, tableName, def)
+
+		// Every tombstone on master should exist on leaf.
+		for pkHash := range masterTombstones {
+			if !leafTombstones[pkHash] {
+				t.Errorf("tombstone convergence: %s missing tombstone pk=%s (master has it)", leafID, pkHash)
+			}
+		}
+		// Every tombstone on leaf should exist on master.
+		for pkHash := range leafTombstones {
+			if !masterTombstones[pkHash] {
+				t.Errorf("tombstone convergence: %s has extra tombstone pk=%s (master doesn't)", leafID, pkHash)
+			}
+		}
+	}
+}
+
+// collectTombstones returns the set of PK hashes for all tombstone rows in a table.
+func collectTombstones(t *testing.T, r *repo.Repo, tableName string, def repo.TableDef) map[string]bool {
+	t.Helper()
+	rows, _, err := repo.ListXRows(r.DB(), tableName, def)
+	if err != nil {
+		t.Fatalf("collectTombstones %s: %v", tableName, err)
+	}
+
+	var pkColDefs []repo.ColumnDef
+	var pkNames []string
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+			pkNames = append(pkNames, col.Name)
+		}
+	}
+
+	tombstones := make(map[string]bool)
+	for _, row := range rows {
+		if repo.IsTombstone(def, row) {
+			pkValues := make(map[string]any)
+			for _, name := range pkNames {
+				pkValues[name] = row[name]
+			}
+			pkHash := repo.PKHash(pkColDefs, pkValues)
+			tombstones[pkHash] = true
+		}
+	}
+	return tombstones
 }
 
 // --- Helpers ---

--- a/dst/tablesync_test.go
+++ b/dst/tablesync_test.go
@@ -1087,3 +1087,144 @@ func TestTS_StressTest1000Rows(t *testing.T) {
 	assertBoundedProgress(t, sim, table, def, 1)
 	logRowCounts(t, sim, table, def)
 }
+
+// =============================================================================
+// Deletion, Resurrection, and Integer PK tests
+// =============================================================================
+
+// TestTableSync_Deletion_Convergence: peer A deletes, peers B and C converge to tombstone.
+func TestTableSync_Deletion_Convergence(t *testing.T) {
+	sim, masterRepo, _ := newTableSyncSim(t, 42, 3, false)
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed a row on master.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "d1", "hostname": "alpha", "status": "online",
+	}, 1000)
+
+	// Sync so all leaves have the row.
+	if err := sim.Run(30); err != nil {
+		t.Fatalf("Run (seed): %v", err)
+	}
+	for _, leafID := range sim.LeafIDs() {
+		assertRowCount(t, sim.Leaf(leafID).Repo(), string(leafID), "devices", def, 1)
+	}
+
+	// Delete on master.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "d1"})
+	deleted, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000)
+	if err != nil || !deleted {
+		t.Fatalf("master delete: deleted=%v err=%v", deleted, err)
+	}
+
+	// Sync until convergence.
+	if err := sim.Run(50); err != nil {
+		t.Fatalf("Run (delete): %v", err)
+	}
+
+	// All leaves should have a tombstone.
+	for _, leafID := range sim.LeafIDs() {
+		row, mtime, _ := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if row == nil {
+			t.Errorf("%s: row should exist as tombstone", leafID)
+			continue
+		}
+		if !repo.IsTombstone(def, row) {
+			t.Errorf("%s: row should be tombstone", leafID)
+		}
+		if mtime != 2000 {
+			t.Errorf("%s: mtime=%d, want 2000", leafID, mtime)
+		}
+	}
+}
+
+// TestTableSync_Deletion_Resurrection: delete then resurrect with newer mtime — all converge to live row.
+func TestTableSync_Deletion_Resurrection(t *testing.T) {
+	sim, masterRepo, _ := newTableSyncSim(t, 99, 2, false)
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed and sync.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "d1", "hostname": "alpha", "status": "online",
+	}, 1000)
+	if err := sim.Run(30); err != nil {
+		t.Fatalf("Run (seed): %v", err)
+	}
+
+	// Delete on master.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "d1"})
+	repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000)
+
+	// Sync deletion.
+	if err := sim.Run(30); err != nil {
+		t.Fatalf("Run (delete): %v", err)
+	}
+
+	// Resurrect on a leaf with newer mtime.
+	leaf0 := sim.Leaf(sim.LeafIDs()[0]).Repo()
+	upsertRow(t, leaf0, "devices", map[string]any{
+		"device_id": "d1", "hostname": "beta", "status": "active",
+	}, 3000)
+
+	// Sync resurrection.
+	if err := sim.Run(50); err != nil {
+		t.Fatalf("Run (resurrect): %v", err)
+	}
+
+	// All peers should have the live row with mtime 3000.
+	for _, leafID := range sim.LeafIDs() {
+		row, mtime, _ := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if row == nil {
+			t.Errorf("%s: row missing after resurrection", leafID)
+			continue
+		}
+		if repo.IsTombstone(def, row) {
+			t.Errorf("%s: row should be live after resurrection", leafID)
+		}
+		if mtime != 3000 {
+			t.Errorf("%s: mtime=%d, want 3000", leafID, mtime)
+		}
+	}
+	// Master too.
+	row, mtime, _ := repo.LookupXRow(masterRepo.DB(), "devices", def, pkHash)
+	if row == nil || repo.IsTombstone(def, row) || mtime != 3000 {
+		t.Errorf("master: row=%v tombstone=%v mtime=%d", row != nil, row != nil && repo.IsTombstone(def, row), mtime)
+	}
+}
+
+// TestTableSync_IntegerPK_Convergence: large integer PK (>2^53) convergence across peers.
+func TestTableSync_IntegerPK_Convergence(t *testing.T) {
+	sim, masterRepo, _ := newTableSyncSim(t, 77, 2, false)
+	def := repo.TableDef{
+		Columns: []repo.ColumnDef{
+			{Name: "seq", Type: "integer", PK: true},
+			{Name: "payload", Type: "text"},
+		},
+		Conflict: "mtime-wins",
+	}
+	registerTableAll(t, sim, masterRepo, "events", def, 1000)
+
+	// Seed row with large integer PK (>2^53).
+	bigPK := int64(1<<53 + 1)
+	upsertRow(t, masterRepo, "events", map[string]any{
+		"seq": bigPK, "payload": "event-data",
+	}, 1000)
+
+	// Sync.
+	if err := sim.Run(100); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify all peers have matching catalog hashes.
+	masterHash, _ := repo.CatalogHash(masterRepo.DB(), "events", def)
+	for _, leafID := range sim.LeafIDs() {
+		leafHash, _ := repo.CatalogHash(sim.Leaf(leafID).Repo().DB(), "events", def)
+		if leafHash != masterHash {
+			t.Errorf("%s: catalog hash %q != master %q", leafID, leafHash, masterHash)
+		}
+	}
+}

--- a/dst/tablesync_test.go
+++ b/dst/tablesync_test.go
@@ -100,7 +100,13 @@ func assertRowCount(t *testing.T, r *repo.Repo, label, table string, def repo.Ta
 // assertRowValue checks a specific row's column value by PK lookup.
 func assertRowValue(t *testing.T, r *repo.Repo, label, table string, def repo.TableDef, pk map[string]any, col, want string) {
 	t.Helper()
-	pkHash := repo.PKHash(pk)
+	var pkColDefs []repo.ColumnDef
+	for _, c := range def.Columns {
+		if c.PK {
+			pkColDefs = append(pkColDefs, c)
+		}
+	}
+	pkHash := repo.PKHash(pkColDefs, pk)
 	row, _, err := repo.LookupXRow(r.DB(), table, def, pkHash)
 	if err != nil {
 		t.Fatalf("LookupXRow %s: %v", label, err)

--- a/dst/tablesync_test.go
+++ b/dst/tablesync_test.go
@@ -1055,6 +1055,221 @@ func TestTS_MixedWorkload(t *testing.T) {
 	logRowCounts(t, sim, table, def)
 }
 
+// =============================================================================
+// Adversarial deletion tests (buggify=true) — seeds 307-309
+// =============================================================================
+
+// TestTS_Adversarial_DeletionConvergence: 5 rows seeded, 3 deleted on master,
+// must converge under BUGGIFY fault injection (10% drop rate).
+func TestTS_Adversarial_DeletionConvergence(t *testing.T) {
+	seed := seedFor(307)
+	sim, masterRepo, _ := newTableSyncSim(t, seed, 3, true)
+	sim.Network().SetDropRate(0.10)
+
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed 5 rows on master.
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("d%d", i)
+		upsertRow(t, masterRepo, "devices", map[string]any{
+			"device_id": id,
+			"hostname":  fmt.Sprintf("host-%d", i),
+			"status":    "online",
+		}, 1000)
+	}
+
+	// Sync to distribute rows (extra steps for buggify).
+	if err := sim.Run(stepsFor(300)); err != nil {
+		t.Fatalf("Run (distribute): %v", err)
+	}
+
+	// Delete 3 of the 5 rows on master.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	for i := 0; i < 3; i++ {
+		id := fmt.Sprintf("d%d", i)
+		pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": id})
+		if _, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000); err != nil {
+			t.Fatalf("DeleteXRowByPKHash d%d: %v", i, err)
+		}
+	}
+
+	// Many rounds to converge under faults.
+	if err := sim.Run(stepsFor(500)); err != nil {
+		t.Fatalf("Run (converge): %v", err)
+	}
+
+	t.Logf("[adversarial-deletion] seed=%d steps=%d syncs=%d errors=%d",
+		seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	if err := sim.CheckSafety(); err != nil {
+		t.Fatalf("Safety: %v", err)
+	}
+
+	// All leaves should have 3 tombstones and 2 live rows.
+	for _, leafID := range sim.LeafIDs() {
+		leafRepo := sim.Leaf(leafID).Repo()
+		rows, _, err := repo.ListXRows(leafRepo.DB(), "devices", def)
+		if err != nil {
+			t.Fatalf("ListXRows %s: %v", leafID, err)
+		}
+		tombstones := 0
+		live := 0
+		for _, row := range rows {
+			if repo.IsTombstone(def, row) {
+				tombstones++
+			} else {
+				live++
+			}
+		}
+		if tombstones != 3 {
+			t.Errorf("%s: tombstones=%d, want 3", leafID, tombstones)
+		}
+		if live != 2 {
+			t.Errorf("%s: live=%d, want 2", leafID, live)
+		}
+	}
+
+	// Catalog hashes should match (tombstones excluded from catalog).
+	masterHash, err := repo.CatalogHash(masterRepo.DB(), "devices", def)
+	if err != nil {
+		t.Fatalf("CatalogHash master: %v", err)
+	}
+	for _, leafID := range sim.LeafIDs() {
+		leafHash, err := repo.CatalogHash(sim.Leaf(leafID).Repo().DB(), "devices", def)
+		if err != nil {
+			t.Fatalf("CatalogHash %s: %v", leafID, err)
+		}
+		if leafHash != masterHash {
+			t.Errorf("%s: catalog hash %q != master %q", leafID, leafHash, masterHash)
+		}
+	}
+}
+
+// TestTS_Adversarial_DeleteUpdateRace: concurrent delete (mtime=2000) vs update
+// (mtime=3000) on the same PK under BUGGIFY. mtime=3000 update must win.
+func TestTS_Adversarial_DeleteUpdateRace(t *testing.T) {
+	seed := seedFor(308)
+	sim, masterRepo, _ := newTableSyncSim(t, seed, 2, true)
+	sim.Network().SetDropRate(0.10)
+
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed row and sync so both leaves have it.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "contested",
+		"hostname":  "original",
+		"status":    "online",
+	}, 1000)
+	if err := sim.Run(stepsFor(300)); err != nil {
+		t.Fatalf("Run (seed): %v", err)
+	}
+
+	// Concurrent: master deletes at mtime=2000, leaf-0 updates at mtime=3000.
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "contested"})
+	if _, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000); err != nil {
+		t.Fatalf("DeleteXRowByPKHash: %v", err)
+	}
+	leaf0 := sim.Leaf(sim.LeafIDs()[0]).Repo()
+	upsertRow(t, leaf0, "devices", map[string]any{
+		"device_id": "contested",
+		"hostname":  "updated",
+		"status":    "active",
+	}, 3000)
+
+	// Many rounds — mtime=3000 update should win (resurrection beats older delete).
+	if err := sim.Run(stepsFor(500)); err != nil {
+		t.Fatalf("Run (race): %v", err)
+	}
+
+	t.Logf("[adversarial-race] seed=%d steps=%d syncs=%d errors=%d",
+		seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	if err := sim.CheckSafety(); err != nil {
+		t.Fatalf("Safety: %v", err)
+	}
+
+	// All leaves should have the live row at mtime=3000.
+	for _, leafID := range sim.LeafIDs() {
+		row, mtime, err := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if err != nil {
+			t.Fatalf("LookupXRow %s: %v", leafID, err)
+		}
+		if row == nil {
+			t.Errorf("%s: row missing", leafID)
+			continue
+		}
+		if repo.IsTombstone(def, row) {
+			t.Errorf("%s: should be live (mtime=3000 wins over delete at mtime=2000)", leafID)
+		}
+		if mtime != 3000 {
+			t.Errorf("%s: mtime=%d, want 3000", leafID, mtime)
+		}
+	}
+	// Master too.
+	row, mtime, err := repo.LookupXRow(masterRepo.DB(), "devices", def, pkHash)
+	if err != nil {
+		t.Fatalf("LookupXRow master: %v", err)
+	}
+	if row == nil || repo.IsTombstone(def, row) || mtime != 3000 {
+		t.Errorf("master: row=%v tombstone=%v mtime=%d, want live row at mtime=3000",
+			row != nil, row != nil && repo.IsTombstone(def, row), mtime)
+	}
+}
+
+// TestTS_Adversarial_DeleteUnseenRow: row is inserted then immediately deleted on
+// master before any sync. Leaves never see the live row; they must receive the
+// tombstone via the PKData path and converge under BUGGIFY.
+func TestTS_Adversarial_DeleteUnseenRow(t *testing.T) {
+	seed := seedFor(309)
+	sim, masterRepo, _ := newTableSyncSim(t, seed, 2, true)
+	sim.Network().SetDropRate(0.10)
+
+	def := deviceTableDef()
+	registerTableAll(t, sim, masterRepo, "devices", def, 1000)
+
+	// Seed row and immediately delete on master — leaves never see the live row.
+	upsertRow(t, masterRepo, "devices", map[string]any{
+		"device_id": "ephemeral",
+		"hostname":  "ghost",
+		"status":    "gone",
+	}, 1000)
+	pkColDefs := []repo.ColumnDef{{Name: "device_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"device_id": "ephemeral"})
+	if _, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "devices", def, pkHash, 2000); err != nil {
+		t.Fatalf("DeleteXRowByPKHash: %v", err)
+	}
+
+	// Sync — leaves should receive tombstone via PKData (never had the live row).
+	if err := sim.Run(stepsFor(400)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	t.Logf("[adversarial-unseen] seed=%d steps=%d syncs=%d errors=%d",
+		seed, sim.Steps, sim.TotalSyncs, sim.TotalErrors)
+
+	if err := sim.CheckSafety(); err != nil {
+		t.Fatalf("Safety: %v", err)
+	}
+
+	// All leaves should have a tombstone for "ephemeral".
+	for _, leafID := range sim.LeafIDs() {
+		row, _, err := repo.LookupXRow(sim.Leaf(leafID).Repo().DB(), "devices", def, pkHash)
+		if err != nil {
+			t.Fatalf("LookupXRow %s: %v", leafID, err)
+		}
+		if row == nil {
+			t.Errorf("%s: should have tombstone for unseen row", leafID)
+			continue
+		}
+		if !repo.IsTombstone(def, row) {
+			t.Errorf("%s: should be tombstone, got live row", leafID)
+		}
+	}
+}
+
 // TestTS_StressTest1000Rows: 1000 rows on master, 2 peers, verify no crash.
 // The goal is survival under load — not convergence.
 func TestTS_StressTest1000Rows(t *testing.T) {

--- a/dst/tablesync_test.go
+++ b/dst/tablesync_test.go
@@ -1443,3 +1443,69 @@ func TestTableSync_IntegerPK_Convergence(t *testing.T) {
 		}
 	}
 }
+
+// TestTableSync_Deletion_CompositePK: delete one row from a composite PK table,
+// verify only that row becomes a tombstone while the other row remains live.
+func TestTableSync_Deletion_CompositePK(t *testing.T) {
+	sim, masterRepo, _ := newTableSyncSim(t, 55, 2, false)
+	def := repo.TableDef{
+		Columns: []repo.ColumnDef{
+			{Name: "org", Type: "text", PK: true},
+			{Name: "user_id", Type: "text", PK: true},
+			{Name: "role", Type: "text"},
+		},
+		Conflict: "mtime-wins",
+	}
+	registerTableAll(t, sim, masterRepo, "members", def, 1000)
+
+	// Seed two rows with same first PK component but different second.
+	upsertRow(t, masterRepo, "members", map[string]any{
+		"org": "acme", "user_id": "alice", "role": "admin",
+	}, 1000)
+	upsertRow(t, masterRepo, "members", map[string]any{
+		"org": "acme", "user_id": "bob", "role": "member",
+	}, 1000)
+
+	// Sync to distribute.
+	if err := sim.Run(50); err != nil {
+		t.Fatalf("Run (seed): %v", err)
+	}
+
+	// Delete only alice, not bob.
+	pkColDefs := []repo.ColumnDef{
+		{Name: "org", Type: "text", PK: true},
+		{Name: "user_id", Type: "text", PK: true},
+	}
+	aliceHash := repo.PKHash(pkColDefs, map[string]any{"org": "acme", "user_id": "alice"})
+	if _, err := repo.DeleteXRowByPKHash(masterRepo.DB(), "members", def, aliceHash, 2000); err != nil {
+		t.Fatalf("DeleteXRowByPKHash alice: %v", err)
+	}
+
+	// Sync deletion.
+	if err := sim.Run(50); err != nil {
+		t.Fatalf("Run (delete): %v", err)
+	}
+
+	// All peers: alice=tombstone, bob=live.
+	bobHash := repo.PKHash(pkColDefs, map[string]any{"org": "acme", "user_id": "bob"})
+	for _, leafID := range sim.LeafIDs() {
+		db := sim.Leaf(leafID).Repo().DB()
+		aliceRow, _, _ := repo.LookupXRow(db, "members", def, aliceHash)
+		if aliceRow == nil || !repo.IsTombstone(def, aliceRow) {
+			t.Errorf("%s: alice should be tombstone", leafID)
+		}
+		bobRow, _, _ := repo.LookupXRow(db, "members", def, bobHash)
+		if bobRow == nil || repo.IsTombstone(def, bobRow) {
+			t.Errorf("%s: bob should be live", leafID)
+		}
+	}
+	// Master too.
+	aliceRow, _, _ := repo.LookupXRow(masterRepo.DB(), "members", def, aliceHash)
+	if aliceRow == nil || !repo.IsTombstone(def, aliceRow) {
+		t.Error("master: alice should be tombstone")
+	}
+	bobRow, _, _ := repo.LookupXRow(masterRepo.DB(), "members", def, bobHash)
+	if bobRow == nil || repo.IsTombstone(def, bobRow) {
+		t.Error("master: bob should be live")
+	}
+}

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -2,10 +2,12 @@ package repo
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/dmestas/edgesync/go-libfossil/db"
@@ -225,18 +227,68 @@ func ListSyncedTables(d *db.DB) ([]TableInfo, error) {
 	return tables, rows.Err()
 }
 
+// normalizeValue converts a value to its canonical string representation
+// based on the declared column type. This ensures PK hashes are identical
+// regardless of how the value arrived (JSON unmarshal, SQLite scan, etc.).
+func normalizeValue(colType string, v any) string {
+	switch colType {
+	case "integer":
+		switch n := v.(type) {
+		case int64:
+			return strconv.FormatInt(n, 10)
+		case float64:
+			return strconv.FormatInt(int64(n), 10)
+		case int:
+			return strconv.FormatInt(int64(n), 10)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	case "real":
+		switch n := v.(type) {
+		case float64:
+			return strconv.FormatFloat(n, 'f', -1, 64)
+		case int64:
+			return strconv.FormatFloat(float64(n), 'f', -1, 64)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	case "text":
+		s, _ := v.(string)
+		return s
+	case "blob":
+		b, _ := v.([]byte)
+		return hex.EncodeToString(b)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
 // PKHash computes a deterministic SHA1 hash of the primary key values.
-// The map keys are sorted to ensure determinism.
-func PKHash(pkValues map[string]any) string {
+// Values are normalized to canonical strings based on declared column types
+// to avoid JSON round-trip coercion issues (e.g., int64 → float64).
+func PKHash(pkCols []ColumnDef, pkValues map[string]any) string {
+	if pkCols == nil {
+		panic("repo.PKHash: pkCols must not be nil")
+	}
 	if pkValues == nil {
 		panic("repo.PKHash: pkValues must not be nil")
 	}
-	// json.Marshal sorts keys, ensuring determinism.
-	data, err := json.Marshal(pkValues)
-	if err != nil {
-		panic(fmt.Sprintf("repo.PKHash: json.Marshal: %v", err))
+
+	// Sort PK columns lexicographically for determinism.
+	sorted := make([]ColumnDef, len(pkCols))
+	copy(sorted, pkCols)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	// Build canonical representation: name=normalizedValue joined by \x00.
+	var parts []string
+	for _, col := range sorted {
+		v := pkValues[col.Name]
+		parts = append(parts, col.Name+"="+normalizeValue(col.Type, v))
 	}
-	return hash.SHA1(data)
+	canonical := strings.Join(parts, "\x00")
+	return hash.SHA1([]byte(canonical))
 }
 
 // UpsertXRow inserts or replaces a row in the extension table.
@@ -350,30 +402,30 @@ func LookupXRow(d *db.DB, tableName string, def TableDef, pkHash string) (map[st
 		return nil, 0, err
 	}
 
-	// Extract PK columns.
-	var pkCols []string
+	// Extract PK columns (with type info for normalizeValue).
+	var pkColDefs []ColumnDef
 	for _, col := range def.Columns {
 		if col.PK {
-			pkCols = append(pkCols, col.Name)
+			pkColDefs = append(pkColDefs, col)
 		}
 	}
 
 	// Find matching row.
 	for i, row := range rows {
 		pkValues := make(map[string]any)
-		for _, pk := range pkCols {
-			pkValues[pk] = row[pk]
+		for _, col := range pkColDefs {
+			pkValues[col.Name] = row[col.Name]
 		}
-		computed := PKHash(pkValues)
+		computed := PKHash(pkColDefs, pkValues)
 		if computed == pkHash {
 			// Postcondition: re-derive PK hash from the row we're about to
 			// return and verify it matches the requested hash. Guards against
 			// PK column extraction bugs.
 			verifyPK := make(map[string]any)
-			for _, pk := range pkCols {
-				verifyPK[pk] = row[pk]
+			for _, col := range pkColDefs {
+				verifyPK[col.Name] = row[col.Name]
 			}
-			if PKHash(verifyPK) != pkHash {
+			if PKHash(pkColDefs, verifyPK) != pkHash {
 				panic(fmt.Sprintf("repo.LookupXRow: postcondition violated: re-derived PK hash != %q", pkHash))
 			}
 			return row, mtimes[i], nil
@@ -397,11 +449,11 @@ func CatalogHash(d *db.DB, tableName string, def TableDef) (string, error) {
 		return "", err
 	}
 
-	// Extract PK columns.
-	var pkCols []string
+	// Extract PK columns (with type info for normalizeValue).
+	var pkColDefs []ColumnDef
 	for _, col := range def.Columns {
 		if col.PK {
-			pkCols = append(pkCols, col.Name)
+			pkColDefs = append(pkColDefs, col)
 		}
 	}
 
@@ -413,11 +465,11 @@ func CatalogHash(d *db.DB, tableName string, def TableDef) (string, error) {
 	var entries []entry
 	for i, row := range rows {
 		pkValues := make(map[string]any)
-		for _, pk := range pkCols {
-			pkValues[pk] = row[pk]
+		for _, col := range pkColDefs {
+			pkValues[col.Name] = row[col.Name]
 		}
 		entries = append(entries, entry{
-			pkHash: PKHash(pkValues),
+			pkHash: PKHash(pkColDefs, pkValues),
 			mtime:  mtimes[i],
 		})
 	}

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -235,6 +235,9 @@ func ListSyncedTables(d *db.DB) ([]TableInfo, error) {
 // based on the declared column type. This ensures PK hashes are identical
 // regardless of how the value arrived (JSON unmarshal, SQLite scan, etc.).
 func normalizeValue(colType string, v any) string {
+	if v == nil {
+		panic(fmt.Sprintf("repo.normalizeValue: value must not be nil for column type %q", colType))
+	}
 	switch colType {
 	case "integer":
 		switch n := v.(type) {
@@ -244,8 +247,14 @@ func normalizeValue(colType string, v any) string {
 			return strconv.FormatInt(int64(n), 10)
 		case int:
 			return strconv.FormatInt(int64(n), 10)
+		case json.Number:
+			i, err := n.Int64()
+			if err != nil {
+				panic(fmt.Sprintf("repo.normalizeValue: integer column got non-integer json.Number %q", n))
+			}
+			return strconv.FormatInt(i, 10)
 		default:
-			return fmt.Sprintf("%v", v)
+			panic(fmt.Sprintf("repo.normalizeValue: integer column got unexpected type %T", v))
 		}
 	case "real":
 		switch n := v.(type) {
@@ -253,17 +262,29 @@ func normalizeValue(colType string, v any) string {
 			return strconv.FormatFloat(n, 'f', -1, 64)
 		case int64:
 			return strconv.FormatFloat(float64(n), 'f', -1, 64)
+		case json.Number:
+			f, err := n.Float64()
+			if err != nil {
+				panic(fmt.Sprintf("repo.normalizeValue: real column got non-float json.Number %q", n))
+			}
+			return strconv.FormatFloat(f, 'f', -1, 64)
 		default:
-			return fmt.Sprintf("%v", v)
+			panic(fmt.Sprintf("repo.normalizeValue: real column got unexpected type %T", v))
 		}
 	case "text":
-		s, _ := v.(string)
+		s, ok := v.(string)
+		if !ok {
+			panic(fmt.Sprintf("repo.normalizeValue: text column got unexpected type %T", v))
+		}
 		return s
 	case "blob":
-		b, _ := v.([]byte)
+		b, ok := v.([]byte)
+		if !ok {
+			panic(fmt.Sprintf("repo.normalizeValue: blob column got unexpected type %T", v))
+		}
 		return hex.EncodeToString(b)
 	default:
-		return fmt.Sprintf("%v", v)
+		panic(fmt.Sprintf("repo.normalizeValue: unsupported column type %q", colType))
 	}
 }
 
@@ -442,6 +463,12 @@ func LookupXRow(d *db.DB, tableName string, def TableDef, pkHash string) (map[st
 // A tombstone represents a deleted row (UV-style convention).
 // Returns false for tables with only PK columns (no value columns to NULL).
 func IsTombstone(def TableDef, row map[string]any) bool {
+	if row == nil {
+		panic("repo.IsTombstone: row must not be nil")
+	}
+	if len(def.Columns) == 0 {
+		panic("repo.IsTombstone: def.Columns must not be empty")
+	}
 	hasValueCol := false
 	for _, col := range def.Columns {
 		if col.PK {
@@ -461,6 +488,15 @@ func IsTombstone(def TableDef, row map[string]any) bool {
 func DeleteXRowByPKHash(d *db.DB, tableName string, def TableDef, pkHash string, mtime int64) (bool, error) {
 	if d == nil {
 		panic("repo.DeleteXRowByPKHash: d must not be nil")
+	}
+	if tableName == "" {
+		panic("repo.DeleteXRowByPKHash: tableName must not be empty")
+	}
+	if pkHash == "" {
+		panic("repo.DeleteXRowByPKHash: pkHash must not be empty")
+	}
+	if len(def.Columns) == 0 {
+		panic("repo.DeleteXRowByPKHash: def.Columns must not be empty")
 	}
 
 	row, currentMtime, err := LookupXRow(d, tableName, def, pkHash)

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -170,8 +170,8 @@ func createExtensionTable(d *db.DB, name string, def TableDef) error {
 		}
 	}
 	cols = append(cols, "mtime INTEGER NOT NULL")
-	if def.Conflict == "owner-write" {
-		cols = append(cols, "_owner TEXT NOT NULL")
+	if def.Conflict == "owner-write" || def.Conflict == "self-write" {
+		cols = append(cols, "_owner TEXT NOT NULL DEFAULT ''")
 	}
 
 	// Paired assertion — RegisterSyncedTable validates hasPK above, but

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -164,7 +164,11 @@ func createExtensionTable(d *db.DB, name string, def TableDef) error {
 		default:
 			return fmt.Errorf("createExtensionTable: unsupported column type %q", col.Type)
 		}
-		cols = append(cols, fmt.Sprintf("%s %s NOT NULL", col.Name, sqlType))
+		if col.PK {
+			cols = append(cols, fmt.Sprintf("%s %s NOT NULL", col.Name, sqlType))
+		} else {
+			cols = append(cols, fmt.Sprintf("%s %s", col.Name, sqlType))
+		}
 		if col.PK {
 			pkCols = append(pkCols, col.Name)
 		}

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -459,6 +459,78 @@ func LookupXRow(d *db.DB, tableName string, def TableDef, pkHash string) (map[st
 	return nil, 0, nil
 }
 
+// LookupXRowOwner returns the _owner field for the row identified by pkHash,
+// or "" if the row doesn't exist or the table has no owner column.
+func LookupXRowOwner(d *db.DB, tableName string, def TableDef, pkHash string) (string, error) {
+	if d == nil {
+		panic("repo.LookupXRowOwner: d must not be nil")
+	}
+	if tableName == "" {
+		panic("repo.LookupXRowOwner: tableName must not be empty")
+	}
+	if pkHash == "" {
+		panic("repo.LookupXRowOwner: pkHash must not be empty")
+	}
+
+	// Only tables with self-write/owner-write conflict have an _owner column.
+	hasOwner := def.Conflict == "self-write" || def.Conflict == "owner-write"
+	if !hasOwner {
+		return "", nil
+	}
+
+	// Scan all rows to find the one matching pkHash (same strategy as LookupXRow).
+	sql := fmt.Sprintf("SELECT * FROM x_%s", tableName)
+	rows, err := d.Query(sql)
+	if err != nil {
+		return "", fmt.Errorf("repo.LookupXRowOwner: %w", err)
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return "", fmt.Errorf("repo.LookupXRowOwner: columns: %w", err)
+	}
+
+	var pkColDefs []ColumnDef
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+		}
+	}
+
+	for rows.Next() {
+		values := make([]any, len(columns))
+		valuePtrs := make([]any, len(columns))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return "", err
+		}
+
+		rowMap := make(map[string]any)
+		var owner string
+		for i, col := range columns {
+			if col == "_owner" {
+				if v, ok := values[i].(string); ok {
+					owner = v
+				}
+			} else if col != "mtime" {
+				rowMap[col] = values[i]
+			}
+		}
+
+		pkValues := make(map[string]any)
+		for _, col := range pkColDefs {
+			pkValues[col.Name] = rowMap[col.Name]
+		}
+		if PKHash(pkColDefs, pkValues) == pkHash {
+			return owner, nil
+		}
+	}
+	return "", rows.Err()
+}
+
 // IsTombstone returns true if all non-PK value columns in the row are nil.
 // A tombstone represents a deleted row (UV-style convention).
 // Returns false for tables with only PK columns (no value columns to NULL).

--- a/go-libfossil/repo/tablesync.go
+++ b/go-libfossil/repo/tablesync.go
@@ -438,6 +438,81 @@ func LookupXRow(d *db.DB, tableName string, def TableDef, pkHash string) (map[st
 	return nil, 0, nil
 }
 
+// IsTombstone returns true if all non-PK value columns in the row are nil.
+// A tombstone represents a deleted row (UV-style convention).
+// Returns false for tables with only PK columns (no value columns to NULL).
+func IsTombstone(def TableDef, row map[string]any) bool {
+	hasValueCol := false
+	for _, col := range def.Columns {
+		if col.PK {
+			continue
+		}
+		hasValueCol = true
+		if row[col.Name] != nil {
+			return false
+		}
+	}
+	return hasValueCol
+}
+
+// DeleteXRowByPKHash tombstones a row identified by PK hash. Sets all non-PK
+// value columns to NULL and updates mtime. Returns true if applied, false if
+// row doesn't exist or has a newer mtime.
+func DeleteXRowByPKHash(d *db.DB, tableName string, def TableDef, pkHash string, mtime int64) (bool, error) {
+	if d == nil {
+		panic("repo.DeleteXRowByPKHash: d must not be nil")
+	}
+
+	row, currentMtime, err := LookupXRow(d, tableName, def, pkHash)
+	if err != nil {
+		return false, err
+	}
+	if row == nil {
+		return false, nil
+	}
+	if currentMtime > mtime {
+		return false, nil
+	}
+
+	var pkCols []string
+	var pkValues []any
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col.Name)
+			pkValues = append(pkValues, row[col.Name])
+		}
+	}
+
+	var setClauses []string
+	for _, col := range def.Columns {
+		if col.PK {
+			continue
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = NULL", col.Name))
+	}
+	setClauses = append(setClauses, "mtime = ?")
+
+	var whereClauses []string
+	for _, pk := range pkCols {
+		whereClauses = append(whereClauses, fmt.Sprintf("%s = ?", pk))
+	}
+
+	args := []any{mtime}
+	args = append(args, pkValues...)
+
+	sqlStr := fmt.Sprintf(
+		"UPDATE x_%s SET %s WHERE %s",
+		tableName,
+		strings.Join(setClauses, ", "),
+		strings.Join(whereClauses, " AND "),
+	)
+	_, err = d.Exec(sqlStr, args...)
+	if err != nil {
+		return false, fmt.Errorf("repo.DeleteXRowByPKHash: update: %w", err)
+	}
+	return true, nil
+}
+
 // CatalogHash computes the SHA1 hash of all rows in the extension table.
 // Format: "pk_hash mtime\n" for each row, sorted by pk_hash.
 func CatalogHash(d *db.DB, tableName string, def TableDef) (string, error) {
@@ -468,6 +543,10 @@ func CatalogHash(d *db.DB, tableName string, def TableDef) (string, error) {
 	}
 	var entries []entry
 	for i, row := range rows {
+		// Exclude tombstones from catalog hash (UV convention).
+		if IsTombstone(def, row) {
+			continue
+		}
 		pkValues := make(map[string]any)
 		for _, col := range pkColDefs {
 			pkValues[col.Name] = row[col.Name]

--- a/go-libfossil/repo/tablesync_test.go
+++ b/go-libfossil/repo/tablesync_test.go
@@ -173,6 +173,108 @@ func TestExtensionTableNullableValueColumns(t *testing.T) {
 	}
 }
 
+func TestIsTombstone(t *testing.T) {
+	def := TableDef{
+		Columns: []ColumnDef{
+			{Name: "id", Type: "text", PK: true},
+			{Name: "data", Type: "text"},
+			{Name: "count", Type: "integer"},
+		},
+		Conflict: "mtime-wins",
+	}
+	if IsTombstone(def, map[string]any{"id": "k1", "data": "hello", "count": int64(5)}) {
+		t.Error("live row should not be tombstone")
+	}
+	if !IsTombstone(def, map[string]any{"id": "k1", "data": nil, "count": nil}) {
+		t.Error("row with all nil values should be tombstone")
+	}
+	if IsTombstone(def, map[string]any{"id": "k1", "data": nil, "count": int64(5)}) {
+		t.Error("partial nil should not be tombstone")
+	}
+}
+
+func TestDeleteXRowByPKHash(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	RegisterSyncedTable(r.DB(), "del_test", def, 1000)
+	UpsertXRow(r.DB(), "del_test", map[string]any{"id": "k1", "data": "hello"}, 1000)
+
+	pkColDefs := []ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := PKHash(pkColDefs, map[string]any{"id": "k1"})
+	deleted, err := DeleteXRowByPKHash(r.DB(), "del_test", def, pkHash, 2000)
+	if err != nil {
+		t.Fatalf("DeleteXRowByPKHash: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deletion to apply")
+	}
+
+	row, mtime, err := LookupXRow(r.DB(), "del_test", def, pkHash)
+	if err != nil {
+		t.Fatalf("LookupXRow: %v", err)
+	}
+	if row == nil {
+		t.Fatal("tombstone row should still exist")
+	}
+	if mtime != 2000 {
+		t.Errorf("mtime = %d, want 2000", mtime)
+	}
+	if !IsTombstone(def, row) {
+		t.Error("row should be tombstone after deletion")
+	}
+
+	deleted, err = DeleteXRowByPKHash(r.DB(), "del_test", def, pkHash, 1500)
+	if err != nil {
+		t.Fatalf("DeleteXRowByPKHash (older): %v", err)
+	}
+	if deleted {
+		t.Error("older delete should be rejected")
+	}
+
+	UpsertXRow(r.DB(), "del_test", map[string]any{"id": "k1", "data": "revived"}, 3000)
+	row, _, _ = LookupXRow(r.DB(), "del_test", def, pkHash)
+	if IsTombstone(def, row) {
+		t.Error("row should be live after resurrection")
+	}
+}
+
+func TestCatalogHashExcludesTombstones(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	RegisterSyncedTable(r.DB(), "cat_test", def, 1000)
+
+	UpsertXRow(r.DB(), "cat_test", map[string]any{"id": "k1", "data": "a"}, 1000)
+	UpsertXRow(r.DB(), "cat_test", map[string]any{"id": "k2", "data": "b"}, 1000)
+	hashBefore, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	pkColDefs := []ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := PKHash(pkColDefs, map[string]any{"id": "k1"})
+	DeleteXRowByPKHash(r.DB(), "cat_test", def, pkHash, 2000)
+	hashAfter, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	if hashBefore == hashAfter {
+		t.Error("catalog hash should change after deletion")
+	}
+
+	pkHash2 := PKHash(pkColDefs, map[string]any{"id": "k2"})
+	DeleteXRowByPKHash(r.DB(), "cat_test", def, pkHash2, 2000)
+	hashEmpty, _ := CatalogHash(r.DB(), "cat_test", def)
+
+	RegisterSyncedTable(r.DB(), "cat_empty", def, 1000)
+	hashFresh, _ := CatalogHash(r.DB(), "cat_empty", def)
+	if hashEmpty != hashFresh {
+		t.Errorf("all-tombstone table hash %q != empty table hash %q", hashEmpty, hashFresh)
+	}
+}
+
 func TestCatalogHash(t *testing.T) {
 	r := setupTSRepo(t)
 	EnsureSyncSchema(r.DB())

--- a/go-libfossil/repo/tablesync_test.go
+++ b/go-libfossil/repo/tablesync_test.go
@@ -34,17 +34,62 @@ func TestValidateTableName(t *testing.T) {
 }
 
 func TestPKHash(t *testing.T) {
-	h := PKHash(map[string]any{"peer_id": "leaf-01"})
+	pkCols := []ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	h := PKHash(pkCols, map[string]any{"peer_id": "leaf-01"})
 	if h == "" {
 		t.Fatal("PKHash returned empty")
 	}
-	h2 := PKHash(map[string]any{"peer_id": "leaf-01"})
+	h2 := PKHash(pkCols, map[string]any{"peer_id": "leaf-01"})
 	if h != h2 {
 		t.Fatalf("PKHash not deterministic: %q vs %q", h, h2)
 	}
-	h3 := PKHash(map[string]any{"peer_id": "leaf-02"})
+	h3 := PKHash(pkCols, map[string]any{"peer_id": "leaf-02"})
 	if h == h3 {
 		t.Fatal("different inputs produced same hash")
+	}
+}
+
+func TestPKHashTypeAware(t *testing.T) {
+	pkCols := []ColumnDef{{Name: "id", Type: "integer", PK: true}}
+
+	// int64 and float64 of same value must produce identical hashes.
+	h1 := PKHash(pkCols, map[string]any{"id": int64(42)})
+	h2 := PKHash(pkCols, map[string]any{"id": float64(42)})
+	if h1 != h2 {
+		t.Fatalf("int64 vs float64: %q != %q", h1, h2)
+	}
+
+	// Large integer (>2^53): float64 loses precision before PKHash even sees it.
+	// float64(1<<53+1) == float64(1<<53) due to IEEE 754 rounding, so the
+	// hashes will differ — that is correct and expected. We verify that the
+	// int64 path at least produces a stable, non-empty hash.
+	big := int64(1<<53 + 1) // 9007199254740993
+	h3 := PKHash(pkCols, map[string]any{"id": big})
+	if h3 == "" {
+		t.Fatal("large int64 PK hash is empty")
+	}
+	// Verify the int64 hash is deterministic.
+	h3b := PKHash(pkCols, map[string]any{"id": big})
+	if h3 != h3b {
+		t.Fatalf("large int64 PK hash not deterministic: %q vs %q", h3, h3b)
+	}
+
+	// Composite PK with mixed types.
+	mixedCols := []ColumnDef{
+		{Name: "org", Type: "text", PK: true},
+		{Name: "seq", Type: "integer", PK: true},
+	}
+	h5 := PKHash(mixedCols, map[string]any{"org": "acme", "seq": int64(7)})
+	h6 := PKHash(mixedCols, map[string]any{"org": "acme", "seq": float64(7)})
+	if h5 != h6 {
+		t.Fatalf("composite mixed types: %q != %q", h5, h6)
+	}
+
+	// Text PK must still work.
+	textCols := []ColumnDef{{Name: "name", Type: "text", PK: true}}
+	h7 := PKHash(textCols, map[string]any{"name": "hello"})
+	if h7 == "" {
+		t.Fatal("text PK hash is empty")
 	}
 }
 
@@ -97,7 +142,8 @@ func TestUpsertAndLookupXRow(t *testing.T) {
 		t.Fatalf("UpsertXRow: %v", err)
 	}
 
-	pkHash := PKHash(map[string]any{"peer_id": "leaf-01"})
+	pkCols := []ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	pkHash := PKHash(pkCols, map[string]any{"peer_id": "leaf-01"})
 	got, mtime, err := LookupXRow(r.DB(), "peer_registry", def, pkHash)
 	if err != nil {
 		t.Fatalf("LookupXRow: %v", err)

--- a/go-libfossil/repo/tablesync_test.go
+++ b/go-libfossil/repo/tablesync_test.go
@@ -156,6 +156,23 @@ func TestUpsertAndLookupXRow(t *testing.T) {
 	}
 }
 
+func TestExtensionTableNullableValueColumns(t *testing.T) {
+	r := setupTSRepo(t)
+	EnsureSyncSchema(r.DB())
+	def := TableDef{
+		Columns:  []ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	if err := RegisterSyncedTable(r.DB(), "nullable_test", def, 1000); err != nil {
+		t.Fatal(err)
+	}
+	// Insert row with NULL value column — should succeed for tombstone support.
+	_, err := r.DB().Exec("INSERT INTO x_nullable_test(id, data, mtime) VALUES('k1', NULL, 1000)")
+	if err != nil {
+		t.Fatalf("insert with NULL value column should succeed: %v", err)
+	}
+}
+
 func TestCatalogHash(t *testing.T) {
 	r := setupTSRepo(t)
 	EnsureSyncSchema(r.DB())

--- a/go-libfossil/sync/client.go
+++ b/go-libfossil/sync/client.go
@@ -549,7 +549,7 @@ func (s *session) processResponse(msg *xfer.Message) (bool, error) {
 				s.uvToSend[c.Name] = true
 			}
 
-		case *xfer.SchemaCard, *xfer.XIGotCard, *xfer.XGimmeCard, *xfer.XRowCard:
+		case *xfer.SchemaCard, *xfer.XIGotCard, *xfer.XGimmeCard, *xfer.XRowCard, *xfer.XDeleteCard:
 			if err := s.processXTableCard(card); err != nil {
 				return false, err
 			}

--- a/go-libfossil/sync/client_tablesync.go
+++ b/go-libfossil/sync/client_tablesync.go
@@ -81,13 +81,14 @@ func (s *session) buildTableXIGotCards(info repo.TableInfo) ([]xfer.Card, error)
 	}
 
 	pkCols := extractPKColumns(info.Def)
+	pkColDefs := extractPKColumnDefs(info.Def)
 	var cards []xfer.Card
 	for i, row := range rows {
 		pkValues := make(map[string]any)
 		for _, col := range pkCols {
 			pkValues[col] = row[col]
 		}
-		pkHash := repo.PKHash(pkValues)
+		pkHash := repo.PKHash(pkColDefs, pkValues)
 		mtime := mtimes[i]
 
 		// BUGGIFY: 2% chance send stale mtime to test server-side comparison.
@@ -278,6 +279,17 @@ func extractPKColumns(def repo.TableDef) []string {
 	for _, col := range def.Columns {
 		if col.PK {
 			pkCols = append(pkCols, col.Name)
+		}
+	}
+	return pkCols
+}
+
+// extractPKColumnDefs returns the ColumnDef of all PK columns from a TableDef.
+func extractPKColumnDefs(def repo.TableDef) []repo.ColumnDef {
+	var pkCols []repo.ColumnDef
+	for _, col := range def.Columns {
+		if col.PK {
+			pkCols = append(pkCols, col)
 		}
 	}
 	return pkCols

--- a/go-libfossil/sync/client_tablesync.go
+++ b/go-libfossil/sync/client_tablesync.go
@@ -276,9 +276,19 @@ func (s *session) handleXRowResponse(c *xfer.XRowCard) error {
 		return fmt.Errorf("handleXRowResponse: ensure schema: %w", err)
 	}
 
+	def, err := s.getXTableDef(c.Table)
+	if err != nil {
+		return fmt.Errorf("handleXRowResponse: get table def %s: %w", c.Table, err)
+	}
+
 	var row map[string]any
-	if err := json.Unmarshal(c.Content, &row); err != nil {
+	rowDec := json.NewDecoder(bytesReader(c.Content))
+	rowDec.UseNumber()
+	if err := rowDec.Decode(&row); err != nil {
 		return fmt.Errorf("handleXRowResponse: unmarshal %s/%s: %w", c.Table, c.PKHash, err)
+	}
+	if def != nil {
+		coerceJSONNumbers(row, *def)
 	}
 
 	if err := repo.UpsertXRow(s.repo.DB(), c.Table, row, c.MTime); err != nil {
@@ -324,9 +334,12 @@ func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
 		}
 		if existingRow == nil && len(c.PKData) > 0 {
 			var pkValues map[string]any
-			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+			pkDec := json.NewDecoder(bytesReader(c.PKData))
+			pkDec.UseNumber()
+			if err := pkDec.Decode(&pkValues); err != nil {
 				return fmt.Errorf("handleXDeleteResponse: bad PKData: %w", err)
 			}
+			coerceJSONNumbers(pkValues, *def)
 			if err := repo.UpsertXRow(s.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
 				return fmt.Errorf("handleXDeleteResponse: insert tombstone: %w", err)
 			}

--- a/go-libfossil/sync/client_tablesync.go
+++ b/go-libfossil/sync/client_tablesync.go
@@ -119,7 +119,7 @@ func (s *session) buildTableSendCards(info repo.TableInfo) ([]xfer.Card, error) 
 		}
 	}
 
-	// Emit xrow for rows queued to send.
+	// Emit xrow or xdelete for rows queued to send.
 	if sends, ok := s.xTableToSend[info.Name]; ok {
 		for pkHash := range sends {
 			row, mtime, err := repo.LookupXRow(s.repo.DB(), info.Name, info.Def, pkHash)
@@ -130,16 +130,35 @@ func (s *session) buildTableSendCards(info repo.TableInfo) ([]xfer.Card, error) 
 				delete(sends, pkHash)
 				continue
 			}
-			rowJSON, err := json.Marshal(row)
-			if err != nil {
-				return nil, fmt.Errorf("buildTableSendCards: marshal row %s/%s: %w", info.Name, pkHash, err)
+			if repo.IsTombstone(info.Def, row) {
+				// Send xdelete with PK data.
+				pkCols := extractPKColumns(info.Def)
+				pkValues := make(map[string]any)
+				for _, col := range pkCols {
+					pkValues[col] = row[col]
+				}
+				pkData, err := json.Marshal(pkValues)
+				if err != nil {
+					return nil, fmt.Errorf("buildTableSendCards: marshal pk %s/%s: %w", info.Name, pkHash, err)
+				}
+				cards = append(cards, &xfer.XDeleteCard{
+					Table:  info.Name,
+					PKHash: pkHash,
+					MTime:  mtime,
+					PKData: pkData,
+				})
+			} else {
+				rowJSON, err := json.Marshal(row)
+				if err != nil {
+					return nil, fmt.Errorf("buildTableSendCards: marshal row %s/%s: %w", info.Name, pkHash, err)
+				}
+				cards = append(cards, &xfer.XRowCard{
+					Table:   info.Name,
+					PKHash:  pkHash,
+					MTime:   mtime,
+					Content: rowJSON,
+				})
 			}
-			cards = append(cards, &xfer.XRowCard{
-				Table:   info.Name,
-				PKHash:  pkHash,
-				MTime:   mtime,
-				Content: rowJSON,
-			})
 			delete(sends, pkHash)
 		}
 	}
@@ -158,6 +177,8 @@ func (s *session) processXTableCard(card xfer.Card) error {
 		return s.handleXGimmeResponse(c)
 	case *xfer.XRowCard:
 		return s.handleXRowResponse(c)
+	case *xfer.XDeleteCard:
+		return s.handleXDeleteResponse(c)
 	}
 	return nil
 }
@@ -265,6 +286,54 @@ func (s *session) handleXRowResponse(c *xfer.XRowCard) error {
 	}
 
 	// Remove from gimmes.
+	if gimmes, ok := s.xTableGimmes[c.Table]; ok {
+		delete(gimmes, c.PKHash)
+	}
+
+	return nil
+}
+
+// handleXDeleteResponse processes an xdelete from the server response.
+func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
+	if c == nil {
+		panic("session.handleXDeleteResponse: c must not be nil")
+	}
+
+	if err := repo.EnsureSyncSchema(s.repo.DB()); err != nil {
+		return fmt.Errorf("handleXDeleteResponse: ensure schema: %w", err)
+	}
+
+	def, err := s.getXTableDef(c.Table)
+	if err != nil {
+		return fmt.Errorf("handleXDeleteResponse: get table def %s: %w", c.Table, err)
+	}
+	if def == nil {
+		return nil
+	}
+
+	deleted, err := repo.DeleteXRowByPKHash(s.repo.DB(), c.Table, *def, c.PKHash, c.MTime)
+	if err != nil {
+		return fmt.Errorf("handleXDeleteResponse: delete %s/%s: %w", c.Table, c.PKHash, err)
+	}
+
+	// If row didn't exist locally, insert tombstone using PKData.
+	if !deleted {
+		existingRow, _, lookupErr := repo.LookupXRow(s.repo.DB(), c.Table, *def, c.PKHash)
+		if lookupErr != nil {
+			return fmt.Errorf("handleXDeleteResponse: lookup: %w", lookupErr)
+		}
+		if existingRow == nil && len(c.PKData) > 0 {
+			var pkValues map[string]any
+			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+				return fmt.Errorf("handleXDeleteResponse: bad PKData: %w", err)
+			}
+			if err := repo.UpsertXRow(s.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
+				return fmt.Errorf("handleXDeleteResponse: insert tombstone: %w", err)
+			}
+		}
+	}
+
+	// Remove from gimmes if present.
 	if gimmes, ok := s.xTableGimmes[c.Table]; ok {
 		delete(gimmes, c.PKHash)
 	}

--- a/go-libfossil/sync/client_tablesync.go
+++ b/go-libfossil/sync/client_tablesync.go
@@ -131,6 +131,11 @@ func (s *session) buildTableSendCards(info repo.TableInfo) ([]xfer.Card, error) 
 				continue
 			}
 			if repo.IsTombstone(info.Def, row) {
+				// BUGGIFY: 3% chance skip sending xdelete to test re-queue next round.
+				if s.opts.Buggify != nil && s.opts.Buggify.Check("client.buildTableSendCards.skipXDelete", 0.03) {
+					delete(sends, pkHash)
+					continue
+				}
 				// Send xdelete with PK data.
 				pkCols := extractPKColumns(info.Def)
 				pkValues := make(map[string]any)
@@ -310,6 +315,11 @@ func (s *session) handleXRowResponse(c *xfer.XRowCard) error {
 func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
 	if c == nil {
 		panic("session.handleXDeleteResponse: c must not be nil")
+	}
+
+	// BUGGIFY: 5% chance drop received xdelete to test re-send next round.
+	if s.opts.Buggify != nil && s.opts.Buggify.Check("client.handleXDeleteResponse.drop", 0.05) {
+		return nil
 	}
 
 	if err := repo.EnsureSyncSchema(s.repo.DB()); err != nil {

--- a/go-libfossil/sync/client_tablesync.go
+++ b/go-libfossil/sync/client_tablesync.go
@@ -168,6 +168,9 @@ func (s *session) buildTableSendCards(info repo.TableInfo) ([]xfer.Card, error) 
 
 // processXTableCard dispatches incoming table sync cards to their handlers.
 func (s *session) processXTableCard(card xfer.Card) error {
+	if card == nil {
+		panic("session.processXTableCard: card must not be nil")
+	}
 	switch c := card.(type) {
 	case *xfer.SchemaCard:
 		return s.handleXSchemaCard(c)
@@ -321,29 +324,8 @@ func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
 		return nil
 	}
 
-	deleted, err := repo.DeleteXRowByPKHash(s.repo.DB(), c.Table, *def, c.PKHash, c.MTime)
-	if err != nil {
-		return fmt.Errorf("handleXDeleteResponse: delete %s/%s: %w", c.Table, c.PKHash, err)
-	}
-
-	// If row didn't exist locally, insert tombstone using PKData.
-	if !deleted {
-		existingRow, _, lookupErr := repo.LookupXRow(s.repo.DB(), c.Table, *def, c.PKHash)
-		if lookupErr != nil {
-			return fmt.Errorf("handleXDeleteResponse: lookup: %w", lookupErr)
-		}
-		if existingRow == nil && len(c.PKData) > 0 {
-			var pkValues map[string]any
-			pkDec := json.NewDecoder(bytesReader(c.PKData))
-			pkDec.UseNumber()
-			if err := pkDec.Decode(&pkValues); err != nil {
-				return fmt.Errorf("handleXDeleteResponse: bad PKData: %w", err)
-			}
-			coerceJSONNumbers(pkValues, *def)
-			if err := repo.UpsertXRow(s.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
-				return fmt.Errorf("handleXDeleteResponse: insert tombstone: %w", err)
-			}
-		}
+	if err := applyXDeleteLocally(s.repo.DB(), c.Table, *def, c.PKHash, c.MTime, c.PKData); err != nil {
+		return err
 	}
 
 	// Remove from gimmes if present.
@@ -357,6 +339,9 @@ func (s *session) handleXDeleteResponse(c *xfer.XDeleteCard) error {
 // extractPKColumns returns the names of all primary key columns from a TableDef.
 // This is a package-level function shared by both client and handler.
 func extractPKColumns(def repo.TableDef) []string {
+	if len(def.Columns) == 0 {
+		panic("extractPKColumns: def.Columns must not be empty")
+	}
 	var pkCols []string
 	for _, col := range def.Columns {
 		if col.PK {
@@ -368,6 +353,9 @@ func extractPKColumns(def repo.TableDef) []string {
 
 // extractPKColumnDefs returns the ColumnDef of all PK columns from a TableDef.
 func extractPKColumnDefs(def repo.TableDef) []repo.ColumnDef {
+	if len(def.Columns) == 0 {
+		panic("extractPKColumnDefs: def.Columns must not be empty")
+	}
 	var pkCols []repo.ColumnDef
 	for _, col := range def.Columns {
 		if col.PK {

--- a/go-libfossil/sync/client_tablesync_test.go
+++ b/go-libfossil/sync/client_tablesync_test.go
@@ -122,6 +122,75 @@ func TestTableSyncEndToEnd(t *testing.T) {
 	}
 }
 
+func TestTableSyncDeletion(t *testing.T) {
+	serverRepo, clientRepo := newTableSyncRepoPair(t)
+
+	def := repo.TableDef{
+		Columns: []repo.ColumnDef{
+			{Name: "id", Type: "text", PK: true},
+			{Name: "value", Type: "text"},
+		},
+		Conflict: "mtime-wins",
+	}
+	if err := repo.RegisterSyncedTable(serverRepo.DB(), "tasks", def, 100); err != nil {
+		t.Fatalf("register server: %v", err)
+	}
+	if err := repo.RegisterSyncedTable(clientRepo.DB(), "tasks", def, 100); err != nil {
+		t.Fatalf("register client: %v", err)
+	}
+
+	// Seed same row on both sides at mtime 1000.
+	row := map[string]any{"id": "row-1", "value": "hello"}
+	if err := repo.UpsertXRow(serverRepo.DB(), "tasks", row, 1000); err != nil {
+		t.Fatalf("upsert server row: %v", err)
+	}
+	if err := repo.UpsertXRow(clientRepo.DB(), "tasks", row, 1000); err != nil {
+		t.Fatalf("upsert client row: %v", err)
+	}
+
+	// Delete on server at mtime 2000.
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "row-1"})
+	deleted, err := repo.DeleteXRowByPKHash(serverRepo.DB(), "tasks", def, pkHash, 2000)
+	if err != nil {
+		t.Fatalf("DeleteXRowByPKHash: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected row to be deleted on server")
+	}
+
+	transport := &MockTransport{Handler: func(req *xfer.Message) *xfer.Message {
+		resp, err := HandleSync(context.Background(), serverRepo, req)
+		if err != nil {
+			t.Fatalf("HandleSync: %v", err)
+		}
+		return resp
+	}}
+
+	_, err = Sync(context.Background(), clientRepo, transport, SyncOpts{
+		Pull: true, Push: true,
+		ProjectCode: "p", ServerCode: "s",
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// Verify client's row is now a tombstone with mtime 2000.
+	clientRow, clientMtime, err := repo.LookupXRow(clientRepo.DB(), "tasks", def, pkHash)
+	if err != nil {
+		t.Fatalf("LookupXRow client: %v", err)
+	}
+	if clientRow == nil {
+		t.Fatal("client row not found after sync")
+	}
+	if !repo.IsTombstone(def, clientRow) {
+		t.Errorf("client row is not a tombstone: %v", clientRow)
+	}
+	if clientMtime != 2000 {
+		t.Errorf("client mtime = %d, want 2000", clientMtime)
+	}
+}
+
 func TestTableSyncSchemaDeployment(t *testing.T) {
 	serverRepo, clientRepo := newTableSyncRepoPair(t)
 

--- a/go-libfossil/sync/handler.go
+++ b/go-libfossil/sync/handler.go
@@ -321,6 +321,8 @@ func (h *handler) handleDataCard(card xfer.Card) error {
 		return h.handleXGimme(c)
 	case *xfer.XRowCard:
 		return h.handleXRow(c)
+	case *xfer.XDeleteCard:
+		return h.handleXDelete(c)
 	}
 	return nil
 }

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -241,6 +241,12 @@ func (h *handler) handleXRow(c *xfer.XRowCard) error {
 // Returns the row map and true on success, or nil and false if an error card was emitted.
 // UseNumber is required to preserve large integers (>2^53) that float64 cannot represent exactly.
 func (h *handler) verifyXRowPKHash(c *xfer.XRowCard, st *SyncedTable) (map[string]any, bool) {
+	if c == nil {
+		panic("handler.verifyXRowPKHash: c must not be nil")
+	}
+	if st == nil {
+		panic("handler.verifyXRowPKHash: st must not be nil")
+	}
 	var row map[string]any
 	dec := json.NewDecoder(bytesReader(c.Content))
 	dec.UseNumber()
@@ -273,6 +279,15 @@ func (h *handler) verifyXRowPKHash(c *xfer.XRowCard, st *SyncedTable) (map[strin
 // resolveXRowConflict applies the table's conflict resolution policy.
 // Returns true if the incoming row should be accepted, false to reject.
 func (h *handler) resolveXRowConflict(c *xfer.XRowCard, st *SyncedTable, row map[string]any) (bool, error) {
+	if c == nil {
+		panic("handler.resolveXRowConflict: c must not be nil")
+	}
+	if st == nil {
+		panic("handler.resolveXRowConflict: st must not be nil")
+	}
+	if row == nil {
+		panic("handler.resolveXRowConflict: row must not be nil")
+	}
 	localRow, localMtime, err := repo.LookupXRow(h.repo.DB(), c.Table, st.Def, c.PKHash)
 	if err != nil {
 		return false, fmt.Errorf("handler.resolveXRowConflict: lookup %s/%s: %w", c.Table, c.PKHash, err)
@@ -316,6 +331,12 @@ func (h *handler) resolveXRowConflict(c *xfer.XRowCard, st *SyncedTable, row map
 
 // sendXRow sends a single row to the client.
 func (h *handler) sendXRow(table string, st *SyncedTable, pkHash string) error {
+	if st == nil {
+		panic("handler.sendXRow: st must not be nil")
+	}
+	if pkHash == "" {
+		panic("handler.sendXRow: pkHash must not be empty")
+	}
 	row, mtime, err := repo.LookupXRow(h.repo.DB(), table, st.Def, pkHash)
 	if err != nil {
 		return fmt.Errorf("handler.sendXRow: lookup %s/%s: %w", table, pkHash, err)
@@ -343,6 +364,9 @@ func (h *handler) sendXRow(table string, st *SyncedTable, pkHash string) error {
 // emitXIGots emits schema and xigot cards for all synced tables.
 // Schema cards are sent so that pulling clients learn about new tables.
 func (h *handler) emitXIGots() error {
+	if h.syncedTables == nil {
+		panic("handler.emitXIGots: syncedTables must not be nil")
+	}
 	for name, st := range h.syncedTables {
 		// BUGGIFY: 5% chance skip schema card to test client retry on missing schema.
 		if h.buggify != nil && h.buggify.Check("handler.emitXIGots.dropSchema", 0.05) {
@@ -372,6 +396,12 @@ func (h *handler) emitXIGots() error {
 
 // emitXIGotsForTable emits xigot cards for all rows in a table.
 func (h *handler) emitXIGotsForTable(table string, st *SyncedTable) error {
+	if st == nil {
+		panic("handler.emitXIGotsForTable: st must not be nil")
+	}
+	if table == "" {
+		panic("handler.emitXIGotsForTable: table must not be empty")
+	}
 	rows, mtimes, err := repo.ListXRows(h.repo.DB(), table, st.Def)
 	if err != nil {
 		return fmt.Errorf("handler.emitXIGotsForTable: list %s: %w", table, err)
@@ -416,43 +446,26 @@ func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
 
 	st, ok := h.syncedTables[c.Table]
 	if !ok {
+		// Table not registered locally — skip silently. The client may have
+		// a newer schema version that includes this table; we'll learn about
+		// it when the schema card arrives in a future round.
 		return nil
 	}
 
-	deleted, err := repo.DeleteXRowByPKHash(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime)
-	if err != nil {
-		return fmt.Errorf("handler.handleXDelete: %w", err)
-	}
-
-	// If row didn't exist locally, insert tombstone using PKData.
-	if !deleted {
-		existingRow, _, lookupErr := repo.LookupXRow(h.repo.DB(), c.Table, st.Def, c.PKHash)
-		if lookupErr != nil {
-			return fmt.Errorf("handler.handleXDelete: lookup: %w", lookupErr)
-		}
-		if existingRow == nil && len(c.PKData) > 0 {
-			var pkValues map[string]any
-			pkDec := json.NewDecoder(bytesReader(c.PKData))
-			pkDec.UseNumber()
-			if err := pkDec.Decode(&pkValues); err != nil {
-				h.resp = append(h.resp, &xfer.ErrorCard{
-					Message: fmt.Sprintf("xdelete %s/%s: bad PKData: %v", c.Table, c.PKHash, err),
-				})
-				return nil
-			}
-			coerceJSONNumbers(pkValues, st.Def)
-			// Insert tombstone row with only PK values (value cols will be NULL).
-			if err := repo.UpsertXRow(h.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
-				return fmt.Errorf("handler.handleXDelete: insert tombstone: %w", err)
-			}
-		}
-	}
-
-	return nil
+	return applyXDeleteLocally(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime, c.PKData)
 }
 
 // sendXDelete sends a tombstone deletion card to the client.
 func (h *handler) sendXDelete(table string, st *SyncedTable, pkHash string, mtime int64, row map[string]any) {
+	if st == nil {
+		panic("handler.sendXDelete: st must not be nil")
+	}
+	if pkHash == "" {
+		panic("handler.sendXDelete: pkHash must not be empty")
+	}
+	if row == nil {
+		panic("handler.sendXDelete: row must not be nil")
+	}
 	pkCols := extractPKColumns(st.Def)
 	pkValues := make(map[string]any)
 	for _, col := range pkCols {
@@ -486,7 +499,11 @@ func bytesReader(b []byte) *bytes.Reader {
 // (int64 for "integer" columns, float64 for "real" columns) based on the
 // declared column definitions. This is required after UseNumber decoding to
 // preserve large integers (>2^53) that float64 cannot represent exactly.
+// It modifies row in place.
 func coerceJSONNumbers(row map[string]any, def repo.TableDef) {
+	if row == nil {
+		panic("coerceJSONNumbers: row must not be nil")
+	}
 	for _, col := range def.Columns {
 		v, ok := row[col.Name]
 		if !ok {

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -146,8 +146,12 @@ func (h *handler) handleXIGot(c *xfer.XIGotCard) error {
 		return nil
 	}
 
-	// Compare mtimes: if local is newer, push it; otherwise no-op.
+	// Compare mtimes: if local is newer, push it (or send xdelete if tombstone).
 	if localMtime > c.MTime {
+		if repo.IsTombstone(st.Def, localRow) {
+			h.sendXDelete(c.Table, st, c.PKHash, localMtime, localRow)
+			return nil
+		}
 		return h.sendXRow(c.Table, st, c.PKHash)
 	}
 
@@ -390,6 +394,75 @@ func (h *handler) emitXIGotsForTable(table string, st *SyncedTable) error {
 		})
 	}
 	return nil
+}
+
+// handleXDelete processes a table sync deletion card.
+func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
+	if c == nil {
+		panic("handler.handleXDelete: c must not be nil")
+	}
+	if !h.pushOK {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("xdelete %s/%s rejected: no push card", c.Table, c.PKHash),
+		})
+		return nil
+	}
+
+	st, ok := h.syncedTables[c.Table]
+	if !ok {
+		return nil
+	}
+
+	deleted, err := repo.DeleteXRowByPKHash(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime)
+	if err != nil {
+		return fmt.Errorf("handler.handleXDelete: %w", err)
+	}
+
+	// If row didn't exist locally, insert tombstone using PKData.
+	if !deleted {
+		existingRow, _, lookupErr := repo.LookupXRow(h.repo.DB(), c.Table, st.Def, c.PKHash)
+		if lookupErr != nil {
+			return fmt.Errorf("handler.handleXDelete: lookup: %w", lookupErr)
+		}
+		if existingRow == nil && len(c.PKData) > 0 {
+			var pkValues map[string]any
+			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+				h.resp = append(h.resp, &xfer.ErrorCard{
+					Message: fmt.Sprintf("xdelete %s/%s: bad PKData: %v", c.Table, c.PKHash, err),
+				})
+				return nil
+			}
+			// Insert tombstone row with only PK values (value cols will be NULL).
+			if err := repo.UpsertXRow(h.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
+				return fmt.Errorf("handler.handleXDelete: insert tombstone: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// sendXDelete sends a tombstone deletion card to the client.
+func (h *handler) sendXDelete(table string, st *SyncedTable, pkHash string, mtime int64, row map[string]any) {
+	pkCols := extractPKColumns(st.Def)
+	pkValues := make(map[string]any)
+	for _, col := range pkCols {
+		pkValues[col] = row[col]
+	}
+	pkData, err := json.Marshal(pkValues)
+	if err != nil {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("xdelete %s/%s: marshal PKData: %v", table, pkHash, err),
+		})
+		return
+	}
+
+	h.resp = append(h.resp, &xfer.XDeleteCard{
+		Table:  table,
+		PKHash: pkHash,
+		MTime:  mtime,
+		PKData: pkData,
+	})
 }
 
 // extractPKColumns is defined in client_tablesync.go as a package-level

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -238,14 +239,19 @@ func (h *handler) handleXRow(c *xfer.XRowCard) error {
 
 // verifyXRowPKHash unmarshals the row JSON and verifies the PK hash matches.
 // Returns the row map and true on success, or nil and false if an error card was emitted.
+// UseNumber is required to preserve large integers (>2^53) that float64 cannot represent exactly.
 func (h *handler) verifyXRowPKHash(c *xfer.XRowCard, st *SyncedTable) (map[string]any, bool) {
 	var row map[string]any
-	if err := json.Unmarshal(c.Content, &row); err != nil {
+	dec := json.NewDecoder(bytesReader(c.Content))
+	dec.UseNumber()
+	if err := dec.Decode(&row); err != nil {
 		h.resp = append(h.resp, &xfer.ErrorCard{
 			Message: fmt.Sprintf("xrow %s/%s: unmarshal: %v", c.Table, c.PKHash, err),
 		})
 		return nil, false
 	}
+	// Coerce json.Number values to native Go types based on column definitions.
+	coerceJSONNumbers(row, st.Def)
 
 	pkCols := extractPKColumns(st.Def)
 	pkColDefs := extractPKColumnDefs(st.Def)
@@ -426,12 +432,15 @@ func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
 		}
 		if existingRow == nil && len(c.PKData) > 0 {
 			var pkValues map[string]any
-			if err := json.Unmarshal(c.PKData, &pkValues); err != nil {
+			pkDec := json.NewDecoder(bytesReader(c.PKData))
+			pkDec.UseNumber()
+			if err := pkDec.Decode(&pkValues); err != nil {
 				h.resp = append(h.resp, &xfer.ErrorCard{
 					Message: fmt.Sprintf("xdelete %s/%s: bad PKData: %v", c.Table, c.PKHash, err),
 				})
 				return nil
 			}
+			coerceJSONNumbers(pkValues, st.Def)
 			// Insert tombstone row with only PK values (value cols will be NULL).
 			if err := repo.UpsertXRow(h.repo.DB(), c.Table, pkValues, c.MTime); err != nil {
 				return fmt.Errorf("handler.handleXDelete: insert tombstone: %w", err)
@@ -467,3 +476,38 @@ func (h *handler) sendXDelete(table string, st *SyncedTable, pkHash string, mtim
 
 // extractPKColumns is defined in client_tablesync.go as a package-level
 // function shared by both client and handler code.
+
+// bytesReader wraps a byte slice in a bytes.Reader for use with json.NewDecoder.
+func bytesReader(b []byte) *bytes.Reader {
+	return bytes.NewReader(b)
+}
+
+// coerceJSONNumbers converts json.Number values in a row map to native Go types
+// (int64 for "integer" columns, float64 for "real" columns) based on the
+// declared column definitions. This is required after UseNumber decoding to
+// preserve large integers (>2^53) that float64 cannot represent exactly.
+func coerceJSONNumbers(row map[string]any, def repo.TableDef) {
+	for _, col := range def.Columns {
+		v, ok := row[col.Name]
+		if !ok {
+			continue
+		}
+		n, ok := v.(json.Number)
+		if !ok {
+			continue
+		}
+		switch col.Type {
+		case "integer":
+			if i, err := n.Int64(); err == nil {
+				row[col.Name] = i
+			}
+		case "real":
+			if f, err := n.Float64(); err == nil {
+				row[col.Name] = f
+			}
+		default:
+			// text, blob: leave as string representation of the number
+			row[col.Name] = n.String()
+		}
+	}
+}

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -150,6 +150,10 @@ func (h *handler) handleXIGot(c *xfer.XIGotCard) error {
 	// Compare mtimes: if local is newer, push it (or send xdelete if tombstone).
 	if localMtime > c.MTime {
 		if repo.IsTombstone(st.Def, localRow) {
+			// BUGGIFY: 5% chance skip xdelete to test multi-round convergence.
+			if h.buggify != nil && h.buggify.Check("handler.handleXIGot.skipXDelete", 0.05) {
+				return nil
+			}
 			h.sendXDelete(c.Table, st, c.PKHash, localMtime, localRow)
 			return nil
 		}
@@ -452,6 +456,14 @@ func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
 		return nil
 	}
 
+	// BUGGIFY: 3% chance reject a valid xdelete to test client re-push.
+	if h.buggify != nil && h.buggify.Check("handler.handleXDelete.reject", 0.03) {
+		h.resp = append(h.resp, &xfer.ErrorCard{
+			Message: fmt.Sprintf("buggify: rejected xdelete %s/%s", c.Table, c.PKHash),
+		})
+		return nil
+	}
+
 	return applyXDeleteLocally(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime, c.PKData)
 }
 
@@ -477,6 +489,14 @@ func (h *handler) sendXDelete(table string, st *SyncedTable, pkHash string, mtim
 			Message: fmt.Sprintf("xdelete %s/%s: marshal PKData: %v", table, pkHash, err),
 		})
 		return
+	}
+
+	// BUGGIFY: 2% chance corrupt PKData to test receiver error handling.
+	if h.buggify != nil && h.buggify.Check("handler.sendXDelete.corruptPKData", 0.02) && len(pkData) > 0 {
+		corrupted := make([]byte, len(pkData))
+		copy(corrupted, pkData)
+		corrupted[0] = '!'
+		pkData = corrupted
 	}
 
 	h.resp = append(h.resp, &xfer.XDeleteCard{

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -244,11 +244,12 @@ func (h *handler) verifyXRowPKHash(c *xfer.XRowCard, st *SyncedTable) (map[strin
 	}
 
 	pkCols := extractPKColumns(st.Def)
+	pkColDefs := extractPKColumnDefs(st.Def)
 	pkValues := make(map[string]any)
 	for _, col := range pkCols {
 		pkValues[col] = row[col]
 	}
-	computedPK := repo.PKHash(pkValues)
+	computedPK := repo.PKHash(pkColDefs, pkValues)
 	if computedPK != c.PKHash {
 		h.resp = append(h.resp, &xfer.ErrorCard{
 			Message: fmt.Sprintf("xrow %s/%s: pk hash mismatch", c.Table, c.PKHash),
@@ -373,13 +374,14 @@ func (h *handler) emitXIGotsForTable(table string, st *SyncedTable) error {
 	}
 
 	pkCols := extractPKColumns(st.Def)
+	pkColDefs := extractPKColumnDefs(st.Def)
 
 	for i, row := range rows {
 		pkValues := make(map[string]any)
 		for _, col := range pkCols {
 			pkValues[col] = row[col]
 		}
-		pkHash := repo.PKHash(pkValues)
+		pkHash := repo.PKHash(pkColDefs, pkValues)
 
 		h.resp = append(h.resp, &xfer.XIGotCard{
 			Table:  table,

--- a/go-libfossil/sync/handler_tablesync.go
+++ b/go-libfossil/sync/handler_tablesync.go
@@ -464,6 +464,18 @@ func (h *handler) handleXDelete(c *xfer.XDeleteCard) error {
 		return nil
 	}
 
+	// Conflict resolution: check ownership for self-write/owner-write tables.
+	if st.Def.Conflict == "self-write" || st.Def.Conflict == "owner-write" {
+		localOwner, err := repo.LookupXRowOwner(h.repo.DB(), c.Table, st.Def, c.PKHash)
+		if err != nil {
+			return fmt.Errorf("handler.handleXDelete: lookup owner %s/%s: %w", c.Table, c.PKHash, err)
+		}
+		if localOwner != "" && localOwner != h.user {
+			// Not the owner — reject deletion silently.
+			return nil
+		}
+	}
+
 	return applyXDeleteLocally(h.repo.DB(), c.Table, st.Def, c.PKHash, c.MTime, c.PKData)
 }
 

--- a/go-libfossil/sync/handler_tablesync_test.go
+++ b/go-libfossil/sync/handler_tablesync_test.go
@@ -71,3 +71,105 @@ func TestHandleXIGotXGimmeXRow(t *testing.T) {
 		t.Fatal("expected xigot for local row")
 	}
 }
+
+func TestHandleXDelete(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "val", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	repo.EnsureSyncSchema(r.DB())
+	repo.RegisterSyncedTable(r.DB(), "kv", def, 100)
+	// Seed a live row at mtime 1000.
+	if err := repo.UpsertXRow(r.DB(), "kv", map[string]any{"id": "row1", "val": "hello"}, 1000); err != nil {
+		t.Fatalf("UpsertXRow: %v", err)
+	}
+
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "row1"})
+
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.XDeleteCard{
+			Table:  "kv",
+			PKHash: pkHash,
+			MTime:  2000,
+			PKData: []byte(`{"id":"row1"}`),
+		},
+	}}
+	_, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Verify the row is now a tombstone with mtime 2000.
+	row, mtime, err := repo.LookupXRow(r.DB(), "kv", def, pkHash)
+	if err != nil {
+		t.Fatalf("LookupXRow: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected tombstone row, got nil")
+	}
+	if !repo.IsTombstone(def, row) {
+		t.Fatalf("expected tombstone, got row with val=%v", row["val"])
+	}
+	if mtime != 2000 {
+		t.Fatalf("expected mtime=2000, got %d", mtime)
+	}
+}
+
+func TestHandleXIGotEmitsXDeleteForTombstone(t *testing.T) {
+	r := setupSyncTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "val", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	repo.EnsureSyncSchema(r.DB())
+	repo.RegisterSyncedTable(r.DB(), "kv", def, 100)
+	// Seed a live row, then tombstone it at mtime 2000.
+	if err := repo.UpsertXRow(r.DB(), "kv", map[string]any{"id": "row1", "val": "hello"}, 1000); err != nil {
+		t.Fatalf("UpsertXRow: %v", err)
+	}
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"id": "row1"})
+	if _, err := repo.DeleteXRowByPKHash(r.DB(), "kv", def, pkHash, 2000); err != nil {
+		t.Fatalf("DeleteXRowByPKHash: %v", err)
+	}
+
+	// Client claims it has the row at old mtime 1000.
+	req := &xfer.Message{Cards: []xfer.Card{
+		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},
+		&xfer.XIGotCard{Table: "kv", PKHash: pkHash, MTime: 1000},
+	}}
+	resp, err := HandleSync(context.Background(), r, req)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Response must contain an XDeleteCard (not an XRowCard) for this pkHash.
+	xdeletes := findCards[*xfer.XDeleteCard](resp)
+	if len(xdeletes) == 0 {
+		t.Fatal("expected xdelete card in response for tombstoned row")
+	}
+	found := false
+	for _, xd := range xdeletes {
+		if xd.Table == "kv" && xd.PKHash == pkHash {
+			found = true
+			if xd.MTime != 2000 {
+				t.Errorf("xdelete mtime = %d, want 2000", xd.MTime)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected xdelete for pkHash %q, got: %+v", pkHash, xdeletes)
+	}
+	// Must NOT contain an XRowCard for the same pkHash.
+	xrows := findCards[*xfer.XRowCard](resp)
+	for _, xr := range xrows {
+		if xr.Table == "kv" && xr.PKHash == pkHash {
+			t.Fatalf("unexpected xrow card for tombstoned row %q", pkHash)
+		}
+	}
+}

--- a/go-libfossil/sync/handler_tablesync_test.go
+++ b/go-libfossil/sync/handler_tablesync_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/dmestas/edgesync/go-libfossil/auth"
 	"github.com/dmestas/edgesync/go-libfossil/repo"
 	"github.com/dmestas/edgesync/go-libfossil/xfer"
 )
@@ -171,5 +172,115 @@ func TestHandleXIGotEmitsXDeleteForTombstone(t *testing.T) {
 		if xr.Table == "kv" && xr.PKHash == pkHash {
 			t.Fatalf("unexpected xrow card for tombstoned row %q", pkHash)
 		}
+	}
+}
+
+func TestHandleXDelete_SelfWriteOwnershipCheck(t *testing.T) {
+	serverRepo := setupSyncTestRepo(t)
+	pc := testProjectCode(t, serverRepo.DB())
+
+	// Create users alice (owner) and bob (non-owner) with push+pull caps.
+	if err := auth.CreateUser(serverRepo.DB(), pc, "alice", "alicesecret", "oi"); err != nil {
+		t.Fatalf("CreateUser alice: %v", err)
+	}
+	if err := auth.CreateUser(serverRepo.DB(), pc, "bob", "bobsecret", "oi"); err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "peer_id", Type: "text", PK: true}, {Name: "status", Type: "text"}},
+		Conflict: "self-write",
+	}
+	repo.EnsureSyncSchema(serverRepo.DB())
+	repo.RegisterSyncedTable(serverRepo.DB(), "peers", def, 1000)
+
+	// Insert row owned by "alice".
+	repo.UpsertXRow(serverRepo.DB(), "peers", map[string]any{
+		"peer_id": "alice", "status": "online", "_owner": "alice",
+	}, 1000)
+
+	pkColDefs := []repo.ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, map[string]any{"peer_id": "alice"})
+
+	// "bob" tries to delete alice's row — should be rejected.
+	aliceLoginCard := buildTestLoginCard("alice", "alicesecret", pc, []byte("dummy"))
+	_ = aliceLoginCard // ensure we build both
+	bobLoginCard := buildTestLoginCard("bob", "bobsecret", pc, []byte("dummy"))
+
+	msg := &xfer.Message{
+		Cards: []xfer.Card{
+			bobLoginCard,
+			&xfer.PushCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.XDeleteCard{
+				Table:  "peers",
+				PKHash: pkHash,
+				MTime:  2000,
+				PKData: []byte(`{"peer_id":"alice"}`),
+			},
+		},
+	}
+
+	_, err := HandleSync(context.Background(), serverRepo, msg)
+	if err != nil {
+		t.Fatalf("HandleSync: %v", err)
+	}
+
+	// Row should still be alive — deletion rejected.
+	row, mtime, _ := repo.LookupXRow(serverRepo.DB(), "peers", def, pkHash)
+	if row == nil {
+		t.Fatal("row should still exist")
+	}
+	if repo.IsTombstone(def, row) {
+		t.Error("row should NOT be tombstone — bob is not the owner")
+	}
+	if mtime != 1000 {
+		t.Errorf("mtime should be unchanged: got %d, want 1000", mtime)
+	}
+}
+
+func TestHandleXDelete_PKDataHashMismatch(t *testing.T) {
+	serverRepo := setupSyncTestRepo(t)
+	def := repo.TableDef{
+		Columns:  []repo.ColumnDef{{Name: "id", Type: "text", PK: true}, {Name: "data", Type: "text"}},
+		Conflict: "mtime-wins",
+	}
+	repo.EnsureSyncSchema(serverRepo.DB())
+	repo.RegisterSyncedTable(serverRepo.DB(), "test_tbl", def, 1000)
+
+	// Send xdelete with PKHash for "k1" but PKData for "INJECTED".
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	realHash := repo.PKHash(pkColDefs, map[string]any{"id": "k1"})
+
+	msg := &xfer.Message{
+		Cards: []xfer.Card{
+			&xfer.PushCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.PullCard{ServerCode: "sc", ProjectCode: "pc"},
+			&xfer.XDeleteCard{
+				Table:  "test_tbl",
+				PKHash: realHash,
+				MTime:  2000,
+				PKData: []byte(`{"id":"INJECTED"}`), // Mismatched!
+			},
+		},
+	}
+
+	// applyXDeleteLocally returns an error on hash mismatch — HandleSync propagates it.
+	_, err := HandleSync(context.Background(), serverRepo, msg)
+	if err == nil {
+		t.Fatal("expected error for PKData hash mismatch, got nil")
+	}
+
+	// Should NOT have inserted a tombstone for "INJECTED".
+	injectedHash := repo.PKHash(pkColDefs, map[string]any{"id": "INJECTED"})
+	row, _, _ := repo.LookupXRow(serverRepo.DB(), "test_tbl", def, injectedHash)
+	if row != nil {
+		t.Error("should NOT have inserted tombstone for mismatched PKData")
+	}
+
+	// Should NOT have inserted a tombstone for "k1" either.
+	row2, _, _ := repo.LookupXRow(serverRepo.DB(), "test_tbl", def, realHash)
+	if row2 != nil {
+		t.Error("should NOT have inserted any tombstone for mismatched PKData")
 	}
 }

--- a/go-libfossil/sync/handler_tablesync_test.go
+++ b/go-libfossil/sync/handler_tablesync_test.go
@@ -41,8 +41,9 @@ func TestHandleXIGotXGimmeXRow(t *testing.T) {
 	repo.EnsureSyncSchema(r.DB())
 	repo.RegisterSyncedTable(r.DB(), "kv", def, 100)
 	repo.UpsertXRow(r.DB(), "kv", map[string]any{"id": "local-key", "val": "local-val"}, 200)
-	localPK := repo.PKHash(map[string]any{"id": "local-key"})
-	remotePK := repo.PKHash(map[string]any{"id": "remote-key"})
+	pkColDefs := []repo.ColumnDef{{Name: "id", Type: "text", PK: true}}
+	localPK := repo.PKHash(pkColDefs, map[string]any{"id": "local-key"})
+	remotePK := repo.PKHash(pkColDefs, map[string]any{"id": "remote-key"})
 	req := &xfer.Message{Cards: []xfer.Card{
 		&xfer.PushCard{ServerCode: "s", ProjectCode: "p"},
 		&xfer.PullCard{ServerCode: "s", ProjectCode: "p"},

--- a/go-libfossil/sync/xdelete.go
+++ b/go-libfossil/sync/xdelete.go
@@ -1,0 +1,47 @@
+package sync
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dmestas/edgesync/go-libfossil/db"
+	"github.com/dmestas/edgesync/go-libfossil/repo"
+)
+
+// applyXDeleteLocally applies an xdelete to the local repo. Calls DeleteXRowByPKHash first;
+// if the row doesn't exist, inserts a tombstone from pkData. Returns nil on success.
+func applyXDeleteLocally(d *db.DB, table string, def repo.TableDef, pkHash string, mtime int64, pkData []byte) error {
+	deleted, err := repo.DeleteXRowByPKHash(d, table, def, pkHash, mtime)
+	if err != nil {
+		return fmt.Errorf("applyXDeleteLocally: delete %s/%s: %w", table, pkHash, err)
+	}
+	if deleted {
+		return nil
+	}
+
+	// Row didn't exist or had newer mtime. Check which case.
+	existingRow, _, err := repo.LookupXRow(d, table, def, pkHash)
+	if err != nil {
+		return fmt.Errorf("applyXDeleteLocally: lookup %s/%s: %w", table, pkHash, err)
+	}
+	if existingRow != nil {
+		return nil // Row exists with newer mtime — no-op.
+	}
+
+	// Row doesn't exist. Insert tombstone from PKData.
+	if len(pkData) == 0 {
+		return nil // No PKData — can't create tombstone.
+	}
+	dec := json.NewDecoder(bytes.NewReader(pkData))
+	dec.UseNumber()
+	var pkValues map[string]any
+	if err := dec.Decode(&pkValues); err != nil {
+		return fmt.Errorf("applyXDeleteLocally: decode PKData %s/%s: %w", table, pkHash, err)
+	}
+	coerceJSONNumbers(pkValues, def)
+	if err := repo.UpsertXRow(d, table, pkValues, mtime); err != nil {
+		return fmt.Errorf("applyXDeleteLocally: insert tombstone %s/%s: %w", table, pkHash, err)
+	}
+	return nil
+}

--- a/go-libfossil/sync/xdelete.go
+++ b/go-libfossil/sync/xdelete.go
@@ -40,6 +40,19 @@ func applyXDeleteLocally(d *db.DB, table string, def repo.TableDef, pkHash strin
 		return fmt.Errorf("applyXDeleteLocally: decode PKData %s/%s: %w", table, pkHash, err)
 	}
 	coerceJSONNumbers(pkValues, def)
+
+	// Verify PKData matches declared PKHash.
+	var pkColDefs []repo.ColumnDef
+	for _, col := range def.Columns {
+		if col.PK {
+			pkColDefs = append(pkColDefs, col)
+		}
+	}
+	computedHash := repo.PKHash(pkColDefs, pkValues)
+	if computedHash != pkHash {
+		return fmt.Errorf("applyXDeleteLocally: PKData hash mismatch %s/%s: computed %s", table, pkHash, computedHash)
+	}
+
 	if err := repo.UpsertXRow(d, table, pkValues, mtime); err != nil {
 		return fmt.Errorf("applyXDeleteLocally: insert tombstone %s/%s: %w", table, pkHash, err)
 	}

--- a/go-libfossil/xfer/card.go
+++ b/go-libfossil/xfer/card.go
@@ -31,6 +31,7 @@ const (
 	CardXIGot                      // 21 — xigot (table sync row announcement)
 	CardXGimme                     // 22 — xgimme (table sync row request)
 	CardXRow                       // 23 — xrow (table sync row payload)
+	CardXDelete                    // 24 — xdelete (table sync row deletion)
 )
 
 // Card is the interface implemented by every xfer card type.

--- a/go-libfossil/xfer/card_tablesync.go
+++ b/go-libfossil/xfer/card_tablesync.go
@@ -41,3 +41,14 @@ type XRowCard struct {
 }
 
 func (c *XRowCard) Type() CardType { return CardXRow }
+
+// XDeleteCard marks a table sync row as deleted (tombstone).
+// Wire: xdelete TABLE PK_HASH MTIME SIZE\nJSON_PK_DATA
+type XDeleteCard struct {
+	Table  string
+	PKHash string
+	MTime  int64
+	PKData []byte // JSON-encoded PK column values
+}
+
+func (c *XDeleteCard) Type() CardType { return CardXDelete }

--- a/go-libfossil/xfer/card_tablesync_test.go
+++ b/go-libfossil/xfer/card_tablesync_test.go
@@ -101,6 +101,51 @@ func TestXGimmeCard_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestXDeleteCardType(t *testing.T) {
+	c := &XDeleteCard{Table: "devices", PKHash: "abc123", MTime: 2000, PKData: []byte(`{"device_id":"d1"}`)}
+	if c.Type() != CardXDelete {
+		t.Fatalf("got %v, want CardXDelete", c.Type())
+	}
+}
+
+func TestXDeleteCard_RoundTrip(t *testing.T) {
+	original := &XDeleteCard{
+		Table:  "devices",
+		PKHash: "abc123def456",
+		MTime:  1711300000,
+		PKData: []byte(`{"device_id":"d1"}`),
+	}
+	var buf bytes.Buffer
+	if err := EncodeCard(&buf, original); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	r := bufio.NewReader(&buf)
+	got, err := DecodeCard(r)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	xd, ok := got.(*XDeleteCard)
+	if !ok {
+		t.Fatalf("got %T, want *XDeleteCard", got)
+	}
+	if xd.Table != original.Table || xd.PKHash != original.PKHash || xd.MTime != original.MTime {
+		t.Errorf("fields mismatch: got %+v", xd)
+	}
+	if string(xd.PKData) != string(original.PKData) {
+		t.Errorf("PKData = %q, want %q", xd.PKData, original.PKData)
+	}
+}
+
+func FuzzParseXDelete(f *testing.F) {
+	f.Add("devices abc123 1711300000 18\n{\"device_id\":\"d1\"}\n")
+	f.Add("t a 0 0\n\n")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, input string) {
+		r := bufio.NewReader(bytes.NewReader([]byte("xdelete " + input)))
+		_, _ = DecodeCard(r) // must not panic
+	})
+}
+
 func TestXRowCard_RoundTrip(t *testing.T) {
 	original := &XRowCard{
 		Table: "peer_registry", PKHash: "abc123", MTime: 1711300000,

--- a/go-libfossil/xfer/decode.go
+++ b/go-libfossil/xfer/decode.go
@@ -478,6 +478,10 @@ func parseSchema(r *bufio.Reader, args []string) (Card, error) {
 	if err != nil {
 		return nil, fmt.Errorf("xfer: schema size: %w", err)
 	}
+	const maxSchemaSize = 64 << 20 // 64 MiB — schema payloads should be small JSON.
+	if size < 0 || size > maxSchemaSize {
+		return nil, fmt.Errorf("xfer: schema size out of bounds: %d", size)
+	}
 	content, err := readPayloadWithTrailingNewline(r, size)
 	if err != nil {
 		return nil, fmt.Errorf("xfer: schema payload: %w", err)
@@ -537,6 +541,10 @@ func parseXRow(r *bufio.Reader, args []string) (Card, error) {
 	size, err := strconv.Atoi(args[3])
 	if err != nil {
 		return nil, fmt.Errorf("xfer: xrow size: %w", err)
+	}
+	const maxXRowSize = 64 << 20 // 64 MiB — row payloads should be small JSON.
+	if size < 0 || size > maxXRowSize {
+		return nil, fmt.Errorf("xfer: xrow size out of bounds: %d", size)
 	}
 	content, err := readPayloadWithTrailingNewline(r, size)
 	if err != nil {

--- a/go-libfossil/xfer/decode.go
+++ b/go-libfossil/xfer/decode.go
@@ -142,6 +142,8 @@ func parseLine(r *bufio.Reader, line string) (Card, error) {
 		return parseXGimme(args)
 	case "xrow":
 		return parseXRow(r, args)
+	case "xdelete":
+		return parseXDelete(r, args)
 	default:
 		return &UnknownCard{Command: cmd, Args: args}, nil
 	}
@@ -499,6 +501,29 @@ func parseXGimme(args []string) (Card, error) {
 		return nil, fmt.Errorf("xfer: xgimme requires 2 args, got %d", len(args))
 	}
 	return &XGimmeCard{Table: args[0], PKHash: args[1]}, nil
+}
+
+func parseXDelete(r *bufio.Reader, args []string) (Card, error) {
+	if len(args) != 4 {
+		return nil, fmt.Errorf("xfer: xdelete requires 4 args, got %d", len(args))
+	}
+	mtime, err := strconv.ParseInt(args[2], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete mtime: %w", err)
+	}
+	size, err := strconv.Atoi(args[3])
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete size: %w", err)
+	}
+	const maxXDeleteSize = 64 << 20 // 64 MiB — PK data should be tiny JSON
+	if size < 0 || size > maxXDeleteSize {
+		return nil, fmt.Errorf("xfer: xdelete size out of range: %d", size)
+	}
+	pkData, err := readPayloadWithTrailingNewline(r, size)
+	if err != nil {
+		return nil, fmt.Errorf("xfer: xdelete payload: %w", err)
+	}
+	return &XDeleteCard{Table: args[0], PKHash: args[1], MTime: mtime, PKData: pkData}, nil
 }
 
 func parseXRow(r *bufio.Reader, args []string) (Card, error) {

--- a/go-libfossil/xfer/encode.go
+++ b/go-libfossil/xfer/encode.go
@@ -267,16 +267,34 @@ func encodeSchema(w *bytes.Buffer, c *SchemaCard) error {
 }
 
 func encodeXIGot(w *bytes.Buffer, c *XIGotCard) error {
+	if c.Table == "" {
+		panic("encodeXIGot: Table must not be empty")
+	}
+	if c.PKHash == "" {
+		panic("encodeXIGot: PKHash must not be empty")
+	}
 	fmt.Fprintf(w, "xigot %s %s %d\n", c.Table, c.PKHash, c.MTime)
 	return nil
 }
 
 func encodeXGimme(w *bytes.Buffer, c *XGimmeCard) error {
+	if c.Table == "" {
+		panic("encodeXGimme: Table must not be empty")
+	}
+	if c.PKHash == "" {
+		panic("encodeXGimme: PKHash must not be empty")
+	}
 	fmt.Fprintf(w, "xgimme %s %s\n", c.Table, c.PKHash)
 	return nil
 }
 
 func encodeXRow(w *bytes.Buffer, c *XRowCard) error {
+	if c.Table == "" {
+		panic("encodeXRow: Table must not be empty")
+	}
+	if c.PKHash == "" {
+		panic("encodeXRow: PKHash must not be empty")
+	}
 	fmt.Fprintf(w, "xrow %s %s %d %d\n", c.Table, c.PKHash, c.MTime, len(c.Content))
 	w.Write(c.Content)
 	w.WriteByte('\n')
@@ -284,6 +302,12 @@ func encodeXRow(w *bytes.Buffer, c *XRowCard) error {
 }
 
 func encodeXDelete(w *bytes.Buffer, c *XDeleteCard) error {
+	if c.Table == "" {
+		panic("encodeXDelete: Table must not be empty")
+	}
+	if c.PKHash == "" {
+		panic("encodeXDelete: PKHash must not be empty")
+	}
 	fmt.Fprintf(w, "xdelete %s %s %d %d\n", c.Table, c.PKHash, c.MTime, len(c.PKData))
 	w.Write(c.PKData)
 	w.WriteByte('\n')

--- a/go-libfossil/xfer/encode.go
+++ b/go-libfossil/xfer/encode.go
@@ -63,6 +63,8 @@ func EncodeCard(w *bytes.Buffer, c Card) error {
 		return encodeXGimme(w, v)
 	case *XRowCard:
 		return encodeXRow(w, v)
+	case *XDeleteCard:
+		return encodeXDelete(w, v)
 	case *UnknownCard:
 		return encodeUnknown(w, v)
 	default:
@@ -277,6 +279,13 @@ func encodeXGimme(w *bytes.Buffer, c *XGimmeCard) error {
 func encodeXRow(w *bytes.Buffer, c *XRowCard) error {
 	fmt.Fprintf(w, "xrow %s %s %d %d\n", c.Table, c.PKHash, c.MTime, len(c.Content))
 	w.Write(c.Content)
+	w.WriteByte('\n')
+	return nil
+}
+
+func encodeXDelete(w *bytes.Buffer, c *XDeleteCard) error {
+	fmt.Fprintf(w, "xdelete %s %s %d %d\n", c.Table, c.PKHash, c.MTime, len(c.PKData))
+	w.Write(c.PKData)
 	w.WriteByte('\n')
 	return nil
 }

--- a/leaf/agent/peer_registry_test.go
+++ b/leaf/agent/peer_registry_test.go
@@ -33,7 +33,8 @@ func TestPeerRegistryEnsureAndSeed(t *testing.T) {
 
 	// Verify the row exists
 	pkValues := map[string]any{"peer_id": "test-peer-1"}
-	pkHash := repo.PKHash(pkValues)
+	pkColDefs := []repo.ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, pkValues)
 
 	row, mtime, err := repo.LookupXRow(r.DB(), "peer_registry", peerRegistryDef, pkHash)
 	if err != nil {
@@ -102,7 +103,8 @@ func TestPeerRegistryUpdateAfterSync(t *testing.T) {
 
 	// Verify last_sync was updated
 	pkValues := map[string]any{"peer_id": "test-peer-2"}
-	pkHash := repo.PKHash(pkValues)
+	pkColDefs := []repo.ColumnDef{{Name: "peer_id", Type: "text", PK: true}}
+	pkHash := repo.PKHash(pkColDefs, pkValues)
 
 	row, mtime, err := repo.LookupXRow(r.DB(), "peer_registry", peerRegistryDef, pkHash)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **CDG-168**: Add `xdelete` card type for row deletion in remote schema sync. UV-style in-place tombstones (NULL value columns, mtime preserved). Full conflict resolution for self-write/owner-write tables.
- **CDG-171**: Replace `json.Marshal`-based PK hash with type-aware canonical string normalization. Prevents hash divergence on JSON round-trip (`int64` → `float64` coercion) for integer PKs.

## Changes

### Wire protocol (`xfer/`)
- New `CardXDelete = 24` with `xdelete TABLE PK_HASH MTIME SIZE\nPKDATA` format
- Encoder, decoder, round-trip test, fuzz test with 64 MiB size guard

### Storage (`repo/`)
- `PKHash` now takes `[]ColumnDef` for type-aware normalization (no JSON in hash path)
- `IsTombstone`, `DeleteXRowByPKHash`, `LookupXRowOwner` helpers
- `CatalogHash` excludes tombstones
- Non-PK columns now nullable in extension table DDL

### Sync protocol (`sync/`)
- Server: `handleXDelete` with ownership check, tombstone-aware `handleXIGot` emits xdelete
- Client: `handleXDeleteResponse`, tombstone-aware `buildTableSendCards`
- Shared `applyXDeleteLocally` with PKData hash verification (prevents PK injection)
- `json.Decoder.UseNumber()` + `coerceJSONNumbers` for large integer safety

### TigerStyle hardening
- Assertions on all new functions (2-per-function minimum)
- Bounds checks on `parseXRow`/`parseSchema` (matching `parseXDelete`)
- Wire encoder field validation

### DST coverage
- 3 normal-mode tests: deletion convergence, resurrection, integer PK, composite PK
- 3 adversarial tests (BUGGIFY=true): multi-row delete, delete+update race, delete-unseen-row
- 6 BUGGIFY injection sites in xdelete paths
- `CheckTombstoneConvergence` invariant

## Test plan

- [ ] `go test ./go-libfossil/... -count=1` — all 28 packages pass
- [ ] `go test ./dst/ -count=1` — all DST tests pass (~43s)
- [ ] `make build` — clean build of edgesync, leaf, bridge
- [ ] Fuzz: `go test ./go-libfossil/xfer/ -fuzz FuzzParseXDelete -fuzztime 30s` — no panics

🤖 Generated with [Claude Code](https://claude.com/claude-code)