### PR TITLE
docs: compress xdelete and PK hash decisions into ARDs

### DIFF
--- a/docs/architecture/sync-protocol.md
+++ b/docs/architecture/sync-protocol.md
@@ -63,6 +63,7 @@ Transport listeners (`ServeHTTP`, `ServeNATS`, `ServeP2P` stub) call `HandleFunc
 | `xigot TABLE PK_HASH MTIME` | Both | "I have this row at this version." |
 | `xgimme TABLE PK_HASH` | Both | "Send me this row." |
 | `xrow TABLE PK_HASH MTIME SIZE\nJSON` | Both | Full row payload |
+| `xdelete TABLE PK_HASH MTIME SIZE\nPKDATA` | Both | Row deletion (tombstone). PKData = JSON PK column values for tombstone insertion on peers that never had the row. |
 
 ### Cluster Cards
 
@@ -138,18 +139,24 @@ Client sends `reqconfig` for `project-code`, `project-name`, `server-code`. Serv
 
 ### Remote Schema Sync (Extension Tables)
 
-Generic table sync primitive using `xigot`/`xgimme`/`xrow` exchange pattern (same as UV sync). All extension tables prefixed `x_` to protect Fossil core tables.
+Generic table sync primitive using `xigot`/`xgimme`/`xrow`/`xdelete` exchange pattern (same as UV sync). All extension tables prefixed `x_` to protect Fossil core tables.
 
 **Conflict strategies** (per-table):
-- `self-write`: peer can only write rows where PK matches its identity
-- `mtime-wins`: last mtime wins (any peer can write any row)
-- `owner-write`: row has `_owner` field, only owner can update
+- `self-write`: peer can only write/delete rows where `_owner` matches its identity
+- `mtime-wins`: last mtime wins (any peer can write/delete any row)
+- `owner-write`: row has `_owner` field, only owner can update/delete
 
 **Schema propagation:** `schema` card in control phase creates table on receiving peer. Append-only evolution (ADD COLUMN only). Version monotonically increases; downgrades rejected.
 
-**Short-circuit:** `pragma xtable-hash TABLE HASH` skips exchange when catalog hashes match. Catalog hash = SHA1 of sorted `pk_hash + " " + mtime + "\n"`.
+**Short-circuit:** `pragma xtable-hash TABLE HASH` skips exchange when catalog hashes match. Catalog hash = SHA1 of sorted `pk_hash + " " + mtime + "\n"` for live (non-tombstone) rows only.
 
-**SQL injection protection:** Table/column names validated against `^[a-z_][a-z0-9_]*$`. JSON payloads always parameterized.
+**Row deletion (tombstones):** Following Fossil's UV pattern, deleted rows remain in `x_<table>` with all non-PK value columns set to NULL and mtime updated to the deletion timestamp. Convention: all value columns NULL = tombstone. Tombstones are excluded from catalog hash but included in xigot exchange so deletions propagate. When a peer receives an xdelete for a row it never had, it inserts a tombstone from the PKData payload. PKData hash is verified against PKHash before insertion. Resurrection: an xrow with a newer mtime than the tombstone overwrites the NULLs.
+
+**PK hash:** Type-aware canonical normalization — values normalized to strings by declared column type (`integer` → `strconv.FormatInt`, `text` → as-is, etc.) then SHA1'd. No JSON in the hash path. Ensures determinism across JSON round-trips that coerce `int64` → `float64`.
+
+**Conflict resolution for deletions:** `self-write`/`owner-write` tables check `_owner` before accepting xdelete — only the row owner can delete. `mtime-wins` allows any peer to delete. Same ownership rules as xrow.
+
+**SQL injection protection:** Table/column names validated against `^[a-z_][a-z0-9_]*$`. JSON payloads always parameterized. Non-PK columns are nullable (required for tombstone support); PK columns remain NOT NULL.
 
 ## Private Artifacts
 

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -58,6 +58,8 @@ Uses production constructors (`agent.New()`, `bridge.New()`), real embedded NATS
 2. Content integrity -- byte-identical expanded content (per-repo rid via `content.Expand`)
 3. Liveness -- convergence within timeout after faults heal
 4. No duplicate blobs -- each UUID appears exactly once per repo
+5. Table sync integrity -- PK hashes and mtimes match across peers
+6. Tombstone convergence -- all peers agree on which extension table rows are tombstones
 
 ## BUGGIFY
 
@@ -78,6 +80,11 @@ Goroutine-safe fault injection inside application code. Complements the fault pr
 | `runSync()` | Return early after 1 round | 5% |
 | `handleMessage()` | Respond with empty message | 3% |
 | `buildLoginCard()` | Use wrong nonce | 2% |
+| `handleXDelete.reject` | Reject valid xdelete | 3% |
+| `sendXDelete.corruptPKData` | Corrupt PKData JSON | 2% |
+| `handleXIGot.skipXDelete` | Skip sending xdelete for tombstone | 5% |
+| `handleXDeleteResponse.drop` | Drop received xdelete | 5% |
+| `buildTableSendCards.skipXDelete` | Skip queued xdelete send | 3% |
 
 ## Fossil Interop Tests
 


### PR DESCRIPTION
## Summary

- Update `sync-protocol.md` ARD with xdelete card, tombstone semantics, deletion conflict resolution, type-aware PK hash, nullable columns
- Update `testing-strategy.md` ARD with tombstone convergence invariant and 5 new BUGGIFY sites

Follow-up to #57 — compresses the design spec and plan into the condensed architectural decision records.

## Test plan

- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)