### PR TITLE
spike: NATS-over-iroh P2P transport (EDG-59)

### DIFF
--- a/bridge/bridge/integration_test.go
+++ b/bridge/bridge/integration_test.go
@@ -138,7 +138,7 @@ func TestIntegrationLeafBridgeFossil(t *testing.T) {
 	// 6. Start leaf Agent (repo -> NATS).
 	a, err := leafagent.New(leafagent.Config{
 		RepoPath:     localPath,
-		NATSUrl:      natsURL,
+		NATSUpstream: natsURL,
 		PollInterval: 10 * time.Second, // long interval; we use SyncNow
 		Push:         true,
 		Pull:         true,

--- a/cmd/edgesync/sync_start.go
+++ b/cmd/edgesync/sync_start.go
@@ -27,7 +27,7 @@ func (c *SyncStartCmd) Run(g *cli.Globals) error {
 
 	a, err := agent.New(agent.Config{
 		RepoPath:     g.Repo,
-		NATSUrl:      c.NATSUrl,
+		NATSUpstream: c.NATSUrl,
 		PollInterval: c.PollInterval,
 		Push:         c.Push,
 		Pull:         c.Pull,

--- a/docs/superpowers/plans/2026-04-08-nats-over-iroh.md
+++ b/docs/superpowers/plans/2026-04-08-nats-over-iroh.md
@@ -1,0 +1,995 @@
+# NATS-over-iroh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tunnel NATS leaf node connections over iroh QUIC streams so P2P agents get presence and messaging without central NATS infrastructure.
+
+**Architecture:** The iroh sidecar gains a TCP-to-QUIC tunnel on a new ALPN. Each Go agent runs an embedded NATS server. A `NATSMesh` module owns the lifecycle: start embedded NATS, start sidecar with `--nats-addr`, establish tunnels to peers based on role and EndpointId comparison. The agent connects its NATS client to the local embedded server.
+
+**Tech Stack:** Rust (iroh-sidecar, tokio, axum), Go (nats-server embedded, leaf agent), iroh 0.97
+
+**Target repos:** EdgeSync (`leaf/agent/`, `iroh-sidecar/src/`)
+
+**Spec:** `docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md`
+
+**IMPORTANT:** Do not add any Claude Code co-author attribution to commits. Work on a feature branch, never push directly to main.
+
+---
+
+## File Structure
+
+### Rust (iroh-sidecar)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `iroh-sidecar/src/tunnel.rs` | Bidirectional TCP-QUIC pipe for NATS leaf connections |
+| Modify | `iroh-sidecar/src/acceptor.rs` | ALPN-based dispatch (xfer vs NATS tunnel) |
+| Modify | `iroh-sidecar/src/server.rs` | New endpoint `POST /nats-tunnel/{endpoint_id}` |
+| Modify | `iroh-sidecar/src/main.rs` | New CLI arg `--nats-addr`, register second ALPN, mod tunnel |
+| Modify | `iroh-sidecar/src/endpoint.rs` | Accept multiple ALPNs |
+
+### Go (leaf agent)
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `leaf/agent/nats_mesh.go` | Embedded NATS + tunnel establishment + startup sequencing |
+| Create | `leaf/agent/nats_mesh_test.go` | Unit tests for mesh lifecycle and role logic |
+| Modify | `leaf/agent/config.go` | Add `NATSRole`, rename `NATSUrl` → `NATSUpstream` |
+| Modify | `leaf/agent/agent.go` | Use NATSMesh in lifecycle, simplify syncTargets |
+| Modify | `leaf/agent/sidecar.go` | Accept optional `--nats-addr` arg |
+
+---
+
+### Task 1: Sidecar — TCP tunnel module
+
+**Files:**
+- Create: `iroh-sidecar/src/tunnel.rs`
+
+- [ ] **Step 1: Create the tunnel module**
+
+Create `iroh-sidecar/src/tunnel.rs`:
+
+```rust
+//! Bidirectional TCP ↔ QUIC tunnel for NATS leaf node connections.
+//!
+//! When a remote peer connects on ALPN `/edgesync/nats-leaf/1`, we:
+//!   1. Accept the bidirectional QUIC stream.
+//!   2. Open a TCP connection to the local NATS server.
+//!   3. Pipe bytes bidirectionally until either side closes.
+
+use iroh::endpoint::Connection;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Handle an incoming NATS tunnel connection from a remote peer.
+///
+/// Opens a TCP connection to the local embedded NATS at `nats_addr`,
+/// then pipes bytes between the QUIC stream and the TCP socket.
+pub async fn handle_connection(connection: Connection, nats_addr: String) {
+    let remote_id = connection.remote_id();
+    tracing::info!(%remote_id, "nats tunnel: accepted connection");
+
+    loop {
+        let (send, recv) = match connection.accept_bi().await {
+            Ok(streams) => streams,
+            Err(e) => {
+                tracing::debug!(%remote_id, "nats tunnel: stream accept ended: {e}");
+                break;
+            }
+        };
+
+        let addr = nats_addr.clone();
+        tokio::spawn(async move {
+            if let Err(e) = pipe_stream(send, recv, &addr).await {
+                tracing::warn!("nats tunnel: pipe error: {e:#}");
+            }
+        });
+    }
+}
+
+/// Establish an outbound NATS tunnel to a remote peer.
+///
+/// Opens a QUIC bidirectional stream on the given connection using the
+/// NATS ALPN, then pipes to the local NATS server at `nats_addr`.
+pub async fn establish_outbound(connection: Connection, nats_addr: String) -> anyhow::Result<()> {
+    let remote_id = connection.remote_id();
+    tracing::info!(%remote_id, "nats tunnel: establishing outbound tunnel");
+
+    let (send, recv) = connection.open_bi().await?;
+    pipe_stream(send, recv, &nats_addr).await?;
+
+    Ok(())
+}
+
+async fn pipe_stream(
+    mut quic_send: iroh::endpoint::SendStream,
+    mut quic_recv: iroh::endpoint::RecvStream,
+    nats_addr: &str,
+) -> anyhow::Result<()> {
+    let tcp = TcpStream::connect(nats_addr).await?;
+    let (mut tcp_read, mut tcp_write) = tcp.into_split();
+
+    // Bidirectional pipe: QUIC → TCP and TCP → QUIC run concurrently.
+    let quic_to_tcp = async {
+        let mut buf = vec![0u8; 32 * 1024];
+        loop {
+            let n = match quic_recv.read(&mut buf).await {
+                Ok(Some(n)) => n,
+                Ok(None) => break,     // QUIC stream finished
+                Err(e) => return Err(anyhow::anyhow!("quic read: {e}")),
+            };
+            tcp_write.write_all(&buf[..n]).await?;
+        }
+        tcp_write.shutdown().await?;
+        Ok::<(), anyhow::Error>(())
+    };
+
+    let tcp_to_quic = async {
+        let mut buf = vec![0u8; 32 * 1024];
+        loop {
+            let n = tcp_read.read(&mut buf).await?;
+            if n == 0 {
+                break; // TCP closed
+            }
+            quic_send.write_all(&buf[..n]).await?;
+        }
+        quic_send.finish()?;
+        Ok::<(), anyhow::Error>(())
+    };
+
+    tokio::select! {
+        r = quic_to_tcp => r?,
+        r = tcp_to_quic => r?,
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `iroh-sidecar/src/main.rs`, add at line 1:
+
+```rust
+mod acceptor;
+mod endpoint;
+mod server;
+mod tunnel;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd iroh-sidecar && cargo check`
+
+Expected: Compiles (tunnel is defined but not yet called).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add iroh-sidecar/src/tunnel.rs iroh-sidecar/src/main.rs
+git commit -m "feat(sidecar): add TCP-QUIC tunnel module for NATS leaf connections"
+```
+
+---
+
+### Task 2: Sidecar — ALPN dispatch in acceptor
+
+**Files:**
+- Modify: `iroh-sidecar/src/acceptor.rs`
+- Modify: `iroh-sidecar/src/endpoint.rs`
+- Modify: `iroh-sidecar/src/main.rs`
+
+- [ ] **Step 1: Define ALPN constants in main.rs**
+
+Add constants and pass both ALPNs to the endpoint and acceptor. In `main.rs`, after the `Args` struct:
+
+```rust
+pub const XFER_ALPN: &[u8] = b"/edgesync/xfer/1";
+pub const NATS_ALPN: &[u8] = b"/edgesync/nats-leaf/1";
+```
+
+- [ ] **Step 2: Update endpoint.rs to accept multiple ALPNs**
+
+Change `create_endpoint` to accept a slice of ALPNs:
+
+```rust
+pub async fn create_endpoint(
+    key_path: &Path,
+    alpns: &[&[u8]],
+) -> anyhow::Result<(Endpoint, String)> {
+    let secret_key = load_or_generate_key(key_path).await?;
+    let endpoint_id = secret_key.public().to_string();
+
+    let endpoint = Endpoint::builder(presets::N0)
+        .secret_key(secret_key)
+        .alpns(alpns.iter().map(|a| a.to_vec()).collect())
+        .bind()
+        .await?;
+
+    tracing::info!(%endpoint_id, "iroh endpoint bound");
+    Ok((endpoint, endpoint_id))
+}
+```
+
+- [ ] **Step 3: Update main.rs to register both ALPNs and pass nats_addr**
+
+Add `--nats-addr` CLI arg:
+
+```rust
+#[derive(Parser)]
+#[command(name = "iroh-sidecar", about = "Iroh P2P proxy for EdgeSync")]
+struct Args {
+    #[arg(long)]
+    socket: PathBuf,
+
+    #[arg(long)]
+    key_path: PathBuf,
+
+    #[arg(long)]
+    callback: String,
+
+    #[arg(long, default_value = "/edgesync/xfer/1")]
+    alpn: String,
+
+    /// Local NATS address to tunnel leaf node connections to.
+    /// If omitted, NATS tunneling is disabled.
+    #[arg(long)]
+    nats_addr: Option<String>,
+}
+```
+
+Update the endpoint creation call:
+
+```rust
+let alpns: Vec<&[u8]> = if args.nats_addr.is_some() {
+    vec![args.alpn.as_bytes(), NATS_ALPN]
+} else {
+    vec![args.alpn.as_bytes()]
+};
+
+let (ep, endpoint_id) = endpoint::create_endpoint(&args.key_path, &alpns).await?;
+```
+
+Pass `nats_addr` to the accept loop:
+
+```rust
+let nats_addr = args.nats_addr.clone();
+let accept_handle = tokio::spawn(async move {
+    acceptor::run_accept_loop(accept_ep, callback_url, nats_addr).await;
+});
+```
+
+- [ ] **Step 4: Update acceptor.rs to dispatch by ALPN**
+
+Change `run_accept_loop` signature to accept `nats_addr`:
+
+```rust
+pub async fn run_accept_loop(
+    endpoint: Endpoint,
+    callback_url: String,
+    nats_addr: Option<String>,
+) {
+```
+
+In `handle_incoming`, dispatch based on ALPN. The connection's ALPN is available via `connection.alpn()`:
+
+```rust
+async fn handle_incoming(
+    incoming: iroh::endpoint::Incoming,
+    client: reqwest::Client,
+    callback_url: String,
+    nats_addr: Option<String>,
+) -> anyhow::Result<()> {
+    let connection = incoming.accept()?.await?;
+    let remote_id = connection.remote_id();
+    let alpn = connection.alpn();
+    tracing::info!(%remote_id, alpn = %String::from_utf8_lossy(&alpn), "accepted incoming connection");
+
+    if alpn == crate::NATS_ALPN {
+        if let Some(addr) = nats_addr {
+            crate::tunnel::handle_connection(connection, addr).await;
+        } else {
+            tracing::warn!(%remote_id, "NATS tunnel connection received but --nats-addr not configured");
+        }
+        return Ok(());
+    }
+
+    // Existing xfer handling (unchanged from here down)
+    let mut stream_tasks = JoinSet::new();
+    loop {
+        let (mut send, mut recv) = match connection.accept_bi().await {
+            Ok(streams) => streams,
+            Err(e) => {
+                tracing::debug!(%remote_id, "stream accept ended: {e}");
+                break;
+            }
+        };
+        let client = client.clone();
+        let callback_url = callback_url.clone();
+        stream_tasks.spawn(async move {
+            if let Err(e) = handle_stream(&mut send, &mut recv, &client, &callback_url, remote_id).await {
+                tracing::warn!(%remote_id, "stream handler error: {e:#}");
+            }
+        });
+    }
+    while let Some(result) = stream_tasks.join_next().await {
+        if let Err(e) = result {
+            tracing::warn!(%remote_id, "stream task panicked: {e:#}");
+        }
+    }
+    Ok(())
+}
+```
+
+Update the `tasks.spawn` call in `run_accept_loop` to pass `nats_addr`:
+
+```rust
+tasks.spawn(async move {
+    if let Err(e) = handle_incoming(incoming, client, callback_url, nats_addr).await {
+        tracing::warn!("accept loop: error handling incoming connection: {e:#}");
+    }
+});
+```
+
+(Note: `nats_addr` needs to be cloned per iteration since it's moved into the spawned task.)
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd iroh-sidecar && cargo check`
+
+Expected: Compiles. Existing behavior unchanged when `--nats-addr` is not provided.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add iroh-sidecar/src/
+git commit -m "feat(sidecar): ALPN dispatch — route xfer and NATS tunnel connections separately"
+```
+
+---
+
+### Task 3: Sidecar — outbound tunnel HTTP endpoint
+
+**Files:**
+- Modify: `iroh-sidecar/src/server.rs`
+
+- [ ] **Step 1: Add nats_addr to AppState**
+
+In `server.rs`, add a field to `AppState`:
+
+```rust
+pub struct AppState {
+    pub endpoint: Endpoint,
+    pub endpoint_id: String,
+    pub alpn: Vec<u8>,
+    pub nats_addr: Option<String>,  // NEW
+    pub conn_cache: Arc<Mutex<HashMap<String, Connection>>>,
+    pub shutdown_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+}
+```
+
+Update the constructor:
+
+```rust
+pub fn new(
+    endpoint: Endpoint,
+    endpoint_id: String,
+    alpn: Vec<u8>,
+    nats_addr: Option<String>,
+    shutdown_tx: oneshot::Sender<()>,
+) -> Self {
+    AppState {
+        endpoint,
+        endpoint_id,
+        alpn,
+        nats_addr,
+        conn_cache: Arc::new(Mutex::new(HashMap::new())),
+        shutdown_tx: Arc::new(Mutex::new(Some(shutdown_tx))),
+    }
+}
+```
+
+- [ ] **Step 2: Add the route and handler**
+
+Add route to `build_router`:
+
+```rust
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/exchange/{endpoint_id}", post(handle_exchange))
+        .route("/nats-tunnel/{endpoint_id}", post(handle_nats_tunnel))
+        .route("/status", get(handle_status))
+        .route("/shutdown", post(handle_shutdown))
+        .with_state(state)
+}
+```
+
+Add the handler:
+
+```rust
+/// POST /nats-tunnel/{endpoint-id}
+///
+/// Establish a long-lived NATS tunnel to a remote peer. Opens a QUIC
+/// connection on the NATS ALPN and pipes bytes to the local NATS server.
+/// Returns 200 immediately; the tunnel runs in a background task.
+async fn handle_nats_tunnel(
+    State(state): State<AppState>,
+    Path(remote_id_str): Path<String>,
+) -> Result<Response, AppError> {
+    let nats_addr = state.nats_addr.as_ref()
+        .ok_or_else(|| AppError::bad_request("NATS tunneling not configured (no --nats-addr)"))?
+        .clone();
+
+    let remote_id = EndpointId::from_str(&remote_id_str)
+        .map_err(|e| AppError::bad_request(format!("invalid endpoint id: {e}")))?;
+
+    // Connect to remote peer on the NATS ALPN.
+    let nats_alpn = crate::NATS_ALPN.to_vec();
+    let addr: EndpointAddr = remote_id.into();
+    let conn = state.endpoint.connect(addr, &nats_alpn)
+        .await
+        .map_err(AppError::internal)?;
+
+    tracing::info!(remote = %remote_id_str, "nats tunnel: established outbound connection");
+
+    // Spawn the tunnel in the background — it runs until either side closes.
+    tokio::spawn(async move {
+        if let Err(e) = crate::tunnel::establish_outbound(conn, nats_addr).await {
+            tracing::warn!(remote = %remote_id_str, "nats tunnel: outbound ended: {e:#}");
+        }
+    });
+
+    Ok(StatusCode::OK.into_response())
+}
+```
+
+- [ ] **Step 3: Update main.rs to pass nats_addr to AppState**
+
+In `main.rs`:
+
+```rust
+let state = server::AppState::new(
+    ep.clone(),
+    endpoint_id,
+    args.alpn.as_bytes().to_vec(),
+    args.nats_addr.clone(),
+    shutdown_tx,
+);
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd iroh-sidecar && cargo check`
+
+- [ ] **Step 5: Build the sidecar**
+
+Run: `cd iroh-sidecar && cargo build`
+
+Expected: Successful build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add iroh-sidecar/src/
+git commit -m "feat(sidecar): add POST /nats-tunnel endpoint for outbound NATS tunnels"
+```
+
+---
+
+### Task 4: Go — Config changes
+
+**Files:**
+- Modify: `leaf/agent/config.go`
+
+- [ ] **Step 1: Add NATSRole and rename NATSUrl**
+
+In `config.go`, add the `NATSRole` type and field, rename `NATSUrl`:
+
+```go
+// NATSRole determines how the embedded NATS server participates in the mesh.
+type NATSRole string
+
+const (
+	// NATSRolePeer is the default. Accepts and solicits leaf connections
+	// based on EndpointId comparison (lower ID solicits).
+	NATSRolePeer NATSRole = "peer"
+
+	// NATSRoleHub only accepts leaf connections, never solicits.
+	// Use for dedicated servers or cluster nodes.
+	NATSRoleHub NATSRole = "hub"
+
+	// NATSRoleLeaf always solicits outward, never accepts.
+	// Use for WASM browsers or lightweight clients.
+	NATSRoleLeaf NATSRole = "leaf"
+)
+```
+
+In the `Config` struct, rename `NATSUrl` to `NATSUpstream` and add `NATSRole`:
+
+```go
+	// NATSRole determines mesh topology (default "peer").
+	NATSRole NATSRole
+
+	// NATSUpstream is an optional external NATS server URL.
+	// If set, the embedded NATS joins it as a leaf node.
+	// Replaces the old NATSUrl field.
+	NATSUpstream string
+```
+
+Remove or comment the old `NATSUrl` field. Update `applyDefaults()`:
+
+```go
+func (c *Config) applyDefaults() {
+	// NATSUrl default removed — embedded NATS replaces it.
+	if c.NATSRole == "" {
+		c.NATSRole = NATSRolePeer
+	}
+	// ... rest unchanged ...
+}
+```
+
+Update `validate()` to check NATSRole:
+
+```go
+func (c *Config) validate() error {
+	if c.RepoPath == "" {
+		return errors.New("agent: config: RepoPath is required")
+	}
+	switch c.NATSRole {
+	case NATSRolePeer, NATSRoleHub, NATSRoleLeaf:
+		// valid
+	default:
+		return fmt.Errorf("agent: config: invalid NATSRole %q (must be peer, hub, or leaf)", c.NATSRole)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Fix all references to NATSUrl**
+
+Search for `NATSUrl` across the leaf module and update to `NATSUpstream`. Key files: `agent.go`, `nats.go`, `cmd/leaf/main.go`.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd leaf && go build ./...`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add leaf/
+git commit -m "feat(agent): add NATSRole config, rename NATSUrl to NATSUpstream"
+```
+
+---
+
+### Task 5: Go — NATSMesh module
+
+**Files:**
+- Create: `leaf/agent/nats_mesh.go`
+- Create: `leaf/agent/nats_mesh_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Create `leaf/agent/nats_mesh_test.go`:
+
+```go
+package agent
+
+import (
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+func TestNATSMeshStartStop(t *testing.T) {
+	mesh := &NATSMesh{
+		role: NATSRolePeer,
+	}
+	clientURL, err := mesh.Start()
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mesh.Stop()
+
+	if clientURL == "" {
+		t.Fatal("clientURL is empty")
+	}
+
+	// Verify we can connect and publish.
+	nc, err := nats.Connect(clientURL, nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	if err := nc.Publish("test.subject", []byte("hello")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	nc.Flush()
+	t.Logf("mesh started at %s, publish OK", clientURL)
+}
+
+func TestNATSMeshRoleLeafPort(t *testing.T) {
+	// peer/hub should have a leaf node port; leaf should not.
+	for _, role := range []NATSRole{NATSRolePeer, NATSRoleHub, NATSRoleLeaf} {
+		t.Run(string(role), func(t *testing.T) {
+			mesh := &NATSMesh{role: role}
+			opts := mesh.buildServerOpts()
+
+			if role == NATSRoleLeaf {
+				if opts.LeafNode.Port != 0 {
+					t.Errorf("leaf role should not set LeafNode.Port, got %d", opts.LeafNode.Port)
+				}
+			} else {
+				if opts.LeafNode.Port != -1 {
+					t.Errorf("%s role should set LeafNode.Port to -1 (random), got %d", role, opts.LeafNode.Port)
+				}
+			}
+		})
+	}
+}
+
+func TestTunnelShouldSolicit(t *testing.T) {
+	tests := []struct {
+		role     NATSRole
+		myID     string
+		peerID   string
+		expected bool
+	}{
+		{NATSRoleLeaf, "zzz", "aaa", true},   // leaf always solicits
+		{NATSRoleHub, "aaa", "zzz", false},    // hub never solicits
+		{NATSRolePeer, "aaa", "zzz", true},    // lower ID solicits
+		{NATSRolePeer, "zzz", "aaa", false},   // higher ID waits
+		{NATSRolePeer, "aaa", "aaa", false},   // same ID (shouldn't happen) — don't solicit
+	}
+	for _, tt := range tests {
+		name := string(tt.role) + "_" + tt.myID + "_vs_" + tt.peerID
+		t.Run(name, func(t *testing.T) {
+			got := shouldSolicit(tt.role, tt.myID, tt.peerID)
+			if got != tt.expected {
+				t.Errorf("shouldSolicit(%s, %s, %s) = %v, want %v",
+					tt.role, tt.myID, tt.peerID, got, tt.expected)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Write the implementation**
+
+Create `leaf/agent/nats_mesh.go`:
+
+```go
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+)
+
+// NATSMesh owns the embedded NATS server and tunnel establishment lifecycle.
+// It encapsulates startup ordering: embedded NATS → sidecar → tunnels.
+type NATSMesh struct {
+	role         NATSRole
+	upstream     string    // optional external NATS URL
+	irohPeers    []string  // remote EndpointIds
+	endpointID   string    // our iroh EndpointId (set after sidecar starts)
+	sidecar      *sidecar  // nil if iroh disabled
+
+	server       *natsserver.Server
+	clientURL    string    // nats://127.0.0.1:<client-port>
+	leafAddr     string    // 127.0.0.1:<leaf-port> (for sidecar --nats-addr)
+}
+
+// Start brings up the embedded NATS server and, if a sidecar is configured,
+// starts it with --nats-addr and establishes tunnels to peers.
+// Returns the NATS client URL for the agent to connect to.
+func (m *NATSMesh) Start() (clientURL string, err error) {
+	// 1. Start embedded NATS.
+	opts := m.buildServerOpts()
+	m.server, err = natsserver.NewServer(opts)
+	if err != nil {
+		return "", fmt.Errorf("nats mesh: create server: %w", err)
+	}
+	m.server.Start()
+	if !m.server.ReadyForConnections(5 * time.Second) {
+		m.server.Shutdown()
+		return "", fmt.Errorf("nats mesh: server not ready within 5s")
+	}
+
+	m.clientURL = m.server.ClientURL()
+	m.leafAddr = fmt.Sprintf("127.0.0.1:%d", opts.LeafNode.Port)
+
+	// 2. Start sidecar with --nats-addr (if iroh enabled).
+	if m.sidecar != nil && m.leafAddr != "" && m.role != NATSRoleLeaf {
+		// For peer/hub, sidecar needs the leaf node port for incoming tunnels.
+		// Sidecar startup is handled by the agent — we just record the addr.
+	}
+
+	// 3. Establish tunnels (if sidecar is ready and peers are known).
+	if m.sidecar != nil && m.endpointID != "" {
+		if err := m.establishTunnels(); err != nil {
+			// Non-fatal — tunnels can be retried.
+			// Log but don't fail startup.
+			fmt.Printf("nats mesh: tunnel establishment: %v\n", err)
+		}
+	}
+
+	return m.clientURL, nil
+}
+
+// Stop shuts down tunnels, sidecar, and embedded NATS.
+func (m *NATSMesh) Stop() {
+	if m.server != nil {
+		m.server.Shutdown()
+		m.server.WaitForShutdown()
+		m.server = nil
+	}
+}
+
+// LeafAddr returns the leaf node listen address for the sidecar's --nats-addr.
+// Empty if role is "leaf" (no leaf port).
+func (m *NATSMesh) LeafAddr() string {
+	return m.leafAddr
+}
+
+// SetEndpointID is called after the sidecar starts and reports its EndpointId.
+func (m *NATSMesh) SetEndpointID(id string) {
+	m.endpointID = id
+}
+
+// SetSidecar provides the sidecar reference for tunnel establishment.
+func (m *NATSMesh) SetSidecar(s *sidecar) {
+	m.sidecar = s
+}
+
+// buildServerOpts creates nats-server options based on role.
+func (m *NATSMesh) buildServerOpts() *natsserver.Options {
+	opts := &natsserver.Options{
+		Host:   "127.0.0.1",
+		Port:   -1, // random client port
+		NoLog:  true,
+		NoSigs: true,
+	}
+
+	switch m.role {
+	case NATSRolePeer, NATSRoleHub:
+		opts.LeafNode.Port = -1 // random leaf node port
+	case NATSRoleLeaf:
+		// No leaf port — this node solicits outward only.
+	}
+
+	// If upstream NATS URL is configured, join as a leaf.
+	if m.upstream != "" {
+		opts.LeafNode.Remotes = []*natsserver.RemoteLeafOpts{
+			{URLs: []*natsserver.URL{{URL: m.upstream}}},
+		}
+	}
+
+	return opts
+}
+
+// establishTunnels tells the sidecar to open NATS tunnels to peers
+// based on role and EndpointId comparison.
+func (m *NATSMesh) establishTunnels() error {
+	if m.sidecar == nil {
+		return nil
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: sidecarDialer(m.sidecar.socketPath),
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	for _, peerID := range m.irohPeers {
+		if !shouldSolicit(m.role, m.endpointID, peerID) {
+			continue
+		}
+
+		url := fmt.Sprintf("http://iroh-sidecar/nats-tunnel/%s", peerID)
+		resp, err := client.Post(url, "", nil)
+		if err != nil {
+			return fmt.Errorf("tunnel to %s: %w", peerID[:12], err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("tunnel to %s: HTTP %d", peerID[:12], resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+// shouldSolicit determines whether we should initiate a NATS tunnel to a peer.
+func shouldSolicit(role NATSRole, myID, peerID string) bool {
+	switch role {
+	case NATSRoleLeaf:
+		return true // always solicit outward
+	case NATSRoleHub:
+		return false // never solicit
+	case NATSRolePeer:
+		return myID < peerID // lower ID solicits
+	default:
+		return false
+	}
+}
+```
+
+Note: `sidecarDialer` is a helper that returns a `DialContext` func for the Unix socket. Check if this already exists in `sidecar.go` — if so, extract and reuse. If not, define it:
+
+```go
+func sidecarDialer(socketPath string) func(ctx context.Context, _, _ string) (net.Conn, error) {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return net.Dial("unix", socketPath)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd leaf && go test ./agent/ -run TestNATSMesh -v -count=1`
+Run: `cd leaf && go test ./agent/ -run TestTunnelShouldSolicit -v -count=1`
+
+Expected: All PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add leaf/agent/nats_mesh.go leaf/agent/nats_mesh_test.go
+git commit -m "feat(agent): add NATSMesh module — embedded NATS + tunnel establishment"
+```
+
+---
+
+### Task 6: Go — Wire NATSMesh into agent lifecycle
+
+**Files:**
+- Modify: `leaf/agent/agent.go`
+- Modify: `leaf/agent/sidecar.go`
+
+- [ ] **Step 1: Add mesh field to Agent**
+
+In `agent.go`, add the mesh to the Agent struct and update `Start()`:
+
+The agent's `Start()` should:
+1. Create NATSMesh with config
+2. Call `mesh.Start()` to get clientURL
+3. Connect NATS client to clientURL (instead of `cfg.NATSUpstream`)
+4. If iroh enabled: start sidecar with `--nats-addr mesh.LeafAddr()`
+5. After sidecar ready: `mesh.SetEndpointID(status.EndpointID)` + `mesh.SetSidecar(sidecar)` + `mesh.establishTunnels()`
+6. Continue with ServeNATS, HTTP, poll loop as before
+
+- [ ] **Step 2: Update sidecar.go to accept natsAddr**
+
+Add `natsAddr` field to the `sidecar` struct:
+
+```go
+type sidecar struct {
+	binPath     string
+	socketPath  string
+	keyPath     string
+	callbackURL string
+	alpn        string
+	natsAddr    string // NEW: optional, for --nats-addr
+	cmd         *exec.Cmd
+	exited      chan struct{}
+	exitErr     error
+}
+```
+
+In `spawn()`, conditionally add the flag:
+
+```go
+args := []string{
+	"--socket", s.socketPath,
+	"--key-path", s.keyPath,
+	"--callback", s.callbackURL,
+	"--alpn", s.alpn,
+}
+if s.natsAddr != "" {
+	args = append(args, "--nats-addr", s.natsAddr)
+}
+s.cmd = exec.Command(s.binPath, args...)
+```
+
+- [ ] **Step 3: Update syncTargets in agent.go**
+
+When NATSMesh is active, the agent should use a single NATSTransport connected to the mesh's clientURL instead of separate NATS + iroh targets. The iroh peers are now reached via NATS leaf node routing through the tunnel.
+
+Keep `IrohTransport` targets as a fallback for backwards compat with peers that don't have embedded NATS.
+
+- [ ] **Step 4: Run agent tests**
+
+Run: `cd leaf && go test ./agent/ -v -count=1 -timeout=60s`
+
+Expected: All existing tests PASS. New mesh tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add leaf/agent/
+git commit -m "feat(agent): wire NATSMesh into agent lifecycle"
+```
+
+---
+
+### Task 7: Integration test — P2P sync over NATS-over-iroh
+
+**Files:**
+- Create: `sim/nats_iroh_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+This test requires two iroh sidecars. It follows the pattern of `sim/iroh_test.go`:
+
+```go
+func TestNATSOverIrohSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS-over-iroh integration test in short mode")
+	}
+	findIrohSidecar(t) // skip if binary not found
+
+	dir := t.TempDir()
+	projCode := "abcdef0123456789abcdef0123456789abcdef01"
+	srvCode := "fedcba9876543210fedcba9876543210fedcba98"
+
+	// 1. Create two repos.
+	// 2. Seed blobs into repo 0.
+	// 3. Start two agents with NATSRole=peer, IrohEnabled=true, no NATSUpstream.
+	//    Each agent uses NATSMesh (embedded NATS + sidecar).
+	// 4. Exchange EndpointIds, configure peers, establish tunnels.
+	// 5. Trigger sync on both agents.
+	// 6. Verify convergence: repo 1 has all blobs from repo 0.
+}
+```
+
+The full test will closely mirror `TestIrohConvergence` but with NATS-over-iroh tunnels instead of direct IrohTransport.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd sim && go test -run TestNATSOverIrohSync -v -count=1 -timeout=120s`
+
+Expected: PASS — blobs sync from agent 0 to agent 1 via embedded NATS over iroh tunnels.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sim/nats_iroh_test.go
+git commit -m "test: integration test for P2P sync over NATS-over-iroh (EDG-59)"
+```
+
+---
+
+### Task 8: Full test suite verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build sidecar**
+
+Run: `cd iroh-sidecar && cargo build`
+
+Expected: Successful.
+
+- [ ] **Step 2: Run leaf agent tests**
+
+Run: `cd leaf && go test ./... -v -count=1 -timeout=60s`
+
+Expected: All PASS.
+
+- [ ] **Step 3: Run sim tests (non-short)**
+
+Run: `go test ./sim/ -v -count=1 -timeout=120s`
+
+Expected: All PASS (iroh tests skip if sidecar binary not present).
+
+- [ ] **Step 4: Run EdgeSync full suite**
+
+Run: `make test`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
+++ b/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
@@ -1,0 +1,221 @@
+# NATS-over-iroh: P2P Presence and Messaging
+
+**Date:** 2026-04-08
+**Target repo:** EdgeSync (agent + sidecar), no go-libfossil changes
+**Linear:** EDG-59
+
+## Problem
+
+Iroh P2P transport today is sync-only — two peers exchange xfer payloads via HTTP through the sidecar. No presence, no broadcast, no peer discovery, no messaging. NATS provides all of these, but requires central infrastructure.
+
+Running NATS leaf node connections over iroh QUIC streams combines iroh's NAT traversal with NATS's pub/sub, presence, and messaging. The agent already speaks NATS — no new application protocol needed.
+
+## Design Decisions
+
+**Embedded NATS always runs.** Every agent starts an in-process NATS server. If `--nats` URL is also provided, the embedded server joins external NATS as a leaf node. This unifies the architecture: the agent always connects to its local embedded NATS, regardless of whether peers are reached via iroh tunnels, external NATS, or both.
+
+**Sidecar is a dumb TCP pipe.** The iroh sidecar gains a new ALPN (`/edgesync/nats-leaf/1`) and a TCP-to-QUIC tunnel. It has zero NATS protocol awareness — it pipes bytes between a local TCP socket (embedded NATS) and an iroh QUIC bidirectional stream. This supports the full NATS feature set: leaf node handshake, subscriptions, pub/sub, JetStream, etc.
+
+**Role-based topology.** Each agent declares a NATS role that determines connection direction:
+
+| Role | Accepts leaf connections | Solicits leaf connections | Use case |
+|------|------------------------|--------------------------|----------|
+| `peer` (default) | Yes | Yes (lower EndpointId solicits) | Native P2P mesh |
+| `hub` | Yes | No | Dedicated server, cluster node |
+| `leaf` | No | Yes (always solicits outward) | WASM browser, lightweight client |
+
+When both sides are `peer`, the one with the lexicographically lower iroh EndpointId initiates the tunnel. This prevents duplicate connections deterministically with no negotiation.
+
+**No changes to iroh upstream.** All Rust changes are in the EdgeSync-owned `iroh-sidecar/` binary. iroh is used as a library dependency only.
+
+## Iroh Sidecar Changes
+
+New module: `iroh-sidecar/src/tunnel.rs`
+
+### New ALPN
+
+`/edgesync/nats-leaf/1` registered alongside existing `/edgesync/xfer/1` at endpoint creation. The acceptor dispatches by ALPN — xfer connections go to the existing callback handler, NATS connections go to the tunnel handler.
+
+### New CLI arg
+
+`--nats-addr <host:port>` — address of the local embedded NATS leaf node port. If omitted, NATS tunneling is disabled (backwards compatible). Passed by the Go agent after starting the embedded NATS server.
+
+### Inbound tunnel (peer connects to us)
+
+1. Acceptor receives QUIC connection, matches NATS ALPN
+2. `tunnel::handle_stream(stream, nats_addr)` opens TCP to local NATS
+3. Spawns two tasks: QUIC read → TCP write, TCP read → QUIC write
+4. Both run until either side closes or errors
+5. Cleanup: close both sides on any error
+
+### Outbound tunnel (we connect to peer)
+
+New HTTP endpoint: `POST /nats-tunnel/{endpoint_id}`
+
+1. Opens QUIC connection to remote peer (reuses connection cache) on NATS ALPN
+2. Opens bidirectional stream
+3. Opens TCP connection to local NATS (`nats_addr`)
+4. Same bidirectional pipe as inbound
+5. Returns 200 once tunnel is established
+6. Tunnel is long-lived — runs in a spawned task, not blocking the HTTP response
+
+### Acceptor dispatch
+
+Modify `acceptor.rs` to match ALPN:
+
+```rust
+let alpn = connection.alpn();
+if alpn == XFER_ALPN {
+    // existing xfer callback handler
+} else if alpn == NATS_ALPN {
+    tunnel::handle_connection(connection, nats_addr).await;
+} else {
+    // unknown ALPN, close connection
+}
+```
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `iroh-sidecar/src/tunnel.rs` | New — bidirectional TCP-QUIC pipe |
+| `iroh-sidecar/src/acceptor.rs` | ALPN dispatch (xfer vs NATS) |
+| `iroh-sidecar/src/server.rs` | New endpoint `POST /nats-tunnel/{endpoint_id}` |
+| `iroh-sidecar/src/main.rs` | New CLI arg `--nats-addr`, register second ALPN |
+| `iroh-sidecar/Cargo.toml` | No new dependencies — tokio TCP + iroh QUIC already available |
+
+## Go Agent Changes
+
+### Embedded NATS server
+
+New file: `leaf/agent/embedded_nats.go`
+
+Always created in `Start()`, shut down in `Stop()`. Listens on `127.0.0.1:<ephemeral>` for client connections and a separate ephemeral port for leaf node connections.
+
+**Configuration by role:**
+
+- `peer` / `hub`: `LeafNode.Port` set to ephemeral port. This is the address passed to the sidecar via `--nats-addr`. Incoming iroh tunnels connect here.
+- `leaf`: `LeafNode.Port` disabled. `LeafNode.Remotes` populated after tunnel establishment — embedded NATS solicits outward through the tunnel to a remote peer's NATS.
+- All roles: if `--nats` URL provided, added to `LeafNode.Remotes` as an upstream (embedded NATS joins external cluster as a leaf).
+
+### Tunnel establishment
+
+New file: `leaf/agent/tunnel.go`
+
+Called after sidecar is ready and EndpointIds are known. For each iroh peer:
+
+```
+if my_role == "leaf":
+    POST /nats-tunnel/{peer_endpoint_id}  (I always solicit)
+elif my_role == "hub":
+    skip  (wait for them to connect)
+elif my_role == "peer":
+    if my_endpoint_id < peer_endpoint_id:
+        POST /nats-tunnel/{peer_endpoint_id}  (I solicit)
+    else:
+        skip  (they will connect to me)
+```
+
+The sidecar handles the QUIC stream lifecycle. The Go agent only triggers establishment.
+
+### Transport simplification
+
+With NATS-over-iroh, the `syncTargets` list collapses. Instead of iterating NATS + iroh targets separately, there's one `NATSTransport` connected to the local embedded server. Iroh peers are reached via NATS leaf node routing — not direct xfer exchange.
+
+The agent connects its NATS client to `nats://127.0.0.1:<embedded-client-port>`. `NATSTransport` and `ServeNATS` work unchanged — they just talk to the local embedded server.
+
+### Config changes
+
+| Field | Change |
+|-------|--------|
+| `NATSRole` | New — `"peer"` (default), `"hub"`, `"leaf"` |
+| `NATSUrl` | No longer required. If set, embedded NATS joins it as a leaf upstream |
+| `IrohEnabled` | Still controls whether sidecar starts. Now also controls NATS tunnel establishment |
+| `IrohPeers` | Still lists remote EndpointIds. Tunnel logic uses these for NATS connections too |
+
+### Agent lifecycle (updated)
+
+```
+Start():
+  1. Create embedded NATS server (role-based config)
+  2. Start embedded NATS
+  3. Connect agent's NATS client to localhost:<embedded-client-port>
+  4. Start iroh sidecar (with --nats-addr localhost:<embedded-leaf-port>)
+  5. Wait for sidecar ready
+  6. Establish NATS tunnels to iroh peers (role + EndpointId logic)
+  7. Start ServeNATS (subscribe to sync subject on embedded NATS)
+  8. Start HTTP server (if configured)
+  9. Start poll loop
+
+Stop():
+  1. Cancel poll loop
+  2. Drain NATS client
+  3. Shutdown sidecar (tunnels close with it)
+  4. Shutdown embedded NATS
+  5. Close repo
+```
+
+### Failure handling
+
+- **Tunnel drops** (QUIC stream closes): sidecar detects EOF, closes TCP side. NATS sees leaf node disconnect. Agent's NATS client has `MaxReconnects(-1)` — reconnect is automatic once tunnel is re-established.
+- **Sidecar crash**: agent's liveness monitor detects exit. Can restart sidecar and re-establish tunnels.
+- **No explicit tunnel health polling** — NATS's built-in disconnect/reconnect handles detection. The agent monitors NATS connection status, not tunnel status.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `leaf/agent/embedded_nats.go` | New — embedded NATS server creation, role-based config |
+| `leaf/agent/tunnel.go` | New — tunnel establishment logic, role + EndpointId comparison |
+| `leaf/agent/agent.go` | Updated lifecycle: embedded NATS + tunnel steps, simplified syncTargets |
+| `leaf/agent/config.go` | New field `NATSRole`, `NATSUrl` no longer required |
+| `leaf/agent/sidecar.go` | Pass `--nats-addr` to sidecar CLI |
+
+## What Does NOT Change
+
+- **go-libfossil** — transport-agnostic, no changes
+- **NATSTransport** (`leaf/agent/nats.go`) — still does request/reply on subjects, connects to localhost
+- **ServeNATS** (`leaf/agent/serve_nats.go`) — still subscribes and handles sync requests
+- **IrohTransport** (`leaf/agent/iroh.go`) — kept for backwards compat with peers that don't have embedded NATS
+- **serve_http.go** — HTTP serving unchanged
+- **Wire protocol** — same xfer cards, same NATS subjects
+- **Bridge** — still works with external NATS (embedded NATS joins as leaf)
+- **Existing `--iroh-peer` xfer path** — still works, tunnel is additive
+
+## Testing
+
+### Unit tests (Go)
+
+- Embedded NATS starts, accepts client connections, shuts down cleanly
+- Role config produces correct NATS server options (leaf port, remotes)
+- Tunnel establishment: correct peers solicited based on role + EndpointId comparison
+- `NATSRole` validation (only "peer", "hub", "leaf" accepted)
+
+### Integration test
+
+Two agents with `--nats-role peer`, iroh sidecars, no external NATS:
+1. Seed blobs on agent A
+2. Verify convergence on agent B
+3. Proves: embedded NATS + iroh tunnel + sync over NATS subjects = working P2P
+
+### Manual verification
+
+- `nats sub '>'` on one peer's embedded server — messages from remote peer arrive
+- Subscribe to `edgesync.presence.*`, publish heartbeats, confirm cross-tunnel visibility
+
+## Scope Boundary
+
+**In scope (this spike):**
+- Iroh sidecar NATS tunnel (Rust)
+- Embedded NATS server in agent (Go)
+- Role-based topology (peer/hub/leaf)
+- Tunnel establishment with EndpointId tie-breaking
+- Integration test proving P2P sync over NATS-over-iroh
+
+**Out of scope:**
+- Presence protocol (subjects, heartbeat format, timeout semantics)
+- Messaging/chat layer
+- Peer discovery via NATS (replacing `--iroh-peer` manual config)
+- JetStream configuration on embedded NATS
+- WASM leaf node mode (future — uses same architecture, different config)
+- Cluster/supercluster topologies (future — hub role enables this)

--- a/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
+++ b/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
@@ -86,21 +86,29 @@ if alpn == XFER_ALPN {
 
 ## Go Agent Changes
 
-### Embedded NATS server
+### NATS Mesh Module
 
-New file: `leaf/agent/embedded_nats.go`
+New file: `leaf/agent/nats_mesh.go`
 
-Always created in `Start()`, shut down in `Stop()`. Listens on `127.0.0.1:<ephemeral>` for client connections and a separate ephemeral port for leaf node connections.
+Single module that owns both the embedded NATS server and tunnel establishment. This keeps lifecycle ordering constraints hidden inside one module instead of spread across the agent. Interface to the agent:
 
-**Configuration by role:**
+```go
+type NATSMesh struct { ... }
+
+func NewNATSMesh(cfg NATSMeshConfig, sidecar *Sidecar) *NATSMesh
+func (m *NATSMesh) Start() (clientURL string, err error)
+func (m *NATSMesh) Stop()
+```
+
+The agent calls `mesh.Start()` and gets back a NATS client URL. Everything else — embedded server config, leaf node ports, tunnel establishment, startup ordering — is internal to the mesh module.
+
+**Embedded NATS configuration by role:**
 
 - `peer` / `hub`: `LeafNode.Port` set to ephemeral port. This is the address passed to the sidecar via `--nats-addr`. Incoming iroh tunnels connect here.
 - `leaf`: `LeafNode.Port` disabled. `LeafNode.Remotes` populated after tunnel establishment — embedded NATS solicits outward through the tunnel to a remote peer's NATS.
-- All roles: if `--nats` URL provided, added to `LeafNode.Remotes` as an upstream (embedded NATS joins external cluster as a leaf).
+- All roles: if `NATSUpstream` URL provided, added to `LeafNode.Remotes` as an upstream (embedded NATS joins external cluster as a leaf).
 
-### Tunnel establishment
-
-New file: `leaf/agent/tunnel.go`
+**Tunnel establishment (internal to mesh):**
 
 Called after sidecar is ready and EndpointIds are known. For each iroh peer:
 
@@ -116,20 +124,31 @@ elif my_role == "peer":
         skip  (they will connect to me)
 ```
 
-The sidecar handles the QUIC stream lifecycle. The Go agent only triggers establishment.
+The sidecar handles the QUIC stream lifecycle. The mesh module only triggers establishment.
+
+**Internal startup sequence** (hidden inside `mesh.Start()`):
+
+1. Create embedded NATS server (role-based config)
+2. Start embedded NATS
+3. Start iroh sidecar (with `--nats-addr localhost:<leaf-port>`)
+4. Wait for sidecar ready
+5. Establish NATS tunnels to iroh peers (role + EndpointId logic)
+6. Return `nats://127.0.0.1:<client-port>` to caller
+
+The agent then connects its NATS client to the returned URL. Ordering constraints are encapsulated — the agent never sees steps 1-5.
 
 ### Transport simplification
 
 With NATS-over-iroh, the `syncTargets` list collapses. Instead of iterating NATS + iroh targets separately, there's one `NATSTransport` connected to the local embedded server. Iroh peers are reached via NATS leaf node routing — not direct xfer exchange.
 
-The agent connects its NATS client to `nats://127.0.0.1:<embedded-client-port>`. `NATSTransport` and `ServeNATS` work unchanged — they just talk to the local embedded server.
+`NATSTransport` and `ServeNATS` work unchanged — they just talk to the local embedded server.
 
 ### Config changes
 
 | Field | Change |
 |-------|--------|
 | `NATSRole` | New — `"peer"` (default), `"hub"`, `"leaf"` |
-| `NATSUrl` | No longer required. If set, embedded NATS joins it as a leaf upstream |
+| `NATSUrl` | Renamed to `NATSUpstream`. No longer required. If set, embedded NATS joins it as a leaf |
 | `IrohEnabled` | Still controls whether sidecar starts. Now also controls NATS tunnel establishment |
 | `IrohPeers` | Still lists remote EndpointIds. Tunnel logic uses these for NATS connections too |
 
@@ -137,46 +156,40 @@ The agent connects its NATS client to `nats://127.0.0.1:<embedded-client-port>`.
 
 ```
 Start():
-  1. Create embedded NATS server (role-based config)
-  2. Start embedded NATS
-  3. Connect agent's NATS client to localhost:<embedded-client-port>
-  4. Start iroh sidecar (with --nats-addr localhost:<embedded-leaf-port>)
-  5. Wait for sidecar ready
-  6. Establish NATS tunnels to iroh peers (role + EndpointId logic)
-  7. Start ServeNATS (subscribe to sync subject on embedded NATS)
-  8. Start HTTP server (if configured)
-  9. Start poll loop
+  1. mesh.Start()  → returns clientURL (mesh handles embedded NATS + sidecar + tunnels internally)
+  2. Connect agent's NATS client to clientURL
+  3. Start ServeNATS (subscribe to sync subject on embedded NATS)
+  4. Start HTTP server (if configured)
+  5. Start poll loop
 
 Stop():
   1. Cancel poll loop
   2. Drain NATS client
-  3. Shutdown sidecar (tunnels close with it)
-  4. Shutdown embedded NATS
-  5. Close repo
+  3. mesh.Stop()  (shuts down sidecar + embedded NATS internally)
+  4. Close repo
 ```
 
 ### Failure handling
 
 - **Tunnel drops** (QUIC stream closes): sidecar detects EOF, closes TCP side. NATS sees leaf node disconnect. Agent's NATS client has `MaxReconnects(-1)` — reconnect is automatic once tunnel is re-established.
 - **Sidecar crash**: agent's liveness monitor detects exit. Can restart sidecar and re-establish tunnels.
-- **No explicit tunnel health polling** — NATS's built-in disconnect/reconnect handles detection. The agent monitors NATS connection status, not tunnel status.
+- **No explicit tunnel health polling** — NATS's built-in disconnect/reconnect handles detection. Tunnel failure is defined out of existence from the agent's perspective.
 
 ### Files changed
 
 | File | Change |
 |------|--------|
-| `leaf/agent/embedded_nats.go` | New — embedded NATS server creation, role-based config |
-| `leaf/agent/tunnel.go` | New — tunnel establishment logic, role + EndpointId comparison |
-| `leaf/agent/agent.go` | Updated lifecycle: embedded NATS + tunnel steps, simplified syncTargets |
-| `leaf/agent/config.go` | New field `NATSRole`, `NATSUrl` no longer required |
-| `leaf/agent/sidecar.go` | Pass `--nats-addr` to sidecar CLI |
+| `leaf/agent/nats_mesh.go` | New — embedded NATS server, role-based config, tunnel establishment, startup sequencing |
+| `leaf/agent/agent.go` | Simplified lifecycle: `mesh.Start()` / `mesh.Stop()`, single NATSTransport |
+| `leaf/agent/config.go` | New field `NATSRole`, rename `NATSUrl` → `NATSUpstream` |
+| `leaf/agent/sidecar.go` | Accept `--nats-addr` passthrough from mesh |
 
 ## What Does NOT Change
 
 - **go-libfossil** — transport-agnostic, no changes
 - **NATSTransport** (`leaf/agent/nats.go`) — still does request/reply on subjects, connects to localhost
 - **ServeNATS** (`leaf/agent/serve_nats.go`) — still subscribes and handles sync requests
-- **IrohTransport** (`leaf/agent/iroh.go`) — kept for backwards compat with peers that don't have embedded NATS
+- **IrohTransport** (`leaf/agent/iroh.go`) — kept for backwards compat with peers that don't have embedded NATS. Deprecate once NATS-over-iroh is stable (follow-up ticket) — having two paths to reach iroh peers increases cognitive load
 - **serve_http.go** — HTTP serving unchanged
 - **Wire protocol** — same xfer cards, same NATS subjects
 - **Bridge** — still works with external NATS (embedded NATS joins as leaf)

--- a/iroh-sidecar/src/acceptor.rs
+++ b/iroh-sidecar/src/acceptor.rs
@@ -9,11 +9,17 @@
 use iroh::Endpoint;
 use tokio::task::JoinSet;
 
+use crate::NATS_ALPN;
+
 /// Run the accept loop until the endpoint is closed.
 ///
 /// Each incoming connection is handled in a tracked task so we can await
 /// all in-flight work on shutdown rather than killing tasks mid-request.
-pub async fn run_accept_loop(endpoint: Endpoint, callback_url: String) {
+pub async fn run_accept_loop(
+    endpoint: Endpoint,
+    callback_url: String,
+    nats_addr: Option<String>,
+) {
     let client = reqwest::Client::new();
     let mut tasks = JoinSet::new();
 
@@ -29,9 +35,10 @@ pub async fn run_accept_loop(endpoint: Endpoint, callback_url: String) {
 
         let client = client.clone();
         let callback_url = callback_url.clone();
+        let nats_addr = nats_addr.clone();
 
         tasks.spawn(async move {
-            if let Err(e) = handle_incoming(incoming, client, callback_url).await {
+            if let Err(e) = handle_incoming(incoming, client, callback_url, nats_addr).await {
                 tracing::warn!("accept loop: error handling incoming connection: {e:#}");
             }
         });
@@ -57,11 +64,23 @@ async fn handle_incoming(
     incoming: iroh::endpoint::Incoming,
     client: reqwest::Client,
     callback_url: String,
+    nats_addr: Option<String>,
 ) -> anyhow::Result<()> {
     let connection = incoming.accept()?.await?;
     let remote_id = connection.remote_id();
-    tracing::info!(%remote_id, "accepted incoming connection");
+    let alpn = connection.alpn();
+    tracing::info!(%remote_id, alpn = %String::from_utf8_lossy(alpn), "accepted incoming connection");
 
+    // Route NATS tunnel connections to the tunnel module.
+    if alpn == NATS_ALPN {
+        let nats_addr = nats_addr.ok_or_else(|| {
+            anyhow::anyhow!("received NATS tunnel connection but --nats-addr is not configured")
+        })?;
+        crate::tunnel::handle_connection(connection, nats_addr).await;
+        return Ok(());
+    }
+
+    // Otherwise handle as xfer (existing behavior).
     let mut stream_tasks = JoinSet::new();
 
     // Each new stream on this connection is a separate request.

--- a/iroh-sidecar/src/endpoint.rs
+++ b/iroh-sidecar/src/endpoint.rs
@@ -5,14 +5,14 @@ use tokio::fs;
 /// Load or generate an Ed25519 keypair, then bind an iroh Endpoint.
 pub async fn create_endpoint(
     key_path: &Path,
-    alpn: &[u8],
+    alpns: &[Vec<u8>],
 ) -> anyhow::Result<(Endpoint, String)> {
     let secret_key = load_or_generate_key(key_path).await?;
     let endpoint_id = secret_key.public().to_string();
 
     let endpoint = Endpoint::builder(presets::N0)
         .secret_key(secret_key)
-        .alpns(vec![alpn.to_vec()])
+        .alpns(alpns.to_vec())
         .bind()
         .await?;
 

--- a/iroh-sidecar/src/main.rs
+++ b/iroh-sidecar/src/main.rs
@@ -1,6 +1,7 @@
 mod acceptor;
 mod endpoint;
 mod server;
+mod tunnel;
 
 use clap::Parser;
 use std::path::PathBuf;

--- a/iroh-sidecar/src/main.rs
+++ b/iroh-sidecar/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> anyhow::Result<()> {
         ep.clone(),
         endpoint_id,
         args.alpn.as_bytes().to_vec(),
+        args.nats_addr.clone(),
         shutdown_tx,
     );
 

--- a/iroh-sidecar/src/main.rs
+++ b/iroh-sidecar/src/main.rs
@@ -7,6 +7,9 @@ use clap::Parser;
 use std::path::PathBuf;
 use tokio::sync::oneshot;
 
+pub const XFER_ALPN: &[u8] = b"/edgesync/xfer/1";
+pub const NATS_ALPN: &[u8] = b"/edgesync/nats-leaf/1";
+
 #[derive(Parser)]
 #[command(name = "iroh-sidecar", about = "Iroh P2P proxy for EdgeSync")]
 struct Args {
@@ -25,6 +28,10 @@ struct Args {
     /// ALPN protocol identifier
     #[arg(long, default_value = "/edgesync/xfer/1")]
     alpn: String,
+
+    /// Local NATS server address for tunnel connections (e.g. 127.0.0.1:4222)
+    #[arg(long)]
+    nats_addr: Option<String>,
 }
 
 #[tokio::main]
@@ -33,9 +40,15 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing::info!(socket = %args.socket.display(), "iroh-sidecar starting");
 
+    let alpns: Vec<Vec<u8>> = if args.nats_addr.is_some() {
+        vec![args.alpn.as_bytes().to_vec(), NATS_ALPN.to_vec()]
+    } else {
+        vec![args.alpn.as_bytes().to_vec()]
+    };
+
     let (ep, endpoint_id) = endpoint::create_endpoint(
         &args.key_path,
-        args.alpn.as_bytes(),
+        &alpns,
     ).await?;
 
     tracing::info!(%endpoint_id, "iroh endpoint ready");
@@ -50,11 +63,12 @@ async fn main() -> anyhow::Result<()> {
         shutdown_tx,
     );
 
-    // Task 4: Accept loop for incoming P2P connections.
+    // Accept loop for incoming P2P connections.
     let accept_ep = ep.clone();
     let callback_url = args.callback.clone();
+    let accept_nats_addr = args.nats_addr.clone();
     let accept_handle = tokio::spawn(async move {
-        acceptor::run_accept_loop(accept_ep, callback_url).await;
+        acceptor::run_accept_loop(accept_ep, callback_url, accept_nats_addr).await;
     });
 
     // Task 3: HTTP server on the Unix socket.

--- a/iroh-sidecar/src/server.rs
+++ b/iroh-sidecar/src/server.rs
@@ -32,6 +32,8 @@ pub struct AppState {
     pub endpoint: Endpoint,
     pub endpoint_id: String,
     pub alpn: Vec<u8>,
+    /// Local NATS server address for tunnel connections.
+    pub nats_addr: Option<String>,
     /// Cache of live outbound connections keyed by remote endpoint-id string.
     pub conn_cache: Arc<Mutex<HashMap<String, Connection>>>,
     /// Send on this channel to trigger graceful shutdown.
@@ -43,22 +45,25 @@ impl AppState {
         endpoint: Endpoint,
         endpoint_id: String,
         alpn: Vec<u8>,
+        nats_addr: Option<String>,
         shutdown_tx: oneshot::Sender<()>,
     ) -> Self {
         AppState {
             endpoint,
             endpoint_id,
             alpn,
+            nats_addr,
             conn_cache: Arc::new(Mutex::new(HashMap::new())),
             shutdown_tx: Arc::new(Mutex::new(Some(shutdown_tx))),
         }
     }
 }
 
-/// Build the axum Router with all three routes wired up.
+/// Build the axum Router with all routes wired up.
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/exchange/{endpoint_id}", post(handle_exchange))
+        .route("/nats-tunnel/{endpoint_id}", post(handle_nats_tunnel))
         .route("/status", get(handle_status))
         .route("/shutdown", post(handle_shutdown))
         .with_state(state)
@@ -90,6 +95,39 @@ async fn handle_exchange(
         .map_err(AppError::internal)?;
 
     Ok((StatusCode::OK, response_bytes).into_response())
+}
+
+/// POST /nats-tunnel/{endpoint-id}
+///
+/// Establishes an outbound NATS leaf node tunnel to a remote peer. Connects
+/// over QUIC using the NATS ALPN, then pipes bidirectionally between the
+/// local NATS server and the remote peer's NATS server. Returns 200
+/// immediately; the tunnel runs in a background task.
+async fn handle_nats_tunnel(
+    State(state): State<AppState>,
+    Path(remote_id_str): Path<String>,
+) -> Result<Response, AppError> {
+    let nats_addr = state.nats_addr.clone().ok_or_else(|| {
+        AppError::bad_request("NATS tunnel not available: --nats-addr not configured")
+    })?;
+
+    let remote_id = EndpointId::from_str(&remote_id_str)
+        .map_err(|e| AppError::bad_request(format!("invalid endpoint id: {e}")))?;
+
+    tracing::info!(remote = %remote_id_str, %nats_addr, "opening outbound NATS tunnel");
+
+    let addr: EndpointAddr = remote_id.into();
+    let conn = state
+        .endpoint
+        .connect(addr, crate::NATS_ALPN)
+        .await
+        .map_err(AppError::internal)?;
+
+    tokio::spawn(async move {
+        crate::tunnel::establish_outbound(conn, nats_addr).await;
+    });
+
+    Ok(StatusCode::OK.into_response())
 }
 
 /// GET /status

--- a/iroh-sidecar/src/server.rs
+++ b/iroh-sidecar/src/server.rs
@@ -100,21 +100,17 @@ async fn handle_exchange(
 /// POST /nats-tunnel/{endpoint-id}
 ///
 /// Establishes an outbound NATS leaf node tunnel to a remote peer. Connects
-/// over QUIC using the NATS ALPN, then pipes bidirectionally between the
-/// local NATS server and the remote peer's NATS server. Returns 200
-/// immediately; the tunnel runs in a background task.
+/// over QUIC using the NATS ALPN, then binds a local TCP listener that the
+/// embedded NATS server can solicit to. Returns `{"port": <u16>}` so the Go
+/// mesh can configure the NATS leaf remote before starting the server.
 async fn handle_nats_tunnel(
     State(state): State<AppState>,
     Path(remote_id_str): Path<String>,
 ) -> Result<Response, AppError> {
-    let nats_addr = state.nats_addr.clone().ok_or_else(|| {
-        AppError::bad_request("NATS tunnel not available: --nats-addr not configured")
-    })?;
-
     let remote_id = EndpointId::from_str(&remote_id_str)
         .map_err(|e| AppError::bad_request(format!("invalid endpoint id: {e}")))?;
 
-    tracing::info!(remote = %remote_id_str, %nats_addr, "opening outbound NATS tunnel");
+    tracing::info!(remote = %remote_id_str, "opening outbound NATS tunnel");
 
     let addr: EndpointAddr = remote_id.into();
     let conn = state
@@ -123,11 +119,11 @@ async fn handle_nats_tunnel(
         .await
         .map_err(AppError::internal)?;
 
-    tokio::spawn(async move {
-        crate::tunnel::establish_outbound(conn, nats_addr).await;
-    });
+    let port = crate::tunnel::establish_outbound(conn)
+        .await
+        .map_err(AppError::internal)?;
 
-    Ok(StatusCode::OK.into_response())
+    Ok(axum::Json(json!({"port": port})).into_response())
 }
 
 /// GET /status

--- a/iroh-sidecar/src/tunnel.rs
+++ b/iroh-sidecar/src/tunnel.rs
@@ -1,16 +1,25 @@
 //! Bidirectional TCP-QUIC pipe for NATS leaf node connections.
 //!
-//! Each QUIC bi-stream is paired with a fresh TCP connection to the local
-//! NATS server. Bytes flow in both directions until either side closes.
+//! The NATS leaf node protocol is asymmetric:
+//!   - **Hub side** sends INFO, waits for CONNECT from the leaf.
+//!   - **Leaf side** sends CONNECT in response to INFO.
+//!
+//! Inbound (accepting) side: the sidecar connects TCP to the local NATS leaf
+//! port, which acts as hub — correct.
+//!
+//! Outbound (soliciting) side: the sidecar binds a local TCP listener and
+//! returns its port. The Go mesh configures the embedded NATS server to solicit
+//! a leaf connection to that port. The sidecar pipes the resulting TCP
+//! connection through QUIC to the remote hub.
 
 use iroh::endpoint::Connection;
 use tokio::io::AsyncWriteExt;
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
 
 /// Handle an inbound connection on the NATS tunnel ALPN.
 ///
 /// Accepts bidirectional streams in a loop and pipes each one to a fresh
-/// TCP connection to `nats_addr`.
+/// TCP connection to `nats_addr` (the local NATS leaf node port, hub side).
 pub async fn handle_connection(connection: Connection, nats_addr: String) {
     let remote_id = connection.remote_id();
     tracing::info!(%remote_id, %nats_addr, "nats tunnel: accepted inbound connection");
@@ -26,42 +35,60 @@ pub async fn handle_connection(connection: Connection, nats_addr: String) {
 
         let nats_addr = nats_addr.clone();
         tokio::spawn(async move {
-            if let Err(e) = pipe_stream(send, recv, &nats_addr).await {
+            if let Err(e) = pipe_to_nats(send, recv, &nats_addr).await {
                 tracing::warn!(%remote_id, "nats tunnel: inbound pipe error: {e:#}");
             }
         });
     }
 }
 
-/// Establish an outbound NATS tunnel stream.
+/// Establish an outbound NATS tunnel.
 ///
-/// Opens one bidirectional stream on the given connection and pipes it to a
-/// fresh TCP connection to `nats_addr`.
-pub async fn establish_outbound(connection: Connection, nats_addr: String) {
+/// Binds `127.0.0.1:0` (ephemeral port) and returns the port. The caller
+/// configures the embedded NATS server to solicit a leaf connection to this
+/// port. When NATS connects, the sidecar opens a QUIC bi-stream to the remote
+/// peer and pipes bytes bidirectionally.
+pub async fn establish_outbound(connection: Connection) -> anyhow::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
     let remote_id = connection.remote_id();
-    tracing::info!(%remote_id, %nats_addr, "nats tunnel: opening outbound stream");
 
-    let (send, recv) = match connection.open_bi().await {
-        Ok(streams) => streams,
-        Err(e) => {
-            tracing::warn!(%remote_id, "nats tunnel: failed to open bi stream: {e:#}");
-            return;
+    tracing::info!(%remote_id, %port, "nats tunnel: outbound listener ready");
+
+    tokio::spawn(async move {
+        // Wait for local NATS to connect (it will solicit to this port).
+        let (tcp_stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(%remote_id, "nats tunnel: accept failed: {e}");
+                return;
+            }
+        };
+
+        // Open QUIC bi-stream to remote peer.
+        let (send, recv) = match connection.open_bi().await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(%remote_id, "nats tunnel: open_bi failed: {e}");
+                return;
+            }
+        };
+
+        // Pipe: local NATS (leaf) <-> QUIC <-> remote NATS (hub)
+        if let Err(e) = pipe_tcp_to_quic(tcp_stream, send, recv).await {
+            tracing::warn!(%remote_id, "nats tunnel: outbound pipe error: {e:#}");
         }
-    };
+    });
 
-    if let Err(e) = pipe_stream(send, recv, &nats_addr).await {
-        tracing::warn!(%remote_id, "nats tunnel: outbound pipe error: {e:#}");
-    }
+    Ok(port)
 }
 
-/// Pipe bytes bidirectionally between a QUIC stream pair and a TCP connection
-/// to the local NATS server.
-async fn pipe_stream(
+/// Pipe bytes bidirectionally between a TCP stream and a QUIC stream pair.
+async fn pipe_tcp_to_quic(
+    tcp: TcpStream,
     mut quic_send: iroh::endpoint::SendStream,
     mut quic_recv: iroh::endpoint::RecvStream,
-    nats_addr: &str,
 ) -> anyhow::Result<()> {
-    let tcp = TcpStream::connect(nats_addr).await?;
     let (mut tcp_read, mut tcp_write) = tcp.into_split();
 
     // QUIC recv -> TCP write
@@ -75,7 +102,6 @@ async fn pipe_stream(
 
     // TCP read -> QUIC send
     let t2q = tokio::spawn(async move {
-        // We need an AsyncRead adapter; TcpStream's read half implements it.
         let mut buf = vec![0u8; 32 * 1024];
         loop {
             let n = match tokio::io::AsyncReadExt::read(&mut tcp_read, &mut buf).await {
@@ -98,4 +124,15 @@ async fn pipe_stream(
     let _ = tokio::join!(q2t, t2q);
 
     Ok(())
+}
+
+/// Connect TCP to a local NATS address and pipe through QUIC streams.
+/// Used by the inbound (hub) side where we connect to the local NATS leaf port.
+async fn pipe_to_nats(
+    quic_send: iroh::endpoint::SendStream,
+    quic_recv: iroh::endpoint::RecvStream,
+    nats_addr: &str,
+) -> anyhow::Result<()> {
+    let tcp = TcpStream::connect(nats_addr).await?;
+    pipe_tcp_to_quic(tcp, quic_send, quic_recv).await
 }

--- a/iroh-sidecar/src/tunnel.rs
+++ b/iroh-sidecar/src/tunnel.rs
@@ -1,0 +1,101 @@
+//! Bidirectional TCP-QUIC pipe for NATS leaf node connections.
+//!
+//! Each QUIC bi-stream is paired with a fresh TCP connection to the local
+//! NATS server. Bytes flow in both directions until either side closes.
+
+use iroh::endpoint::Connection;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+/// Handle an inbound connection on the NATS tunnel ALPN.
+///
+/// Accepts bidirectional streams in a loop and pipes each one to a fresh
+/// TCP connection to `nats_addr`.
+pub async fn handle_connection(connection: Connection, nats_addr: String) {
+    let remote_id = connection.remote_id();
+    tracing::info!(%remote_id, %nats_addr, "nats tunnel: accepted inbound connection");
+
+    loop {
+        let (send, recv) = match connection.accept_bi().await {
+            Ok(streams) => streams,
+            Err(e) => {
+                tracing::debug!(%remote_id, "nats tunnel: stream accept ended: {e}");
+                break;
+            }
+        };
+
+        let nats_addr = nats_addr.clone();
+        tokio::spawn(async move {
+            if let Err(e) = pipe_stream(send, recv, &nats_addr).await {
+                tracing::warn!(%remote_id, "nats tunnel: inbound pipe error: {e:#}");
+            }
+        });
+    }
+}
+
+/// Establish an outbound NATS tunnel stream.
+///
+/// Opens one bidirectional stream on the given connection and pipes it to a
+/// fresh TCP connection to `nats_addr`.
+pub async fn establish_outbound(connection: Connection, nats_addr: String) {
+    let remote_id = connection.remote_id();
+    tracing::info!(%remote_id, %nats_addr, "nats tunnel: opening outbound stream");
+
+    let (send, recv) = match connection.open_bi().await {
+        Ok(streams) => streams,
+        Err(e) => {
+            tracing::warn!(%remote_id, "nats tunnel: failed to open bi stream: {e:#}");
+            return;
+        }
+    };
+
+    if let Err(e) = pipe_stream(send, recv, &nats_addr).await {
+        tracing::warn!(%remote_id, "nats tunnel: outbound pipe error: {e:#}");
+    }
+}
+
+/// Pipe bytes bidirectionally between a QUIC stream pair and a TCP connection
+/// to the local NATS server.
+async fn pipe_stream(
+    mut quic_send: iroh::endpoint::SendStream,
+    mut quic_recv: iroh::endpoint::RecvStream,
+    nats_addr: &str,
+) -> anyhow::Result<()> {
+    let tcp = TcpStream::connect(nats_addr).await?;
+    let (mut tcp_read, mut tcp_write) = tcp.into_split();
+
+    // QUIC recv -> TCP write
+    let q2t = tokio::spawn(async move {
+        if let Err(e) = tokio::io::copy(&mut quic_recv, &mut tcp_write).await {
+            tracing::debug!("nats tunnel: quic->tcp copy ended: {e}");
+        }
+        // Shut down the TCP write half so the NATS server sees EOF.
+        let _ = tcp_write.shutdown().await;
+    });
+
+    // TCP read -> QUIC send
+    let t2q = tokio::spawn(async move {
+        // We need an AsyncRead adapter; TcpStream's read half implements it.
+        let mut buf = vec![0u8; 32 * 1024];
+        loop {
+            let n = match tokio::io::AsyncReadExt::read(&mut tcp_read, &mut buf).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::debug!("nats tunnel: tcp->quic read error: {e}");
+                    break;
+                }
+            };
+            if let Err(e) = quic_send.write_all(&buf[..n]).await {
+                tracing::debug!("nats tunnel: tcp->quic write error: {e}");
+                break;
+            }
+        }
+        let _ = quic_send.finish();
+    });
+
+    // Wait for both copy loops to finish.
+    let _ = tokio::join!(q2t, t2q);
+
+    Ok(())
+}

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -72,8 +72,10 @@ type Agent struct {
 }
 
 // New creates a new Agent from the given configuration.
-// It opens the Fossil repo, reads project-code and server-code from
-// the config table, connects to NATS, and builds the NATSTransport.
+// It opens the Fossil repo and reads project-code / server-code.
+// The embedded NATS server is NOT started here — that happens in Start()
+// after iroh tunnels are established (tunnel ports must be known before
+// NATS can be configured with leaf remotes).
 func New(cfg Config) (*Agent, error) {
 	cfg.applyDefaults()
 	if err := cfg.validate(); err != nil {
@@ -97,69 +99,20 @@ func New(cfg Config) (*Agent, error) {
 		return nil, fmt.Errorf("agent: read server-code: %w", err)
 	}
 
-	// Start the embedded NATS mesh. The mesh handles role-based routing:
-	// it starts a local NATS server and optionally joins an upstream as a leaf.
+	// Create the mesh but don't start it yet. Start() will call
+	// startIrohSidecar (which establishes tunnels and populates
+	// tunnelPorts) before starting the NATS server.
 	mesh := &NATSMesh{
 		role:      cfg.NATSRole,
 		upstream:  cfg.NATSUpstream,
 		irohPeers: cfg.IrohPeers,
 	}
-	clientURL, err := mesh.Start()
-	if err != nil {
-		r.Close()
-		return nil, fmt.Errorf("agent: nats mesh start: %w", err)
-	}
-
-	natsOpts := []nats.Option{
-		nats.Name("edgesync-leaf"),
-		nats.MaxReconnects(-1),
-		nats.ReconnectWait(2 * time.Second),
-		nats.RetryOnFailedConnect(true),
-	}
-	if cfg.CustomDialer != nil {
-		natsOpts = append(natsOpts, nats.SetCustomDialer(cfg.CustomDialer))
-	}
-	natsOpts = append(natsOpts, nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
-		if err != nil {
-			slog.Warn("NATS disconnected", "error", err)
-			if cfg.Logger != nil {
-				cfg.Logger("NATS disconnected: " + err.Error())
-			}
-		}
-	}))
-	natsOpts = append(natsOpts, nats.ReconnectHandler(func(_ *nats.Conn) {
-		slog.Info("NATS reconnected", "url", clientURL)
-		if cfg.Logger != nil {
-			cfg.Logger("NATS reconnected")
-		}
-	}))
-	nc, err := nats.Connect(clientURL, natsOpts...)
-	if err != nil {
-		mesh.Stop()
-		r.Close()
-		return nil, fmt.Errorf("agent: nats connect: %w", err)
-	}
-	if nc.IsConnected() {
-		slog.Info("connected to NATS", "url", clientURL, "upstream", cfg.NATSUpstream, "role", cfg.NATSRole)
-		if cfg.Logger != nil {
-			cfg.Logger("connected to NATS: " + clientURL)
-		}
-	} else {
-		slog.Warn("NATS not yet reachable, will retry in background", "url", clientURL)
-		if cfg.Logger != nil {
-			cfg.Logger("warning: NATS not yet reachable at " + clientURL + ", will retry in background")
-		}
-	}
-
-	transport := NewNATSTransport(nc, projectCode, 0, cfg.SubjectPrefix)
 
 	a := &Agent{
 		config:      cfg,
 		clock:       cfg.Clock,
 		repo:        r,
 		mesh:        mesh,
-		conn:        nc,
-		transport:   transport,
 		projectCode: projectCode,
 		serverCode:  serverCode,
 		syncNow:     make(chan struct{}, 1),
@@ -227,20 +180,36 @@ func (a *Agent) Repo() *libfossil.Repo {
 
 // Start launches the background poll loop and any configured server
 // listeners. Call Stop to shut everything down.
+//
+// The startup order is critical for correct NATS leaf node handshakes:
+//  1. Start iroh sidecar and establish tunnels (get local listener ports)
+//  2. Start embedded NATS server with tunnel ports as leaf remotes
+//  3. Connect NATS client and configure sync targets
+//  4. Start HTTP/NATS serve listeners
+//  5. Launch poll loop
 func (a *Agent) Start() error {
 	a.logf("starting agent...")
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 
-	if err := a.startNATS(ctx); err != nil {
+	// Step 1: iroh sidecar + tunnels (must happen before NATS start).
+	if err := a.startIrohSidecar(ctx); err != nil {
+		cancel()
+		return err
+	}
+
+	// Step 2+3: start embedded NATS mesh and connect client.
+	if err := a.startNATSMesh(); err != nil {
+		cancel()
+		return err
+	}
+
+	// Step 4: serve listeners.
+	if err := a.startNATSServe(ctx); err != nil {
 		cancel()
 		return err
 	}
 	if err := a.startHTTPServer(ctx); err != nil {
-		cancel()
-		return err
-	}
-	if err := a.startIrohSidecar(ctx); err != nil {
 		cancel()
 		return err
 	}
@@ -250,8 +219,67 @@ func (a *Agent) Start() error {
 	return nil
 }
 
-// startNATS launches the NATS serve listener if configured.
-func (a *Agent) startNATS(ctx context.Context) error {
+// startNATSMesh starts the embedded NATS server (with tunnel remotes already
+// configured by EstablishTunnels) and connects the NATS client.
+func (a *Agent) startNATSMesh() error {
+	if a.mesh == nil {
+		return nil
+	}
+
+	clientURL, err := a.mesh.Start()
+	if err != nil {
+		return fmt.Errorf("agent: nats mesh start: %w", err)
+	}
+
+	cfg := a.config
+	natsOpts := []nats.Option{
+		nats.Name("edgesync-leaf"),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2 * time.Second),
+		nats.RetryOnFailedConnect(true),
+	}
+	if cfg.CustomDialer != nil {
+		natsOpts = append(natsOpts, nats.SetCustomDialer(cfg.CustomDialer))
+	}
+	natsOpts = append(natsOpts, nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+		if err != nil {
+			slog.Warn("NATS disconnected", "error", err)
+			if cfg.Logger != nil {
+				cfg.Logger("NATS disconnected: " + err.Error())
+			}
+		}
+	}))
+	natsOpts = append(natsOpts, nats.ReconnectHandler(func(_ *nats.Conn) {
+		slog.Info("NATS reconnected", "url", clientURL)
+		if cfg.Logger != nil {
+			cfg.Logger("NATS reconnected")
+		}
+	}))
+	nc, err := nats.Connect(clientURL, natsOpts...)
+	if err != nil {
+		a.mesh.Stop()
+		return fmt.Errorf("agent: nats connect: %w", err)
+	}
+	if nc.IsConnected() {
+		slog.Info("connected to NATS", "url", clientURL, "upstream", cfg.NATSUpstream, "role", cfg.NATSRole)
+		if cfg.Logger != nil {
+			cfg.Logger("connected to NATS: " + clientURL)
+		}
+	} else {
+		slog.Warn("NATS not yet reachable, will retry in background", "url", clientURL)
+		if cfg.Logger != nil {
+			cfg.Logger("warning: NATS not yet reachable at " + clientURL + ", will retry in background")
+		}
+	}
+
+	a.conn = nc
+	a.transport = NewNATSTransport(nc, a.projectCode, 0, cfg.SubjectPrefix)
+	return nil
+}
+
+// startNATSServe adds the NATS transport as a sync target and launches the
+// NATS request/reply listener if configured.
+func (a *Agent) startNATSServe(ctx context.Context) error {
 	// Add NATS as the primary sync target (always present when agent is built via New).
 	if a.transport != nil {
 		a.syncTargets = append(a.syncTargets, syncTarget{
@@ -284,9 +312,15 @@ func (a *Agent) startHTTPServer(ctx context.Context) error {
 	return nil
 }
 
-// startIrohSidecar launches the iroh sidecar process and registers iroh
-// peers as sync targets. It always creates a dedicated callback listener
-// for sidecar-to-agent xfer traffic (decoupled from the public HTTP server).
+// startIrohSidecar launches the iroh sidecar process, establishes outbound
+// NATS tunnels, and registers iroh peers as sync targets. It creates a
+// dedicated callback listener for sidecar-to-agent xfer traffic (decoupled
+// from the public HTTP server).
+//
+// This runs BEFORE the NATS server starts. The leaf port is pre-reserved so
+// the sidecar knows where NATS will listen for inbound leaf connections.
+// Outbound tunnel ports are collected so the NATS server can be started with
+// them as leaf remotes.
 func (a *Agent) startIrohSidecar(ctx context.Context) error {
 	if !a.config.IrohEnabled {
 		return nil
@@ -295,6 +329,14 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 	binPath, err := a.findIrohBinary()
 	if err != nil {
 		return fmt.Errorf("agent: iroh: %w", err)
+	}
+
+	// Pre-reserve the NATS leaf port so we can tell the sidecar where NATS
+	// will listen before NATS actually starts. NATS will bind this exact port.
+	if a.mesh != nil {
+		if err := a.mesh.ReserveLeafPort(); err != nil {
+			return fmt.Errorf("agent: reserve leaf port: %w", err)
+		}
 	}
 
 	// Use a hash of the repo path to make the socket unique per agent instance,
@@ -330,8 +372,8 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 		alpn:        irohALPN,
 	}
 
-	// If the mesh has a leaf node address, pass it to the sidecar so it can
-	// accept inbound NATS leaf connections from remote peers.
+	// Pass the pre-reserved leaf port so the sidecar can accept inbound NATS
+	// leaf connections from remote peers.
 	if a.mesh != nil && a.mesh.LeafAddr() != "" {
 		a.irohSidecar.natsAddr = a.mesh.LeafAddr()
 	}
@@ -344,7 +386,9 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 	a.irohEndpointID = status.EndpointID
 	a.logf("iroh sidecar ready, endpoint_id=%s", status.EndpointID)
 
-	// Wire the sidecar info back into the mesh for tunnel establishment.
+	// Establish outbound NATS tunnels. Each tunnel returns a local port that
+	// the NATS server will solicit to. These ports are consumed by
+	// startNATSMesh -> mesh.Start -> buildServerOpts.
 	if a.mesh != nil {
 		a.mesh.SetEndpointID(status.EndpointID)
 		a.mesh.SetSidecarSocket(a.irohSock)

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -57,7 +57,8 @@ type Agent struct {
 	config      Config
 	clock       simio.Clock
 	repo        *libfossil.Repo
-	conn        *nats.Conn // nil when created via NewFromParts
+	mesh        *NATSMesh    // nil when created via NewFromParts
+	conn        *nats.Conn   // nil when created via NewFromParts
 	transport   libfossil.Transport
 	syncTargets []syncTarget // unified list of sync destinations
 	projectCode string
@@ -96,6 +97,19 @@ func New(cfg Config) (*Agent, error) {
 		return nil, fmt.Errorf("agent: read server-code: %w", err)
 	}
 
+	// Start the embedded NATS mesh. The mesh handles role-based routing:
+	// it starts a local NATS server and optionally joins an upstream as a leaf.
+	mesh := &NATSMesh{
+		role:      cfg.NATSRole,
+		upstream:  cfg.NATSUpstream,
+		irohPeers: cfg.IrohPeers,
+	}
+	clientURL, err := mesh.Start()
+	if err != nil {
+		r.Close()
+		return nil, fmt.Errorf("agent: nats mesh start: %w", err)
+	}
+
 	natsOpts := []nats.Option{
 		nats.Name("edgesync-leaf"),
 		nats.MaxReconnects(-1),
@@ -114,25 +128,26 @@ func New(cfg Config) (*Agent, error) {
 		}
 	}))
 	natsOpts = append(natsOpts, nats.ReconnectHandler(func(_ *nats.Conn) {
-		slog.Info("NATS reconnected", "url", cfg.NATSUpstream)
+		slog.Info("NATS reconnected", "url", clientURL)
 		if cfg.Logger != nil {
 			cfg.Logger("NATS reconnected")
 		}
 	}))
-	nc, err := nats.Connect(cfg.NATSUpstream, natsOpts...)
+	nc, err := nats.Connect(clientURL, natsOpts...)
 	if err != nil {
+		mesh.Stop()
 		r.Close()
 		return nil, fmt.Errorf("agent: nats connect: %w", err)
 	}
 	if nc.IsConnected() {
-		slog.Info("connected to NATS", "url", cfg.NATSUpstream)
+		slog.Info("connected to NATS", "url", clientURL, "upstream", cfg.NATSUpstream, "role", cfg.NATSRole)
 		if cfg.Logger != nil {
-			cfg.Logger("connected to NATS: " + cfg.NATSUpstream)
+			cfg.Logger("connected to NATS: " + clientURL)
 		}
 	} else {
-		slog.Warn("NATS not yet reachable, will retry in background", "url", cfg.NATSUpstream)
+		slog.Warn("NATS not yet reachable, will retry in background", "url", clientURL)
 		if cfg.Logger != nil {
-			cfg.Logger("warning: NATS not yet reachable at " + cfg.NATSUpstream + ", will retry in background")
+			cfg.Logger("warning: NATS not yet reachable at " + clientURL + ", will retry in background")
 		}
 	}
 
@@ -142,6 +157,7 @@ func New(cfg Config) (*Agent, error) {
 		config:      cfg,
 		clock:       cfg.Clock,
 		repo:        r,
+		mesh:        mesh,
 		conn:        nc,
 		transport:   transport,
 		projectCode: projectCode,
@@ -314,6 +330,12 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 		alpn:        irohALPN,
 	}
 
+	// If the mesh has a leaf node address, pass it to the sidecar so it can
+	// accept inbound NATS leaf connections from remote peers.
+	if a.mesh != nil && a.mesh.LeafAddr() != "" {
+		a.irohSidecar.natsAddr = a.mesh.LeafAddr()
+	}
+
 	status, err := a.irohSidecar.Start(10 * time.Second)
 	if err != nil {
 		callbackSrv.Close()
@@ -321,6 +343,17 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 	}
 	a.irohEndpointID = status.EndpointID
 	a.logf("iroh sidecar ready, endpoint_id=%s", status.EndpointID)
+
+	// Wire the sidecar info back into the mesh for tunnel establishment.
+	if a.mesh != nil {
+		a.mesh.SetEndpointID(status.EndpointID)
+		a.mesh.SetSidecarSocket(a.irohSock)
+		if err := a.mesh.EstablishTunnels(); err != nil {
+			// Non-fatal: log and continue. Tunnels can be retried later.
+			a.logf("warning: establish tunnels: %v", err)
+			slog.Warn("failed to establish iroh NATS tunnels", "error", err)
+		}
+	}
 
 	// Register iroh peers as sync targets.
 	for _, peerID := range a.config.IrohPeers {
@@ -336,7 +369,7 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 }
 
 // Stop cancels the poll loop, waits for it to finish, closes the NATS
-// connection, and closes the repo.
+// connection, shuts down the mesh, and closes the repo.
 func (a *Agent) Stop() error {
 	if a.cancel != nil {
 		a.cancel()
@@ -349,6 +382,9 @@ func (a *Agent) Stop() error {
 	}
 	if a.conn != nil {
 		a.conn.Close()
+	}
+	if a.mesh != nil {
+		a.mesh.Stop()
 	}
 	if a.repo != nil {
 		return a.repo.Close()

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -114,25 +114,25 @@ func New(cfg Config) (*Agent, error) {
 		}
 	}))
 	natsOpts = append(natsOpts, nats.ReconnectHandler(func(_ *nats.Conn) {
-		slog.Info("NATS reconnected", "url", cfg.NATSUrl)
+		slog.Info("NATS reconnected", "url", cfg.NATSUpstream)
 		if cfg.Logger != nil {
 			cfg.Logger("NATS reconnected")
 		}
 	}))
-	nc, err := nats.Connect(cfg.NATSUrl, natsOpts...)
+	nc, err := nats.Connect(cfg.NATSUpstream, natsOpts...)
 	if err != nil {
 		r.Close()
 		return nil, fmt.Errorf("agent: nats connect: %w", err)
 	}
 	if nc.IsConnected() {
-		slog.Info("connected to NATS", "url", cfg.NATSUrl)
+		slog.Info("connected to NATS", "url", cfg.NATSUpstream)
 		if cfg.Logger != nil {
-			cfg.Logger("connected to NATS: " + cfg.NATSUrl)
+			cfg.Logger("connected to NATS: " + cfg.NATSUpstream)
 		}
 	} else {
-		slog.Warn("NATS not yet reachable, will retry in background", "url", cfg.NATSUrl)
+		slog.Warn("NATS not yet reachable, will retry in background", "url", cfg.NATSUpstream)
 		if cfg.Logger != nil {
-			cfg.Logger("warning: NATS not yet reachable at " + cfg.NATSUrl + ", will retry in background")
+			cfg.Logger("warning: NATS not yet reachable at " + cfg.NATSUpstream + ", will retry in background")
 		}
 	}
 

--- a/leaf/agent/agent_test.go
+++ b/leaf/agent/agent_test.go
@@ -15,8 +15,11 @@ func TestConfigDefaults(t *testing.T) {
 	c := Config{RepoPath: "/tmp/test.fossil"}
 	c.applyDefaults()
 
-	if c.NATSUrl != "nats://localhost:4222" {
-		t.Errorf("NATSUrl = %q, want %q", c.NATSUrl, "nats://localhost:4222")
+	if c.NATSUpstream != "" {
+		t.Errorf("NATSUpstream = %q, want empty (no upstream by default)", c.NATSUpstream)
+	}
+	if c.NATSRole != NATSRolePeer {
+		t.Errorf("NATSRole = %q, want %q", c.NATSRole, NATSRolePeer)
 	}
 	if c.PollInterval != 5*time.Second {
 		t.Errorf("PollInterval = %v, want %v", c.PollInterval, 5*time.Second)
@@ -38,7 +41,8 @@ func TestConfigDefaults(t *testing.T) {
 func TestConfigDefaultsPreserveExplicit(t *testing.T) {
 	c := Config{
 		RepoPath:      "/tmp/test.fossil",
-		NATSUrl:       "nats://custom:4223",
+		NATSUpstream:  "nats://custom:4223",
+		NATSRole:      NATSRoleHub,
 		PollInterval:  10 * time.Second,
 		User:          "alice",
 		Push:          true,
@@ -47,8 +51,11 @@ func TestConfigDefaultsPreserveExplicit(t *testing.T) {
 	}
 	c.applyDefaults()
 
-	if c.NATSUrl != "nats://custom:4223" {
-		t.Errorf("NATSUrl = %q, want %q", c.NATSUrl, "nats://custom:4223")
+	if c.NATSUpstream != "nats://custom:4223" {
+		t.Errorf("NATSUpstream = %q, want %q", c.NATSUpstream, "nats://custom:4223")
+	}
+	if c.NATSRole != NATSRoleHub {
+		t.Errorf("NATSRole = %q, want %q", c.NATSRole, NATSRoleHub)
 	}
 	if c.PollInterval != 10*time.Second {
 		t.Errorf("PollInterval = %v, want %v", c.PollInterval, 10*time.Second)
@@ -128,7 +135,7 @@ func TestAgentNewAndStop(t *testing.T) {
 
 	a, err := New(Config{
 		RepoPath: repoPath,
-		NATSUrl:  natsURL,
+		NATSUpstream:  natsURL,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -152,7 +159,7 @@ func TestAgentStartAndStop(t *testing.T) {
 
 	a, err := New(Config{
 		RepoPath:     repoPath,
-		NATSUrl:      natsURL,
+		NATSUpstream:      natsURL,
 		PollInterval: 50 * time.Millisecond,
 	})
 	if err != nil {
@@ -176,7 +183,7 @@ func TestAgentNewBadRepoPath(t *testing.T) {
 
 	_, err := New(Config{
 		RepoPath: "/nonexistent/path/to/repo.fossil",
-		NATSUrl:  natsURL,
+		NATSUpstream:  natsURL,
 	})
 	if err == nil {
 		t.Fatal("expected error for bad repo path, got nil")
@@ -190,7 +197,7 @@ func TestAgentSyncNowNonBlocking(t *testing.T) {
 
 	a, err := New(Config{
 		RepoPath:     repoPath,
-		NATSUrl:      natsURL,
+		NATSUpstream:      natsURL,
 		PollInterval: 10 * time.Second, // long interval so only SyncNow triggers
 	})
 	if err != nil {

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"time"
 
@@ -12,13 +13,27 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// NATSRole determines how the embedded NATS server participates in the mesh.
+type NATSRole string
+
+const (
+	NATSRolePeer NATSRole = "peer" // accepts + solicits (lower EndpointId solicits)
+	NATSRoleHub  NATSRole = "hub"  // accepts only, never solicits
+	NATSRoleLeaf NATSRole = "leaf" // solicits only, never accepts
+)
+
 // Config holds all settings for a leaf agent instance.
 type Config struct {
 	// RepoPath is the path to the local Fossil repository file (required).
 	RepoPath string
 
-	// NATSUrl is the NATS server URL to connect to.
-	NATSUrl string
+	// NATSUpstream is an optional external NATS URL that the embedded server
+	// joins as a leaf node. Empty means standalone mesh (no upstream).
+	NATSUpstream string
+
+	// NATSRole determines how the embedded NATS server participates in the
+	// mesh (peer, hub, or leaf). Default: peer.
+	NATSRole NATSRole
 
 	// PollInterval is how often the agent checks for local changes.
 	PollInterval time.Duration
@@ -111,8 +126,8 @@ type Config struct {
 
 // applyDefaults fills in zero-valued fields with sensible defaults.
 func (c *Config) applyDefaults() {
-	if c.NATSUrl == "" {
-		c.NATSUrl = "nats://localhost:4222"
+	if c.NATSRole == "" {
+		c.NATSRole = NATSRolePeer
 	}
 	if c.PollInterval == 0 {
 		c.PollInterval = 5 * time.Second
@@ -148,6 +163,12 @@ func (c *Config) applyDefaults() {
 func (c *Config) validate() error {
 	if c.RepoPath == "" {
 		return errors.New("agent: config: RepoPath is required")
+	}
+	switch c.NATSRole {
+	case NATSRolePeer, NATSRoleHub, NATSRoleLeaf:
+		// valid
+	default:
+		return fmt.Errorf("agent: config: invalid NATSRole %q (must be peer, hub, or leaf)", c.NATSRole)
 	}
 	return nil
 }

--- a/leaf/agent/integration_test.go
+++ b/leaf/agent/integration_test.go
@@ -161,7 +161,7 @@ func TestIntegrationLeafPush(t *testing.T) {
 	// 6. Create Agent, Start, SyncNow.
 	a, err := New(Config{
 		RepoPath:     localPath,
-		NATSUrl:      natsURL,
+		NATSUpstream:      natsURL,
 		PollInterval: 10 * time.Second, // long interval; we use SyncNow
 		Push:         true,
 		Pull:         false,

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+)
+
+// NATSMesh owns the embedded NATS server and tunnel establishment lifecycle.
+type NATSMesh struct {
+	role      NATSRole
+	upstream  string   // optional external NATS URL
+	irohPeers []string // remote EndpointIds
+	endpointID string  // our iroh EndpointId
+
+	sidecarSocketPath string // for HTTP calls to sidecar
+
+	server    *natsserver.Server
+	clientURL string // nats://127.0.0.1:<client-port>
+	leafAddr  string // 127.0.0.1:<leaf-port> (for sidecar --nats-addr)
+}
+
+// Start brings up the embedded NATS server.
+// Returns the NATS client URL for the agent to connect to.
+func (m *NATSMesh) Start() (clientURL string, err error) {
+	opts := m.buildServerOpts()
+	m.server, err = natsserver.NewServer(opts)
+	if err != nil {
+		return "", fmt.Errorf("nats mesh: create server: %w", err)
+	}
+	m.server.Start()
+	if !m.server.ReadyForConnections(5 * time.Second) {
+		m.server.Shutdown()
+		return "", fmt.Errorf("nats mesh: server not ready within 5s")
+	}
+
+	m.clientURL = m.server.ClientURL()
+
+	// Determine leaf node address for sidecar.
+	if m.role != NATSRoleLeaf {
+		varz, vErr := m.server.Varz(&natsserver.VarzOptions{})
+		if vErr == nil && varz.LeafNode.Port > 0 {
+			m.leafAddr = fmt.Sprintf("127.0.0.1:%d", varz.LeafNode.Port)
+		}
+	}
+
+	return m.clientURL, nil
+}
+
+// EstablishTunnels tells the sidecar to open NATS tunnels to peers.
+// Call after sidecar is started and endpointID is known.
+func (m *NATSMesh) EstablishTunnels() error {
+	if m.sidecarSocketPath == "" || m.endpointID == "" {
+		return nil // no sidecar or no endpoint — nothing to tunnel
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", m.sidecarSocketPath)
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	for _, peerID := range m.irohPeers {
+		if !shouldSolicit(m.role, m.endpointID, peerID) {
+			continue
+		}
+
+		reqURL := fmt.Sprintf("http://iroh-sidecar/nats-tunnel/%s", peerID)
+		resp, err := client.Post(reqURL, "", nil)
+		if err != nil {
+			return fmt.Errorf("tunnel to %s: %w", peerID, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("tunnel to %s: HTTP %d", peerID, resp.StatusCode)
+		}
+	}
+	return nil
+}
+
+// Stop shuts down the embedded NATS server.
+func (m *NATSMesh) Stop() {
+	if m.server != nil {
+		m.server.Shutdown()
+		m.server.WaitForShutdown()
+		m.server = nil
+	}
+}
+
+// LeafAddr returns the leaf node listen address for the sidecar's --nats-addr.
+func (m *NATSMesh) LeafAddr() string {
+	return m.leafAddr
+}
+
+// SetEndpointID is called after the sidecar reports its EndpointId.
+func (m *NATSMesh) SetEndpointID(id string) {
+	m.endpointID = id
+}
+
+// SetSidecarSocket provides the sidecar Unix socket path for tunnel HTTP calls.
+func (m *NATSMesh) SetSidecarSocket(path string) {
+	m.sidecarSocketPath = path
+}
+
+// buildServerOpts creates nats-server options based on role.
+func (m *NATSMesh) buildServerOpts() *natsserver.Options {
+	opts := &natsserver.Options{
+		Host:   "127.0.0.1",
+		Port:   -1, // random client port
+		NoLog:  true,
+		NoSigs: true,
+	}
+
+	switch m.role {
+	case NATSRolePeer, NATSRoleHub:
+		opts.LeafNode.Port = -1 // random leaf node port
+	case NATSRoleLeaf:
+		// No leaf port — this node solicits outward only.
+	}
+
+	// If upstream NATS URL is configured, join as a leaf.
+	if m.upstream != "" {
+		u, err := url.Parse(m.upstream)
+		if err == nil {
+			opts.LeafNode.Remotes = []*natsserver.RemoteLeafOpts{
+				{URLs: []*url.URL{u}},
+			}
+		}
+	}
+
+	return opts
+}
+
+// shouldSolicit determines whether we should initiate a NATS tunnel to a peer.
+func shouldSolicit(role NATSRole, myID, peerID string) bool {
+	switch role {
+	case NATSRoleLeaf:
+		return true
+	case NATSRoleHub:
+		return false
+	case NATSRolePeer:
+		return myID < peerID
+	default:
+		return false
+	}
+}

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,6 +13,23 @@ import (
 )
 
 // NATSMesh owns the embedded NATS server and tunnel establishment lifecycle.
+//
+// The startup order matters because the NATS leaf node protocol is asymmetric:
+//   - Hub side sends INFO, waits for CONNECT from the leaf.
+//   - Leaf side sends CONNECT in response to INFO.
+//
+// The sidecar's outbound tunnel binds a local TCP listener and returns its
+// port. The embedded NATS server must be configured with that port as a leaf
+// remote BEFORE starting. Meanwhile, the sidecar's inbound (accepting) side
+// needs to know the local NATS leaf port to connect to.
+//
+// To break the chicken-and-egg between sidecar needing the leaf port and
+// NATS needing the tunnel ports, we pre-reserve the leaf port:
+//
+//  1. ReserveLeafPort — bind an ephemeral port, record it, close the listener
+//  2. Start sidecar with --nats-addr pointing to the reserved port
+//  3. EstablishTunnels — get outbound tunnel ports from the sidecar
+//  4. Start — build NATS opts with the reserved leaf port + tunnel remotes
 type NATSMesh struct {
 	role      NATSRole
 	upstream  string   // optional external NATS URL
@@ -20,12 +38,99 @@ type NATSMesh struct {
 
 	sidecarSocketPath string // for HTTP calls to sidecar
 
+	// reservedLeafPort is pre-allocated so the sidecar can be told the leaf
+	// address before the NATS server starts. Zero means "let NATS pick".
+	reservedLeafPort int
+
+	// tunnelPorts holds local listener ports returned by the sidecar for each
+	// peer we should solicit. Populated by EstablishTunnels, consumed by Start.
+	tunnelPorts map[string]uint16 // peerID -> local port
+
 	server    *natsserver.Server
 	clientURL string // nats://127.0.0.1:<client-port>
 	leafAddr  string // 127.0.0.1:<leaf-port> (for sidecar --nats-addr)
 }
 
+// tunnelResponse is the JSON body returned by POST /nats-tunnel/{endpoint-id}.
+type tunnelResponse struct {
+	Port uint16 `json:"port"`
+}
+
+// ReserveLeafPort pre-allocates an ephemeral TCP port for the NATS leaf node
+// listener. The port is recorded so buildServerOpts can pass a specific port
+// to NATS instead of -1 (random). The listener is closed immediately — NATS
+// will rebind it when it starts. There is a small TOCTOU window, but in
+// practice collisions are extremely unlikely on localhost.
+//
+// Call this before starting the sidecar so --nats-addr can be set. Only
+// meaningful for hub/peer roles (leaf role has no leaf port).
+func (m *NATSMesh) ReserveLeafPort() error {
+	if m.role == NATSRoleLeaf {
+		return nil // leaf nodes don't listen for leaf connections
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("reserve leaf port: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	m.reservedLeafPort = port
+	m.leafAddr = fmt.Sprintf("127.0.0.1:%d", port)
+	return nil
+}
+
+// EstablishTunnels tells the sidecar to open NATS tunnels to peers.
+// Each tunnel returns a local TCP port that the embedded NATS server will
+// solicit to. Must be called BEFORE Start so the ports can be wired into
+// the NATS server options.
+func (m *NATSMesh) EstablishTunnels() error {
+	if m.sidecarSocketPath == "" || m.endpointID == "" {
+		return nil // no sidecar or no endpoint — nothing to tunnel
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", m.sidecarSocketPath)
+			},
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	m.tunnelPorts = make(map[string]uint16)
+
+	for _, peerID := range m.irohPeers {
+		if !shouldSolicit(m.role, m.endpointID, peerID) {
+			continue
+		}
+
+		reqURL := fmt.Sprintf("http://iroh-sidecar/nats-tunnel/%s", peerID)
+		resp, err := client.Post(reqURL, "", nil)
+		if err != nil {
+			return fmt.Errorf("tunnel to %s: %w", peerID, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return fmt.Errorf("tunnel to %s: HTTP %d", peerID, resp.StatusCode)
+		}
+
+		var tr tunnelResponse
+		err = json.NewDecoder(resp.Body).Decode(&tr)
+		resp.Body.Close()
+		if err != nil {
+			return fmt.Errorf("tunnel to %s: decode response: %w", peerID, err)
+		}
+		if tr.Port == 0 {
+			return fmt.Errorf("tunnel to %s: sidecar returned port 0", peerID)
+		}
+		m.tunnelPorts[peerID] = tr.Port
+	}
+	return nil
+}
+
 // Start brings up the embedded NATS server.
+// Tunnel ports from EstablishTunnels (if any) are included as leaf remotes.
 // Returns the NATS client URL for the agent to connect to.
 func (m *NATSMesh) Start() (clientURL string, err error) {
 	opts := m.buildServerOpts()
@@ -41,8 +146,8 @@ func (m *NATSMesh) Start() (clientURL string, err error) {
 
 	m.clientURL = m.server.ClientURL()
 
-	// Determine leaf node address for sidecar.
-	if m.role != NATSRoleLeaf {
+	// Determine leaf node address for sidecar (when not pre-reserved).
+	if m.role != NATSRoleLeaf && m.leafAddr == "" {
 		varz, vErr := m.server.Varz(&natsserver.VarzOptions{})
 		if vErr == nil && varz.LeafNode.Port > 0 {
 			m.leafAddr = fmt.Sprintf("127.0.0.1:%d", varz.LeafNode.Port)
@@ -50,40 +155,6 @@ func (m *NATSMesh) Start() (clientURL string, err error) {
 	}
 
 	return m.clientURL, nil
-}
-
-// EstablishTunnels tells the sidecar to open NATS tunnels to peers.
-// Call after sidecar is started and endpointID is known.
-func (m *NATSMesh) EstablishTunnels() error {
-	if m.sidecarSocketPath == "" || m.endpointID == "" {
-		return nil // no sidecar or no endpoint — nothing to tunnel
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", m.sidecarSocketPath)
-			},
-		},
-		Timeout: 10 * time.Second,
-	}
-
-	for _, peerID := range m.irohPeers {
-		if !shouldSolicit(m.role, m.endpointID, peerID) {
-			continue
-		}
-
-		reqURL := fmt.Sprintf("http://iroh-sidecar/nats-tunnel/%s", peerID)
-		resp, err := client.Post(reqURL, "", nil)
-		if err != nil {
-			return fmt.Errorf("tunnel to %s: %w", peerID, err)
-		}
-		resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("tunnel to %s: HTTP %d", peerID, resp.StatusCode)
-		}
-	}
-	return nil
 }
 
 // Stop shuts down the embedded NATS server.
@@ -111,6 +182,8 @@ func (m *NATSMesh) SetSidecarSocket(path string) {
 }
 
 // buildServerOpts creates nats-server options based on role.
+// Includes tunnel ports as additional leaf remotes so NATS solicits through the
+// sidecar's QUIC tunnels.
 func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 	opts := &natsserver.Options{
 		Host:   "127.0.0.1",
@@ -121,7 +194,12 @@ func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 
 	switch m.role {
 	case NATSRolePeer, NATSRoleHub:
-		opts.LeafNode.Port = -1 // random leaf node port
+		if m.reservedLeafPort > 0 {
+			opts.LeafNode.Host = "127.0.0.1"
+			opts.LeafNode.Port = m.reservedLeafPort
+		} else {
+			opts.LeafNode.Port = -1 // random leaf node port
+		}
 	case NATSRoleLeaf:
 		// No leaf port — this node solicits outward only.
 	}
@@ -130,9 +208,21 @@ func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 	if m.upstream != "" {
 		u, err := url.Parse(m.upstream)
 		if err == nil {
-			opts.LeafNode.Remotes = []*natsserver.RemoteLeafOpts{
-				{URLs: []*url.URL{u}},
-			}
+			opts.LeafNode.Remotes = append(opts.LeafNode.Remotes,
+				&natsserver.RemoteLeafOpts{URLs: []*url.URL{u}},
+			)
+		}
+	}
+
+	// Add tunnel ports as leaf remotes. Each port is a local TCP listener
+	// managed by the sidecar, which pipes traffic through QUIC to the remote
+	// peer's NATS hub.
+	for _, port := range m.tunnelPorts {
+		u, err := url.Parse(fmt.Sprintf("nats://127.0.0.1:%d", port))
+		if err == nil {
+			opts.LeafNode.Remotes = append(opts.LeafNode.Remotes,
+				&natsserver.RemoteLeafOpts{URLs: []*url.URL{u}},
+			)
 		}
 	}
 

--- a/leaf/agent/nats_mesh_test.go
+++ b/leaf/agent/nats_mesh_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestNATSMeshStartStop(t *testing.T) {
+	mesh := &NATSMesh{role: NATSRolePeer}
+	clientURL, err := mesh.Start()
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mesh.Stop()
+
+	if clientURL == "" {
+		t.Fatal("clientURL is empty")
+	}
+
+	nc, err := nats.Connect(clientURL, nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	if err := nc.Publish("test.subject", []byte("hello")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	nc.Flush()
+	t.Logf("mesh started at %s, publish OK", clientURL)
+}
+
+func TestNATSMeshRoleConfig(t *testing.T) {
+	for _, role := range []NATSRole{NATSRolePeer, NATSRoleHub, NATSRoleLeaf} {
+		t.Run(string(role), func(t *testing.T) {
+			mesh := &NATSMesh{role: role}
+			opts := mesh.buildServerOpts()
+
+			if role == NATSRoleLeaf {
+				if opts.LeafNode.Port != 0 {
+					t.Errorf("leaf role should not set LeafNode.Port, got %d", opts.LeafNode.Port)
+				}
+			} else {
+				if opts.LeafNode.Port != -1 {
+					t.Errorf("%s role should set LeafNode.Port to -1 (random), got %d", role, opts.LeafNode.Port)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldSolicit(t *testing.T) {
+	tests := []struct {
+		role     NATSRole
+		myID     string
+		peerID   string
+		expected bool
+	}{
+		{NATSRoleLeaf, "zzz", "aaa", true},
+		{NATSRoleHub, "aaa", "zzz", false},
+		{NATSRolePeer, "aaa", "zzz", true},
+		{NATSRolePeer, "zzz", "aaa", false},
+		{NATSRolePeer, "aaa", "aaa", false},
+	}
+	for _, tt := range tests {
+		name := string(tt.role) + "_" + tt.myID + "_vs_" + tt.peerID
+		t.Run(name, func(t *testing.T) {
+			got := shouldSolicit(tt.role, tt.myID, tt.peerID)
+			if got != tt.expected {
+				t.Errorf("shouldSolicit(%s, %s, %s) = %v, want %v",
+					tt.role, tt.myID, tt.peerID, got, tt.expected)
+			}
+		})
+	}
+}

--- a/leaf/agent/sidecar.go
+++ b/leaf/agent/sidecar.go
@@ -19,6 +19,7 @@ type sidecar struct {
 	keyPath     string
 	callbackURL string
 	alpn        string
+	natsAddr    string // optional, for --nats-addr (mesh leaf node address)
 	cmd         *exec.Cmd
 	exited      chan struct{} // closed when the process exits
 	exitErr     error        // set before exited is closed
@@ -50,12 +51,16 @@ func (s *sidecar) spawn() error {
 		return fmt.Errorf("iroh sidecar binary not found: %w", err)
 	}
 
-	s.cmd = exec.Command(s.binPath,
+	args := []string{
 		"--socket", s.socketPath,
 		"--key-path", s.keyPath,
 		"--callback", s.callbackURL,
 		"--alpn", s.alpn,
-	)
+	}
+	if s.natsAddr != "" {
+		args = append(args, "--nats-addr", s.natsAddr)
+	}
+	s.cmd = exec.Command(s.binPath, args...)
 	s.cmd.Stdout = os.Stdout
 	s.cmd.Stderr = os.Stderr
 

--- a/leaf/cmd/leaf/main.go
+++ b/leaf/cmd/leaf/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	cfg := agent.Config{
 		RepoPath:         *repoPath,
-		NATSUrl:          *natsURL,
+		NATSUpstream:          *natsURL,
 		PollInterval:     *poll,
 		User:             *user,
 		Password:         *password,

--- a/leaf/cmd/wasm/main.go
+++ b/leaf/cmd/wasm/main.go
@@ -50,7 +50,7 @@ func jsNewAgent(_ js.Value, args []js.Value) any {
 
 	config := agent.Config{
 		RepoPath:     repoPath,
-		NATSUrl:      natsUrl,
+		NATSUpstream:      natsUrl,
 		Push:         true,
 		Pull:         true,
 		PollInterval: time.Duration(pollSec) * time.Second,

--- a/sim/harness.go
+++ b/sim/harness.go
@@ -270,7 +270,7 @@ func (h *Harness) StartAgents() error {
 	for i, repoPath := range h.leafPaths {
 		a, err := agent.New(agent.Config{
 			RepoPath:      repoPath,
-			NATSUrl:       natsTarget,
+			NATSUpstream:  natsTarget,
 
 			Push:          true,
 			Pull:          true,
@@ -389,7 +389,7 @@ func (h *Harness) restartLeaf(target string, t *testing.T) {
 	}
 	a, err := agent.New(agent.Config{
 		RepoPath:      h.leafPaths[idx],
-		NATSUrl:       natsTarget,
+		NATSUpstream:  natsTarget,
 		Push:          true,
 		Pull:          true,
 		PollInterval:  2 * time.Second,

--- a/sim/nats_iroh_test.go
+++ b/sim/nats_iroh_test.go
@@ -1,0 +1,182 @@
+package sim
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/go-libfossil"
+	_ "github.com/danmestas/go-libfossil/db/driver/modernc"
+	"github.com/danmestas/go-libfossil/simio"
+	"github.com/dmestas/edgesync/leaf/agent"
+)
+
+// TestNATSOverIrohSync proves two peer agents created via agent.New() (with
+// embedded NATSMesh, iroh sidecars, and no external NATS) can sync blobs
+// peer-to-peer via iroh QUIC transport.
+//
+// This exercises the full agent lifecycle introduced in Task 6:
+//   - agent.New() → NATSMesh.Start() → embedded NATS server per agent
+//   - agent.Start() → sidecar launch → EndpointId discovery
+//   - IrohTransport sync through sidecar QUIC tunnels
+//
+// The agents use NATSRole=peer and ServeNATSEnabled=true, proving the mesh
+// boots correctly alongside the iroh sidecar. The actual data sync uses
+// IrohTransport (xfer-over-QUIC) which routes through the sidecars.
+func TestNATSOverIrohSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping NATS-over-iroh integration test in short mode")
+	}
+
+	sidecarBin := findIrohSidecar(t)
+
+	dir := t.TempDir()
+
+	// 1. Create two repos with matching project-code + server-code.
+	projCode := "abcdef0123456789abcdef0123456789abcdef01"
+	srvCode := "fedcba9876543210fedcba9876543210fedcba98"
+	var leafPaths [2]string
+	for i := range 2 {
+		path := filepath.Join(dir, fmt.Sprintf("leaf-%d.fossil", i))
+		r, err := libfossil.Create(path, libfossil.CreateOpts{User: "testuser", Rand: simio.CryptoRand{}})
+		if err != nil {
+			t.Fatalf("Create leaf-%d: %v", i, err)
+		}
+		r.SetConfig("project-code", projCode)
+		r.SetConfig("server-code", srvCode)
+		r.Close()
+		leafPaths[i] = path
+	}
+
+	// 2. Seed blobs into leaf-0.
+	r0, err := libfossil.Open(leafPaths[0])
+	if err != nil {
+		t.Fatalf("open leaf-0 for seeding: %v", err)
+	}
+	rng := rand.New(rand.NewSource(77))
+	seededUUIDs, err := SeedLeaf(r0, rng, 8, 2048)
+	if err != nil {
+		r0.Close()
+		t.Fatalf("SeedLeaf: %v", err)
+	}
+	r0.Close()
+	t.Logf("seeded %d blobs into leaf-0", len(seededUUIDs))
+
+	// 3. Create two agents via agent.New() — full lifecycle with NATSMesh.
+	type leafState struct {
+		agent *agent.Agent
+	}
+	var leaves [2]leafState
+
+	for i := range 2 {
+		idx := i // capture for closure
+		cfg := agent.Config{
+			RepoPath:         leafPaths[i],
+			NATSRole:         agent.NATSRolePeer,
+			Push:             true,
+			Pull:             true,
+			PollInterval:     60 * time.Second, // no auto-poll
+			IrohEnabled:      true,
+			IrohKeyPath:      filepath.Join(dir, fmt.Sprintf("leaf-%d.iroh-key", i)),
+			IrohBinaryPath:   sidecarBin,
+			ServeNATSEnabled: true,
+			PeerID:           fmt.Sprintf("test-peer-%d", i),
+			Logger: func(msg string) {
+				t.Logf("[leaf-%d] %s", idx, msg)
+			},
+		}
+
+		a, err := agent.New(cfg)
+		if err != nil {
+			t.Fatalf("agent.New leaf-%d: %v", i, err)
+		}
+		leaves[i] = leafState{agent: a}
+	}
+
+	// Start both agents (mesh + sidecar + NATS serve listener).
+	for i := range 2 {
+		if err := leaves[i].agent.Start(); err != nil {
+			for j := 0; j < i; j++ {
+				leaves[j].agent.Stop()
+			}
+			t.Fatalf("leaf-%d start: %v", i, err)
+		}
+	}
+	defer func() {
+		for i := range 2 {
+			leaves[i].agent.Stop()
+		}
+	}()
+
+	// 4. Wait for both sidecars to report EndpointIds.
+	var endpoints [2]string
+	for i := range 2 {
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			id := leaves[i].agent.IrohEndpointID()
+			if id != "" {
+				endpoints[i] = id
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if endpoints[i] == "" {
+			t.Fatalf("leaf-%d: iroh endpoint ID not available after 15s", i)
+		}
+		t.Logf("leaf-%d endpoint_id=%s", i, endpoints[i])
+	}
+
+	// 5. Sync leaf-0 → leaf-1 via IrohTransport (xfer over sidecar QUIC).
+	// Give sidecars time to register with relay/STUN for peer discovery.
+	time.Sleep(5 * time.Second)
+
+	irohTransport := agent.NewIrohTransport(
+		leaves[0].agent.IrohSocketPath(),
+		endpoints[1],
+	)
+
+	var result *libfossil.SyncResult
+	for attempt := 0; attempt < 5; attempt++ {
+		syncCtx, syncCancel := context.WithTimeout(t.Context(), 15*time.Second)
+		result, err = leaves[0].agent.Repo().Sync(syncCtx, irohTransport, libfossil.SyncOpts{
+			Push:        true,
+			Pull:        true,
+			ProjectCode: projCode,
+			ServerCode:  srvCode,
+		})
+		syncCancel()
+		if err == nil {
+			break
+		}
+		t.Logf("sync attempt %d: %v (retrying...)", attempt+1, err)
+		time.Sleep(3 * time.Second)
+	}
+	if err != nil {
+		t.Fatalf("iroh sync leaf-0 → leaf-1 failed after 5 attempts: %v", err)
+	}
+	t.Logf("sync result: sent=%d recv=%d rounds=%d", result.FilesSent, result.FilesRecvd, result.Rounds)
+
+	// 6. Verify convergence: leaf-1 should have all seeded blobs.
+	var leaf0Blobs, leaf1Blobs int
+	leaves[0].agent.Repo().DB().QueryRow("SELECT count(*) FROM blob WHERE size>0").Scan(&leaf0Blobs)
+	leaves[1].agent.Repo().DB().QueryRow("SELECT count(*) FROM blob WHERE size>0").Scan(&leaf1Blobs)
+	t.Logf("leaf-0: %d blobs, leaf-1: %d blobs", leaf0Blobs, leaf1Blobs)
+
+	if leaf1Blobs < len(seededUUIDs) {
+		t.Errorf("leaf-1 has %d blobs, want >= %d (seeded)", leaf1Blobs, len(seededUUIDs))
+	}
+
+	// Verify specific UUIDs.
+	for _, uuid := range seededUUIDs {
+		var exists int
+		leaves[1].agent.Repo().DB().QueryRow("SELECT count(*) FROM blob WHERE uuid=?", uuid).Scan(&exists)
+		if exists == 0 {
+			t.Errorf("leaf-1 missing blob %s", uuid[:16])
+		}
+	}
+
+	t.Logf("PASS: peer agents with NATSMesh + iroh sidecar — %d blobs synced peer-to-peer", len(seededUUIDs))
+}


### PR DESCRIPTION
## Summary

Run NATS leaf node connections over iroh QUIC bidirectional streams. Each agent runs an embedded NATS server. The iroh sidecar tunnels NATS traffic over a new ALPN (`/edgesync/nats-leaf/1`). Peers form a mesh without central NATS infrastructure.

### Sidecar (Rust)
- New `tunnel.rs` — bidirectional TCP-QUIC pipe for NATS leaf connections
- ALPN dispatch in acceptor — routes xfer vs NATS tunnel connections
- `POST /nats-tunnel/{endpoint_id}` — establishes outbound tunnel, returns local listener port
- Asymmetric tunnel: accepting side connects to local NATS leaf port (hub), soliciting side listens for NATS to connect outward (leaf)

### Agent (Go)
- `NATSMesh` module — embedded NATS server + tunnel establishment + startup sequencing
- `NATSRole` config: `peer` (accepts + solicits), `hub` (accepts only), `leaf` (solicits only)
- Connection direction: lower EndpointId solicits, higher waits (for peer role)
- Pre-reserved leaf port resolves chicken-and-egg between sidecar and NATS startup
- `NATSUrl` renamed to `NATSUpstream` (optional external NATS joined as leaf)

### Key design decisions
- Embedded NATS always runs — agent connects to localhost
- Sidecar is a dumb TCP pipe (zero NATS protocol awareness)
- Tunnel asymmetry matches NATS leaf node protocol (hub sends INFO, leaf sends CONNECT)
- Backwards compatible: `NewFromParts()` still works without mesh

## Test plan
- [x] NATSMesh unit tests (start/stop, role config, shouldSolicit)
- [x] All 25 agent tests pass
- [x] Sidecar builds clean (`cargo build`)
- [x] Integration test: two agents sync via xfer-over-iroh with embedded NATS
- [ ] End-to-end NATS leaf node tunnel verification (needs manual testing with sidecar binary)

## Status

This is a **spike** — the infrastructure is built and unit-tested. The NATS leaf tunnel asymmetry is fixed (outbound returns listener port, NATS solicits through it). Full end-to-end NATS subject propagation across the tunnel needs integration testing with real sidecars.