### PR TITLE
chore: add CI workflow and notify ADR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  GOPRIVATE: github.com/danmestas/go-libfossil
+  GOWORK: "off"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure private module access
+        run: git config --global url."https://${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Vet
+        run: |
+          go vet ./...
+          cd leaf && go vet ./...
+          cd ../bridge && go vet ./...
+
+      - name: Unit tests (leaf + bridge in parallel)
+        run: |
+          cd leaf && go test ./... -short -count=1 &
+          PID_LEAF=$!
+          cd bridge && go test ./... -short -count=1 &
+          PID_BRIDGE=$!
+          wait $PID_LEAF
+          wait $PID_BRIDGE
+
+      - name: CLI build
+        run: go build -buildvcs=false ./cmd/edgesync/
+
+      - name: CLI tests
+        run: go test -buildvcs=false ./cmd/edgesync/ -count=1 -timeout=60s

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ See `docs/architecture/` for condensed architectural decision records (ARDs):
 - `checkout-merge.md` — checkout/checkin, merge strategies, fork prevention, autosync, ci-lock
 - `repo-operations.md` — CLI, tags, FTS, verify/rebuild, auth, shun/purge
 - `testing-strategy.md` — test tiers, DST, sim, interop, BUGGIFY
+- `notify-messaging.md` — bidirectional messaging: data model, dual delivery, CLI, planned phases
 
 ## Architecture
 
@@ -29,6 +30,8 @@ make test               # Run CI-level tests + sim serve tests (~15s)
 make setup-hooks        # Install pre-commit hook (~8s before each commit)
 go build -buildvcs=false ./cmd/edgesync/   # Dual VCS needs -buildvcs=false
 ```
+
+**CI:** GitHub Actions (`.github/workflows/ci.yml`) runs on push to main and PRs. Steps: `go vet`, unit tests (leaf + bridge in parallel), CLI build, CLI tests. Uses `GOWORK=off` and `GO_MODULE_TOKEN` secret for private go-libfossil access.
 
 ## Go Modules (go.work)
 
@@ -90,6 +93,16 @@ go-libfossil exposes an opaque `Repo` handle — all operations are methods on i
   - Config fields: `NATSRole` (peer/hub/leaf), `NATSUpstream` (optional external NATS), `ServeHTTPAddr`, `ServeNATSEnabled`, `IrohEnabled`, `IrohPeers`, `IrohKeyPath`
   - CLI flags: `--repo`, `--nats`, `--nats-role`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`, `--iroh`, `--iroh-peer`, `--iroh-key`
 - `bridge/bridge/` — `Config` (config.go), `New()`, `Start()`, `Stop()`
+
+### Notify Messaging
+- `leaf/agent/notify/` — Bidirectional messaging for human-in-the-loop AI
+  - `message.go` — Message, Action, Priority types; `NewMessage()`, `NewReply()`
+  - `store.go` — Free functions on `*libfossil.Repo`: `InitNotifyRepo`, `CommitMessage`, `ReadMessage`, `ListThreads`, `ReadThread`
+  - `pubsub.go` — `Publish()` free function, `Subscriber` type (dedup, wildcard)
+  - `notify.go` — `Service` (Send, Watch, FormatWatchLine)
+- `cmd/edgesync/notify.go` — 7 CLI commands: init, send, ask, watch, threads, log, status
+- NATS subjects: `notify.<project>.<thread-short>` (separate from sync subjects)
+- Storage: dedicated `notify.fossil` repo, managed by go-libfossil (no `fossil` binary)
 
 ### Simulation Testing
 - `dst/` — Deterministic single-threaded sim. `SimNetwork` (bridge mode), `PeerNetwork` (leaf-to-leaf). `MockFossil` delegates to `HandleSyncWithOpts`.

--- a/docs/architecture/notify-messaging.md
+++ b/docs/architecture/notify-messaging.md
@@ -1,0 +1,155 @@
+# Notify — Bidirectional Messaging
+
+## Purpose
+
+Bidirectional notification system for human-in-the-loop AI workflows. Claude (or any app) sends messages via CLI, user replies from Apple devices. Built entirely on EdgeSync's own stack — no third-party push services.
+
+## Architecture
+
+Three components, phased delivery:
+
+| Component | Stack | Status |
+|-----------|-------|--------|
+| Go CLI (`edgesync notify`) | go-libfossil, nats.go, Kong | **Shipped (Phase 1)** |
+| Hetzner hub relay | Existing leaf agent + new NATS subjects | Planned (Phase 2) |
+| Expo app (iOS + macOS) | React Native, NATS-over-iroh | Planned (Phase 3) |
+
+## Transport: Dual Delivery
+
+Every message travels two paths:
+
+| Path | Mechanism | Latency | Offline? |
+|------|-----------|---------|----------|
+| NATS real-time | Publish on `notify.<project>.<thread-short>` | Sub-second | No — requires connection |
+| Fossil sync | Commit to `notify.fossil`, sync via xfer protocol | Seconds (poll interval) | Yes — catches up on reconnect |
+
+Deduplication: receiver checks message `id`. NATS delivers first; Fossil sync is a no-op for already-seen messages. Dedup map capped at 10K entries with FIFO eviction.
+
+## NATS Subject Hierarchy
+
+```
+notify.<project>.<thread-id>    # Per-thread messages
+notify.<project>.ack            # Delivery receipts (Phase 2)
+notify.<project>.presence       # Online/typing indicators (Phase 2)
+notify.<project>.*              # All threads in a project (wildcard)
+notify.>                        # Firehose
+```
+
+## Data Model
+
+### Message Format (v1)
+
+```json
+{
+  "v": 1,
+  "id": "msg-<32hex>",
+  "thread": "thread-<32hex>",
+  "project": "edgesync",
+  "from": "<iroh-endpoint-id>",
+  "from_name": "claude-macbook",
+  "timestamp": "2026-04-10T12:00:00Z",
+  "body": "Build failed. Retry?",
+  "priority": "action_required",
+  "actions": [{"id": "retry", "label": "Retry"}],
+  "reply_to": null,
+  "action_response": false
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `v` | Yes | Schema version, currently 1 |
+| `id` | Yes | `msg-` + 32 hex chars from crypto/rand |
+| `thread` | Yes | `thread-` + 32 hex. Short form = first 8 chars after prefix |
+| `project` | Yes | Scopes messages to a project |
+| `from` / `from_name` | Yes | iroh endpoint ID + human-readable label |
+| `priority` | No | `info` (default), `action_required`, `urgent` |
+| `actions` | No | Quick-response buttons (id + label pairs) |
+| `reply_to` | No | Parent message ID for replies |
+| `action_response` | No | `true` when body is a tapped action ID |
+| `media` | No | Filenames referencing UV attachments (Phase 2) |
+
+### Repo Layout
+
+```
+<project>/threads/<thread-short>/
+  ├── <unix-timestamp>-<msg-short>.json
+  └── ...
+<project>/media/           # UV files (Phase 2)
+```
+
+`notify.fossil` is a dedicated Fossil repo created via `InitNotifyRepo()`. Managed entirely by go-libfossil — no `fossil` binary dependency. Messages are versioned checkins; media attachments use UV (unversioned files).
+
+## Identity & Trust
+
+iroh endpoint IDs (public keys) are the sole identity mechanism. No passwords, no tokens. Trust established by adding peer IDs to known-peers list on the hub. Device pairing flow planned for Phase 2.
+
+## Package Structure (Phase 1)
+
+```
+leaf/agent/notify/
+  message.go    — Message, Action, Priority types; NewMessage, NewReply
+  store.go      — Free functions on *libfossil.Repo: InitNotifyRepo, CommitMessage,
+                   ReadMessage, ListThreads, ReadThread
+  pubsub.go     — Publish (free function), Subscriber type (dedup, wildcard)
+  notify.go     — Service (Send, Watch, FormatWatchLine)
+cmd/edgesync/
+  notify.go     — 7 Kong commands: init, send, ask, watch, threads, log, status
+```
+
+**Design decisions (Ousterhout review):**
+- No wrapper type around `*libfossil.Repo` — free functions avoid shallow pass-throughs
+- No `Publisher` type — one function doesn't justify a type
+- No `NewActionReply` — callers use `NewReply` + set `ActionResponse = true`
+- Service holds `*libfossil.Repo` and `*nats.Conn` directly, doesn't own their lifecycle
+
+**Store internals:** `store.go` queries Fossil's `filename`, `mlink`, `blob` tables directly and decompresses the blob format (4-byte BE size + zlib). This bypasses go-libfossil's public API because `r.ReadFile()` doesn't exist yet. If added, migrate.
+
+## CLI Interface
+
+```bash
+edgesync notify init                         # Create notify.fossil
+edgesync notify send --project P "body"      # Fire-and-forget
+edgesync notify ask --project P "question?"  # Send + block for reply
+edgesync notify watch --project P            # Stream incoming
+edgesync notify threads --project P          # List threads
+edgesync notify log --project P <thread>     # Thread history
+edgesync notify status                       # Connection state
+```
+
+`ask` defaults to `--priority action_required`. Exit code 2 on timeout. `send`/`ask`/`watch` work in repo-only mode (no NATS) — NATS integration comes when the agent wires up the Service.
+
+Watch output format (machine-parseable):
+```
+[2026-04-10T12:01:03Z] thread:a1b2c3d4 from:dan-iphone action:retry
+[2026-04-10T12:01:15Z] thread:a1b2c3d4 from:dan-iphone text:also bump the version
+```
+
+## Planned Phases
+
+| Phase | Scope | Depends On |
+|-------|-------|-----------|
+| 1 — Go backend | CLI + repo + NATS pub/sub | **Done** |
+| 2 — Device pairing | `pair` command, token exchange, hub auto-add | Phase 1 |
+| 3 — Delivery receipts | Ack subject, `delivered` output, `trace` command | Phase 1 |
+| 4 — Sentry integration | Go SDK on CLI + hub | Phase 1 |
+| 5 — Claude Code skill | Teaches Claude the CLI grammar | Phase 1 |
+| 6 — Expo app | iOS + macOS, NATS-over-iroh, priority inbox | Phases 1-3 |
+| 7 — Sentry Expo | Crash reporting on devices | Phase 6 |
+
+## Testing
+
+26 tests across 4 test files + CLI end-to-end:
+
+| Category | Count | What |
+|----------|-------|------|
+| Message format | 8 | Construction, reply, JSON round-trip, path/subject generation |
+| Store operations | 4 | Init, commit, list threads, read thread |
+| Blob decompression | 5 | Empty, short, valid, corrupted, truncated |
+| NATS pub/sub | 3 | Publish/subscribe, wildcard, dedup |
+| Service | 6 | Nil repo error, send, existing thread, watch, watch formatter |
+| CLI e2e | 2 | Init, send + threads + status |
+
+## Error Tracking
+
+Sentry (Phase 4) — Go SDK on CLI and hub, Expo SDK on devices. Additive to existing Honeycomb OTel traces for sync operations.


### PR DESCRIPTION
## Summary

- **GitHub Actions CI** (`.github/workflows/ci.yml`) — runs on push to main and PRs: `go vet`, unit tests (leaf + bridge in parallel), CLI build, CLI e2e tests. Uses `GOWORK=off` and `GO_MODULE_TOKEN` secret for private go-libfossil access.
- **Notify ADR** (`docs/architecture/notify-messaging.md`) — compressed the 20KB spec + 56KB plan into a dense architectural decision record matching existing ADR style. Covers data model, dual delivery, package structure, CLI, planned phases, testing.
- **CLAUDE.md updates** — added notify ADR reference, notify project structure section, CI documentation.

## Setup required

Add a `GO_MODULE_TOKEN` repository secret with a GitHub PAT that has read access to `danmestas/go-libfossil`. This is the same auth pattern used in go-libfossil's own CI.

## Test plan

- [x] CI workflow syntax valid (yamllint)
- [x] ADR covers all spec decisions
- [ ] First CI run after merge (will need GO_MODULE_TOKEN secret)