### PR TITLE
fix: NATS-over-iroh follow-up — review fixes, interface refactor, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,11 @@ go-libfossil exposes an opaque `Repo` handle — all operations are methods on i
 
 ### Agent/Bridge
 - `leaf/agent/` — `Config` (config.go), `New()`, `Start()`, `Stop()`, `SyncNow()`
+  - `nats_mesh.go` — `NATSMesh` module: embedded NATS server + iroh tunnel establishment
   - `serve_http.go` — composes mux with `/healthz` + `r.XferHandler()` (operational endpoints live here, not in go-libfossil)
   - `serve_nats.go` — NATS request/reply listener for leaf-to-leaf sync
-  - `serve_p2p.go` — libp2p stub
-  - Config fields: `ServeHTTPAddr` (":8080" to serve HTTP), `ServeNATSEnabled` (leaf-to-leaf)
-  - CLI flags: `--repo`, `--nats`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`
+  - Config fields: `NATSRole` (peer/hub/leaf), `NATSUpstream` (optional external NATS), `ServeHTTPAddr`, `ServeNATSEnabled`, `IrohEnabled`, `IrohPeers`, `IrohKeyPath`
+  - CLI flags: `--repo`, `--nats`, `--nats-role`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`, `--iroh`, `--iroh-peer`, `--iroh-key`
 - `bridge/bridge/` — `Config` (config.go), `New()`, `Start()`, `Stop()`
 
 ### Simulation Testing

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ graph LR
     Leaf -- NATS --> Bridge
     Leaf -- NATS --> Peer
     Leaf -- HTTP --> Peer
+    Leaf -- "NATS over iroh (QUIC)" --> Peer
 ```
 
-**Three sync modes:**
+**Four sync modes:**
 1. **Leaf → Bridge → Fossil Server** — Original mode. Bridge translates NATS to HTTP `/xfer`.
 2. **Leaf → Leaf (NATS)** — Peer-to-peer via ServeNATS. No bridge or server needed.
 3. **Leaf → Leaf (HTTP)** — Peer-to-peer via ServeHTTP. Stock `fossil clone`/`fossil sync` works.
+4. **Leaf → Leaf (iroh)** — Peer-to-peer over QUIC with NAT traversal. Each agent runs an embedded NATS server; leaf node connections tunnel over iroh. Enables presence and messaging without central infrastructure.
 
 ## Quick Start
 

--- a/docs/architecture/agent-deployment.md
+++ b/docs/architecture/agent-deployment.md
@@ -11,7 +11,8 @@ The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil re
 | Config Field | Default | CLI Flag | Env Var |
 |---|---|---|---|
 | `RepoPath` | (required) | `--repo` | `LEAF_REPO` |
-| `NATSUrl` | `nats://localhost:4222` | `--nats` | `LEAF_NATS_URL` |
+| `NATSRole` | `"peer"` | `--nats-role` | |
+| `NATSUpstream` | `""` (embedded only) | `--nats` | `LEAF_NATS_URL` |
 | `PollInterval` | `5s` | `--poll` | |
 | `User` | `""` (anonymous) | `--user` | |
 | `Password` | `""` | `--password` | |
@@ -21,6 +22,16 @@ The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil re
 | `ServeNATSEnabled` | `false` | `--serve-nats` | |
 | `UV` | `false` | `--uv` | |
 | `SubjectPrefix` | `"fossil"` | `--prefix` | |
+
+**Embedded NATS:** Every agent runs an in-process NATS server. The agent's NATS client connects to localhost. If `NATSUpstream` is set, the embedded server joins external NATS as a leaf node. If iroh peers are configured, the embedded server connects to them via tunnels over QUIC.
+
+**NATSRole** determines mesh topology:
+
+| Role | Accepts leaf connections | Solicits leaf connections | Use case |
+|---|---|---|---|
+| `peer` (default) | Yes | Yes (lower EndpointId solicits) | Native P2P mesh |
+| `hub` | Yes | No | Dedicated server, cluster node |
+| `leaf` | No | Yes (always solicits outward) | WASM browser, lightweight client |
 
 ## Bridge Architecture
 

--- a/docs/leaf-agent.md
+++ b/docs/leaf-agent.md
@@ -1,127 +1,155 @@
 # Leaf Agent
 
-A daemon process that sits next to a Fossil repo and keeps it synced over NATS.
+A daemon that syncs a local Fossil repo via NATS messaging and/or direct peer-to-peer over iroh.
 
 ## Overview
 
-The leaf agent watches a local Fossil repository for new artifacts and syncs them to a remote Fossil server through a NATS message bus. It implements the client side of Fossil's sync protocol without needing the `fossil` binary installed.
+The leaf agent opens a Fossil repository, runs an embedded NATS server, and syncs artifacts on a poll loop. It implements both the client and server sides of Fossil's sync protocol — a stock `fossil clone`/`fossil sync` can talk to it directly via HTTP.
 
-## How It Works
+## Transport Modes
 
-```
-fossil commit → repo SQLite updated → leaf polls unsent/unclustered tables
-    → sync.Sync() via NATSTransport → NATS request/reply → bridge → fossil server
-```
+| Mode | Transport | Infrastructure | Use case |
+|------|-----------|---------------|----------|
+| Bridged | NATS → Bridge → HTTP | External NATS + Fossil server | Production with central server |
+| Leaf-to-leaf (NATS) | NATS subject request/reply | External NATS | Peer-to-peer via shared NATS |
+| Leaf-to-leaf (HTTP) | HTTP `/xfer` | None | Direct sync, `fossil clone` compat |
+| Leaf-to-leaf (iroh) | NATS over QUIC tunnel | iroh sidecar | P2P with NAT traversal, no central infra |
 
-1. **Opens a Fossil repo** via `repo.Open(path)` — reads `project-code` and `server-code` from the SQLite config table
-2. **Connects to NATS** at the configured URL
-3. **Runs a poll loop** — every N seconds (default 5s):
-   - Queries `unsent` and `unclustered` tables for new local artifacts
-   - If anything found (or pull is enabled), calls `sync.Sync()` through the NATS transport
-4. **Syncs via NATS request/reply** — encodes an xfer Message, publishes to `<prefix>.<project-code>.sync`, waits for the bridge's reply, decodes the response
-5. **Handles signals**:
-   - `SIGUSR1` — triggers an immediate sync (skips the poll timer)
-   - `SIGINT` / `SIGTERM` — graceful shutdown (stops loop, closes NATS, closes repo)
-
-## Usage
-
-```bash
-leaf-agent --repo /path/to/repo.fossil \
-           --nats nats://localhost:4222 \
-           --poll 5s \
-           --user anonymous \
-           --push \
-           --pull
-```
-
-### Flags
+## Flags
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
 | `--repo` | `LEAF_REPO` | (required) | Path to `.fossil` repo file |
-| `--nats` | `LEAF_NATS_URL` | `nats://localhost:4222` | NATS server URL |
-| `--poll` | — | `5s` | Poll interval |
-| `--user` | `LEAF_USER` | `anonymous` | Sync user |
+| `--nats` | `LEAF_NATS_URL` | `""` | Optional upstream NATS URL (embedded server joins as leaf) |
+| `--nats-role` | | `peer` | Mesh role: `peer`, `hub`, or `leaf` |
+| `--poll` | | `5s` | Poll interval |
+| `--user` | `LEAF_USER` | (anonymous) | Sync user |
 | `--password` | `LEAF_PASSWORD` | (empty) | Sync password |
-| `--push` | — | `true` | Enable pushing local artifacts |
-| `--pull` | — | `true` | Enable pulling remote artifacts |
-| `--prefix` | — | `fossil` | NATS subject prefix |
+| `--push` / `--no-push` | | `true` | Enable pushing local artifacts |
+| `--pull` / `--no-pull` | | `true` | Enable pulling remote artifacts |
+| `--serve-http` | `LEAF_SERVE_HTTP` | (disabled) | HTTP listen address for `/xfer` + `/healthz` |
+| `--serve-nats` | | `false` | Enable NATS request/reply listener |
+| `--uv` | | `false` | Sync unversioned files (wiki, forum, attachments) |
+| `--prefix` | | `fossil` | NATS subject prefix |
+| `--iroh` | `LEAF_IROH` | `false` | Enable iroh sidecar for P2P |
+| `--iroh-peer` | | (none) | Remote EndpointId (repeatable) |
+| `--iroh-key` | `LEAF_IROH_KEY` | `<repo>.iroh-key` | Ed25519 keypair path |
+| `--verbose` / `-v` | | `false` | Verbose logging |
 
-### Manual Sync
+## Embedded NATS
+
+Every agent runs an in-process NATS server on a random localhost port. The agent's NATS client connects to this local server. This is transparent — the agent doesn't need to know whether peers are reached via external NATS, iroh tunnels, or both.
+
+If `--nats` is provided, the embedded server joins the external NATS as a leaf node. Messages flow between external and embedded NATS automatically.
+
+## Connecting Two Nodes over iroh
+
+iroh enables peer-to-peer sync over QUIC with automatic NAT traversal. No central NATS server or VPN needed — just two machines with internet access.
+
+### Prerequisites
+
+- Both machines have the `leaf` and `iroh-sidecar` binaries
+- Both repos have matching `project-code` and `server-code`
+
+### Step 1: Start both agents
+
+On machine A:
+```bash
+leaf --repo project.fossil --iroh --serve-nats --poll 5s
+```
+
+On machine B:
+```bash
+leaf --repo project.fossil --iroh --serve-nats --poll 5s
+```
+
+Both agents will start their iroh sidecars and log their EndpointIds:
+```
+iroh sidecar ready, endpoint_id=abc123def456...
+```
+
+### Step 2: Exchange EndpointIds
+
+Copy each machine's EndpointId and restart with `--iroh-peer`:
+
+On machine A:
+```bash
+leaf --repo project.fossil --iroh --serve-nats \
+     --iroh-peer <machine-B-endpoint-id>
+```
+
+On machine B:
+```bash
+leaf --repo project.fossil --iroh --serve-nats \
+     --iroh-peer <machine-A-endpoint-id>
+```
+
+The agents will establish a NATS leaf node tunnel over iroh QUIC. Sync happens automatically on the next poll cycle.
+
+### How it works
+
+```
+Machine A                              Machine B
+┌─────────────────┐                   ┌─────────────────┐
+│ Leaf Agent      │                   │ Leaf Agent      │
+│  ↕ nats://      │                   │  ↕ nats://      │
+│ Embedded NATS   │                   │ Embedded NATS   │
+│  ↕ TCP          │                   │  ↕ TCP          │
+│ iroh sidecar    │◄═══ QUIC ════════►│ iroh sidecar    │
+│ (NAT traversal) │   (encrypted)     │ (NAT traversal) │
+└─────────────────┘                   └─────────────────┘
+```
+
+1. Each agent runs an embedded NATS server
+2. The iroh sidecar tunnels NATS leaf node connections over QUIC
+3. The lower EndpointId peer initiates the tunnel (deterministic, no config needed)
+4. NATS handles message routing, subscriptions, and reconnection automatically
+5. Sync happens over NATS subjects — the agent's `NATSTransport` doesn't know it's going over iroh
+
+### Roles
+
+For simple two-node sync, the default `peer` role works. For more complex topologies:
+
+- **`--nats-role hub`** — Dedicated server that only accepts connections. Use when one machine is always-on and others connect to it.
+- **`--nats-role leaf`** — Lightweight client that always solicits outward. Use for WASM browsers or ephemeral machines.
+- **`--nats-role peer`** (default) — Both accepts and solicits. The peer with the lexicographically lower EndpointId initiates the connection.
+
+### With an existing NATS server
+
+You can combine iroh P2P with an external NATS server. The embedded NATS joins the external server as a leaf:
 
 ```bash
-# Trigger immediate sync without waiting for poll
-kill -USR1 $(pgrep leaf-agent)
+leaf --repo project.fossil --iroh --serve-nats \
+     --nats nats://central-server:4222 \
+     --iroh-peer <peer-endpoint-id>
 ```
+
+This gives you:
+- Central NATS for peers that can reach it directly
+- iroh tunnels for peers behind NAT or firewalls
+- All peers see each other through the NATS leaf node graph
 
 ## Architecture
 
 ```
 leaf/
-  cmd/leaf/main.go      CLI entry point, flag parsing, signal handling
+  cmd/leaf/main.go        CLI entry point, flag parsing, signal handling
   agent/
-    config.go            Config struct with defaults and validation
-    agent.go             Agent: New/Start/Stop/SyncNow, poll loop
-    nats.go              NATSTransport implementing sync.Transport
+    config.go             Config struct with defaults and validation
+    agent.go              Agent: New/Start/Stop/SyncNow, poll loop
+    nats_mesh.go          NATSMesh: embedded NATS + iroh tunnel lifecycle
+    nats.go               NATSTransport implementing libfossil.Transport
+    iroh.go               IrohTransport for direct xfer-over-QUIC
+    sidecar.go            iroh-sidecar process management
+    serve_http.go         HTTP server (/healthz + /xfer)
+    serve_nats.go         NATS request/reply handler
+    peer_registry.go      Peer discovery metadata table
 ```
-
-### NATSTransport
-
-Implements `sync.Transport` over NATS request/reply:
-
-```go
-type NATSTransport struct {
-    conn    *nats.Conn
-    subject string        // "<prefix>.<project-code>.sync"
-    timeout time.Duration // default 30s
-}
-
-func (t *NATSTransport) Exchange(ctx, req) (*xfer.Message, error) {
-    // 1. req.Encode() → zlib bytes with 4-byte size prefix
-    // 2. conn.RequestWithContext(ctx, subject, bytes)
-    // 3. xfer.Decode(reply.Data) → *xfer.Message
-}
-```
-
-### Poll Loop
-
-```go
-for {
-    select {
-    case <-ctx.Done():
-        return  // shutdown
-    case <-time.After(pollInterval):
-        doSync()
-    case <-syncNow:
-        doSync()  // SIGUSR1 triggered
-    }
-}
-```
-
-The poll goroutine is the sole executor of `doSync()` — `SyncNow()` only sends on a buffered channel, avoiding concurrent SQLite access.
-
-### doSync
-
-1. **Optimization check** — if `unsent` and `unclustered` tables are both empty and pull is disabled, skip this round
-2. Call `sync.Sync(ctx, repo, transport, opts)`
-3. Log results (rounds, files sent/received, errors)
-4. On error: log and continue (don't crash)
 
 ## What It Does NOT Do
 
-- No web UI or HTTP server
+- No web UI
 - No multi-repo support (one agent per repo)
-- No JetStream persistence (request/reply only — JetStream is a future upgrade)
-- No peer discovery or P2P sync
-- No filesystem watching (polls SQLite tables, not the filesystem)
-- No authentication computation (uses `nobody` permissions or sends login card if user/password provided)
-
-## Dependencies
-
-- `go-libfossil` — sync engine, repo access, xfer codec
-- `github.com/nats-io/nats.go` — NATS client
-- `github.com/nats-io/nats-server/v2` — embedded NATS server (test only)
-
-## Relationship to Bridge
-
-The leaf agent sends sync requests over NATS. It does not know or care what's on the other end. In production, a [bridge](bridge.md) subscribes to those requests and proxies them to a Fossil HTTP server. In tests, a mock subscriber plays the same role.
+- No filesystem watching (polls SQLite tables)
+- No peer discovery (manual `--iroh-peer` config for now)
+- No JetStream persistence (request/reply only)

--- a/iroh-sidecar/src/main.rs
+++ b/iroh-sidecar/src/main.rs
@@ -60,7 +60,6 @@ async fn main() -> anyhow::Result<()> {
         ep.clone(),
         endpoint_id,
         args.alpn.as_bytes().to_vec(),
-        args.nats_addr.clone(),
         shutdown_tx,
     );
 

--- a/iroh-sidecar/src/server.rs
+++ b/iroh-sidecar/src/server.rs
@@ -32,8 +32,6 @@ pub struct AppState {
     pub endpoint: Endpoint,
     pub endpoint_id: String,
     pub alpn: Vec<u8>,
-    /// Local NATS server address for tunnel connections.
-    pub nats_addr: Option<String>,
     /// Cache of live outbound connections keyed by remote endpoint-id string.
     pub conn_cache: Arc<Mutex<HashMap<String, Connection>>>,
     /// Send on this channel to trigger graceful shutdown.
@@ -45,14 +43,12 @@ impl AppState {
         endpoint: Endpoint,
         endpoint_id: String,
         alpn: Vec<u8>,
-        nats_addr: Option<String>,
         shutdown_tx: oneshot::Sender<()>,
     ) -> Self {
         AppState {
             endpoint,
             endpoint_id,
             alpn,
-            nats_addr,
             conn_cache: Arc::new(Mutex::new(HashMap::new())),
             shutdown_tx: Arc::new(Mutex::new(Some(shutdown_tx))),
         }

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -219,14 +219,22 @@ func (a *Agent) Start() error {
 	return nil
 }
 
-// startNATSMesh starts the embedded NATS server (with tunnel remotes already
-// configured by EstablishTunnels) and connects the NATS client.
+// startNATSMesh starts the embedded NATS server and connects the NATS client.
+// If iroh is active, passes sidecar info so the mesh can establish tunnels.
 func (a *Agent) startNATSMesh() error {
 	if a.mesh == nil {
 		return nil
 	}
 
-	clientURL, err := a.mesh.Start()
+	var sc *SidecarInfo
+	if a.irohSidecar != nil && a.irohEndpointID != "" {
+		sc = &SidecarInfo{
+			EndpointID: a.irohEndpointID,
+			SocketPath: a.irohSock,
+		}
+	}
+
+	clientURL, err := a.mesh.Start(sc)
 	if err != nil {
 		return fmt.Errorf("agent: nats mesh start: %w", err)
 	}
@@ -386,18 +394,9 @@ func (a *Agent) startIrohSidecar(ctx context.Context) error {
 	a.irohEndpointID = status.EndpointID
 	a.logf("iroh sidecar ready, endpoint_id=%s", status.EndpointID)
 
-	// Establish outbound NATS tunnels. Each tunnel returns a local port that
-	// the NATS server will solicit to. These ports are consumed by
-	// startNATSMesh -> mesh.Start -> buildServerOpts.
-	if a.mesh != nil {
-		a.mesh.SetEndpointID(status.EndpointID)
-		a.mesh.SetSidecarSocket(a.irohSock)
-		if err := a.mesh.EstablishTunnels(); err != nil {
-			// Non-fatal: log and continue. Tunnels can be retried later.
-			a.logf("warning: establish tunnels: %v", err)
-			slog.Warn("failed to establish iroh NATS tunnels", "error", err)
-		}
-	}
+	// Tunnel establishment is now handled by mesh.Start(SidecarInfo) in
+	// startNATSMesh. The mesh uses the EndpointID and socket path to
+	// establish tunnels before starting the NATS server.
 
 	// Register iroh peers as sync targets.
 	for _, peerID := range a.config.IrohPeers {

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -100,6 +101,7 @@ func (m *NATSMesh) EstablishTunnels() error {
 
 	m.tunnelPorts = make(map[string]uint16)
 
+	var errs []error
 	for _, peerID := range m.irohPeers {
 		if !shouldSolicit(m.role, m.endpointID, peerID) {
 			continue
@@ -108,25 +110,29 @@ func (m *NATSMesh) EstablishTunnels() error {
 		reqURL := fmt.Sprintf("http://iroh-sidecar/nats-tunnel/%s", peerID)
 		resp, err := client.Post(reqURL, "", nil)
 		if err != nil {
-			return fmt.Errorf("tunnel to %s: %w", peerID, err)
+			errs = append(errs, fmt.Errorf("tunnel to %s: %w", peerID, err))
+			continue
 		}
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
-			return fmt.Errorf("tunnel to %s: HTTP %d", peerID, resp.StatusCode)
+			errs = append(errs, fmt.Errorf("tunnel to %s: HTTP %d", peerID, resp.StatusCode))
+			continue
 		}
 
 		var tr tunnelResponse
 		err = json.NewDecoder(resp.Body).Decode(&tr)
 		resp.Body.Close()
 		if err != nil {
-			return fmt.Errorf("tunnel to %s: decode response: %w", peerID, err)
+			errs = append(errs, fmt.Errorf("tunnel to %s: decode response: %w", peerID, err))
+			continue
 		}
 		if tr.Port == 0 {
-			return fmt.Errorf("tunnel to %s: sidecar returned port 0", peerID)
+			errs = append(errs, fmt.Errorf("tunnel to %s: sidecar returned port 0", peerID))
+			continue
 		}
 		m.tunnelPorts[peerID] = tr.Port
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Start brings up the embedded NATS server.
@@ -141,7 +147,7 @@ func (m *NATSMesh) Start() (clientURL string, err error) {
 	m.server.Start()
 	if !m.server.ReadyForConnections(5 * time.Second) {
 		m.server.Shutdown()
-		return "", fmt.Errorf("nats mesh: server not ready within 5s")
+		return "", fmt.Errorf("nats mesh: server not ready within 5s (reserved leaf port: %d)", m.reservedLeafPort)
 	}
 
 	m.clientURL = m.server.ClientURL()

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -13,7 +13,17 @@ import (
 	natsserver "github.com/nats-io/nats-server/v2/server"
 )
 
+// SidecarInfo provides the sidecar details that NATSMesh needs for tunnel
+// establishment. Passed to Start so the mesh can drive the full sequence.
+type SidecarInfo struct {
+	EndpointID string // our iroh EndpointId
+	SocketPath string // Unix socket for HTTP calls to sidecar
+}
+
 // NATSMesh owns the embedded NATS server and tunnel establishment lifecycle.
+//
+// The caller creates a NATSMesh and calls Start(). Everything else — port
+// reservation, tunnel establishment, NATS server configuration — is internal.
 //
 // The startup order matters because the NATS leaf node protocol is asymmetric:
 //   - Hub side sends INFO, waits for CONNECT from the leaf.
@@ -24,32 +34,20 @@ import (
 // remote BEFORE starting. Meanwhile, the sidecar's inbound (accepting) side
 // needs to know the local NATS leaf port to connect to.
 //
-// To break the chicken-and-egg between sidecar needing the leaf port and
-// NATS needing the tunnel ports, we pre-reserve the leaf port:
-//
-//  1. ReserveLeafPort — bind an ephemeral port, record it, close the listener
-//  2. Start sidecar with --nats-addr pointing to the reserved port
-//  3. EstablishTunnels — get outbound tunnel ports from the sidecar
-//  4. Start — build NATS opts with the reserved leaf port + tunnel remotes
+// To break the chicken-and-egg, Start pre-reserves the leaf port, uses it
+// to tell the sidecar where NATS will listen, establishes tunnels to get
+// remote ports, then starts NATS with all ports configured.
 type NATSMesh struct {
 	role      NATSRole
 	upstream  string   // optional external NATS URL
 	irohPeers []string // remote EndpointIds
-	endpointID string  // our iroh EndpointId
 
-	sidecarSocketPath string // for HTTP calls to sidecar
-
-	// reservedLeafPort is pre-allocated so the sidecar can be told the leaf
-	// address before the NATS server starts. Zero means "let NATS pick".
+	// Set internally during Start.
 	reservedLeafPort int
-
-	// tunnelPorts holds local listener ports returned by the sidecar for each
-	// peer we should solicit. Populated by EstablishTunnels, consumed by Start.
-	tunnelPorts map[string]uint16 // peerID -> local port
-
-	server    *natsserver.Server
-	clientURL string // nats://127.0.0.1:<client-port>
-	leafAddr  string // 127.0.0.1:<leaf-port> (for sidecar --nats-addr)
+	tunnelPorts      map[string]uint16 // peerID -> local port
+	server           *natsserver.Server
+	clientURL        string // nats://127.0.0.1:<client-port>
+	leafAddr         string // 127.0.0.1:<leaf-port> (for sidecar --nats-addr)
 }
 
 // tunnelResponse is the JSON body returned by POST /nats-tunnel/{endpoint-id}.
@@ -57,17 +55,21 @@ type tunnelResponse struct {
 	Port uint16 `json:"port"`
 }
 
+// LeafAddr returns the pre-reserved leaf node listen address for the sidecar's
+// --nats-addr. Only valid after ReserveLeafPort or Start. Empty for leaf role.
+func (m *NATSMesh) LeafAddr() string {
+	return m.leafAddr
+}
+
 // ReserveLeafPort pre-allocates an ephemeral TCP port for the NATS leaf node
-// listener. The port is recorded so buildServerOpts can pass a specific port
-// to NATS instead of -1 (random). The listener is closed immediately — NATS
-// will rebind it when it starts. There is a small TOCTOU window, but in
-// practice collisions are extremely unlikely on localhost.
+// listener. The sidecar needs this address at launch (--nats-addr), which
+// happens before Start. The listener is closed immediately — NATS rebinds it.
 //
-// Call this before starting the sidecar so --nats-addr can be set. Only
-// meaningful for hub/peer roles (leaf role has no leaf port).
+// This is the one method that must be called before Start when iroh is enabled.
+// For non-iroh usage, Start handles everything.
 func (m *NATSMesh) ReserveLeafPort() error {
 	if m.role == NATSRoleLeaf {
-		return nil // leaf nodes don't listen for leaf connections
+		return nil
 	}
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -81,19 +83,65 @@ func (m *NATSMesh) ReserveLeafPort() error {
 	return nil
 }
 
-// EstablishTunnels tells the sidecar to open NATS tunnels to peers.
-// Each tunnel returns a local TCP port that the embedded NATS server will
-// solicit to. Must be called BEFORE Start so the ports can be wired into
-// the NATS server options.
-func (m *NATSMesh) EstablishTunnels() error {
-	if m.sidecarSocketPath == "" || m.endpointID == "" {
-		return nil // no sidecar or no endpoint — nothing to tunnel
+// Start brings up the NATS mesh. If sidecar info is provided, it establishes
+// tunnels to iroh peers first, then starts the embedded NATS server with
+// tunnel ports wired as leaf remotes. Returns the NATS client URL.
+//
+// Pass nil for sidecar when iroh is not enabled.
+func (m *NATSMesh) Start(sidecar *SidecarInfo) (clientURL string, err error) {
+	// Step 1: establish tunnels (if sidecar available).
+	if sidecar != nil {
+		if tunnelErr := m.establishTunnels(sidecar); tunnelErr != nil {
+			// Non-fatal: partial connectivity is better than none.
+			fmt.Printf("nats mesh: tunnel establishment (non-fatal): %v\n", tunnelErr)
+		}
+	}
+
+	// Step 2: start embedded NATS with tunnel ports as leaf remotes.
+	opts := m.buildServerOpts()
+	m.server, err = natsserver.NewServer(opts)
+	if err != nil {
+		return "", fmt.Errorf("nats mesh: create server: %w", err)
+	}
+	m.server.Start()
+	if !m.server.ReadyForConnections(5 * time.Second) {
+		m.server.Shutdown()
+		return "", fmt.Errorf("nats mesh: server not ready within 5s (reserved leaf port: %d)", m.reservedLeafPort)
+	}
+
+	m.clientURL = m.server.ClientURL()
+
+	// Determine leaf node address when not pre-reserved.
+	if m.role != NATSRoleLeaf && m.leafAddr == "" {
+		varz, vErr := m.server.Varz(&natsserver.VarzOptions{})
+		if vErr == nil && varz.LeafNode.Port > 0 {
+			m.leafAddr = fmt.Sprintf("127.0.0.1:%d", varz.LeafNode.Port)
+		}
+	}
+
+	return m.clientURL, nil
+}
+
+// Stop shuts down the embedded NATS server.
+func (m *NATSMesh) Stop() {
+	if m.server != nil {
+		m.server.Shutdown()
+		m.server.WaitForShutdown()
+		m.server = nil
+	}
+}
+
+// establishTunnels tells the sidecar to open NATS tunnels to peers.
+// Each tunnel returns a local TCP port that NATS will solicit to.
+func (m *NATSMesh) establishTunnels(sc *SidecarInfo) error {
+	if sc.SocketPath == "" || sc.EndpointID == "" {
+		return nil
 	}
 
 	client := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", m.sidecarSocketPath)
+				return net.Dial("unix", sc.SocketPath)
 			},
 		},
 		Timeout: 10 * time.Second,
@@ -103,7 +151,7 @@ func (m *NATSMesh) EstablishTunnels() error {
 
 	var errs []error
 	for _, peerID := range m.irohPeers {
-		if !shouldSolicit(m.role, m.endpointID, peerID) {
+		if !shouldSolicit(m.role, sc.EndpointID, peerID) {
 			continue
 		}
 
@@ -133,58 +181,6 @@ func (m *NATSMesh) EstablishTunnels() error {
 		m.tunnelPorts[peerID] = tr.Port
 	}
 	return errors.Join(errs...)
-}
-
-// Start brings up the embedded NATS server.
-// Tunnel ports from EstablishTunnels (if any) are included as leaf remotes.
-// Returns the NATS client URL for the agent to connect to.
-func (m *NATSMesh) Start() (clientURL string, err error) {
-	opts := m.buildServerOpts()
-	m.server, err = natsserver.NewServer(opts)
-	if err != nil {
-		return "", fmt.Errorf("nats mesh: create server: %w", err)
-	}
-	m.server.Start()
-	if !m.server.ReadyForConnections(5 * time.Second) {
-		m.server.Shutdown()
-		return "", fmt.Errorf("nats mesh: server not ready within 5s (reserved leaf port: %d)", m.reservedLeafPort)
-	}
-
-	m.clientURL = m.server.ClientURL()
-
-	// Determine leaf node address for sidecar (when not pre-reserved).
-	if m.role != NATSRoleLeaf && m.leafAddr == "" {
-		varz, vErr := m.server.Varz(&natsserver.VarzOptions{})
-		if vErr == nil && varz.LeafNode.Port > 0 {
-			m.leafAddr = fmt.Sprintf("127.0.0.1:%d", varz.LeafNode.Port)
-		}
-	}
-
-	return m.clientURL, nil
-}
-
-// Stop shuts down the embedded NATS server.
-func (m *NATSMesh) Stop() {
-	if m.server != nil {
-		m.server.Shutdown()
-		m.server.WaitForShutdown()
-		m.server = nil
-	}
-}
-
-// LeafAddr returns the leaf node listen address for the sidecar's --nats-addr.
-func (m *NATSMesh) LeafAddr() string {
-	return m.leafAddr
-}
-
-// SetEndpointID is called after the sidecar reports its EndpointId.
-func (m *NATSMesh) SetEndpointID(id string) {
-	m.endpointID = id
-}
-
-// SetSidecarSocket provides the sidecar Unix socket path for tunnel HTTP calls.
-func (m *NATSMesh) SetSidecarSocket(path string) {
-	m.sidecarSocketPath = path
 }
 
 // buildServerOpts creates nats-server options based on role.

--- a/leaf/agent/nats_mesh_test.go
+++ b/leaf/agent/nats_mesh_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNATSMeshStartStop(t *testing.T) {
 	mesh := &NATSMesh{role: NATSRolePeer}
-	clientURL, err := mesh.Start()
+	clientURL, err := mesh.Start(nil) // no sidecar
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}


### PR DESCRIPTION
## Summary

Post-merge follow-up for PR#64 (NATS-over-iroh spike). Three commits that were pushed after the merge:

- **Review fixes:** Remove dead `nats_addr` field from sidecar AppState, `EstablishTunnels` continues on individual peer failure (`errors.Join`), better error message on mesh startup failure
- **Interface refactor:** Collapse NATSMesh from 7 methods to 4 — `Start(sidecar *SidecarInfo)` owns the full startup sequence internally. No more conjoined setter methods.
- **Docs:** Update CLAUDE.md, agent-deployment ARD, README (4th sync mode), and full rewrite of leaf-agent.md with step-by-step P2P connection guide

## Test plan

- [x] `cargo check` clean (sidecar)
- [x] All 25 agent tests pass
- [x] `go build ./...` clean across all modules