### PR TITLE
feat(notify): wire into agent + NATS CLI flags

### DIFF
--- a/cmd/edgesync/notify.go
+++ b/cmd/edgesync/notify.go
@@ -11,6 +11,7 @@ import (
 	libfossil "github.com/danmestas/go-libfossil"
 	"github.com/danmestas/go-libfossil/cli"
 	"github.com/dmestas/edgesync/leaf/agent/notify"
+	"github.com/nats-io/nats.go"
 )
 
 // NotifyCmd is the top-level "notify" command group.
@@ -41,6 +42,21 @@ func openNotifyRepo(g *cli.Globals) (*libfossil.Repo, error) {
 		return nil, fmt.Errorf("open notify repo: %w", err)
 	}
 	return r, nil
+}
+
+// connectNATS optionally connects to a NATS server. Returns nil conn if url is empty.
+func connectNATS(url string) (*nats.Conn, error) {
+	if url == "" {
+		return nil, nil
+	}
+	nc, err := nats.Connect(url,
+		nats.Name("edgesync-notify-cli"),
+		nats.Timeout(5*time.Second),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("connect to NATS %s: %w", url, err)
+	}
+	return nc, nil
 }
 
 // parseActions splits a comma-separated string into Action slices.
@@ -85,6 +101,7 @@ type NotifySendCmd struct {
 	Thread   string `help:"Existing thread short ID (omit to start a new thread)"`
 	Actions  string `help:"Comma-separated action labels"`
 	Priority string `help:"Priority level (info, action_required, urgent)" default:"info" enum:"info,action_required,urgent"`
+	NATS     string `help:"NATS server URL (enables real-time delivery)" env:"EDGESYNC_NATS"`
 	Body     string `arg:"" help:"Message body"`
 }
 
@@ -98,8 +115,17 @@ func (c *NotifySendCmd) Run(g *cli.Globals) error {
 	}
 	defer r.Close()
 
+	nc, err := connectNATS(c.NATS)
+	if err != nil {
+		return err
+	}
+	if nc != nil {
+		defer nc.Close()
+	}
+
 	svc, err := notify.NewService(notify.ServiceConfig{
-		Repo: r,
+		Repo:     r,
+		NATSConn: nc,
 	})
 	if err != nil {
 		return err
@@ -130,6 +156,7 @@ type NotifyAskCmd struct {
 	Actions  string        `help:"Comma-separated action labels"`
 	Priority string        `help:"Priority level (info, action_required, urgent)" default:"action_required" enum:"info,action_required,urgent"`
 	Timeout  time.Duration `help:"Timeout waiting for reply (0 = forever)" default:"0s"`
+	NATS     string        `help:"NATS server URL (required for receiving replies)" env:"EDGESYNC_NATS"`
 	Body     string        `arg:"" help:"Message body"`
 }
 
@@ -143,8 +170,17 @@ func (c *NotifyAskCmd) Run(g *cli.Globals) error {
 	}
 	defer r.Close()
 
+	nc, err := connectNATS(c.NATS)
+	if err != nil {
+		return err
+	}
+	if nc != nil {
+		defer nc.Close()
+	}
+
 	svc, err := notify.NewService(notify.ServiceConfig{
-		Repo: r,
+		Repo:     r,
+		NATSConn: nc,
 	})
 	if err != nil {
 		return err
@@ -197,6 +233,7 @@ func (c *NotifyAskCmd) Run(g *cli.Globals) error {
 type NotifyWatchCmd struct {
 	Project string `help:"Project code" required:""`
 	Thread  string `help:"Filter to specific thread short ID"`
+	NATS    string `help:"NATS server URL (required for real-time delivery)" env:"EDGESYNC_NATS"`
 }
 
 func (c *NotifyWatchCmd) Run(g *cli.Globals) error {
@@ -209,8 +246,17 @@ func (c *NotifyWatchCmd) Run(g *cli.Globals) error {
 	}
 	defer r.Close()
 
+	nc, err := connectNATS(c.NATS)
+	if err != nil {
+		return err
+	}
+	if nc != nil {
+		defer nc.Close()
+	}
+
 	svc, err := notify.NewService(notify.ServiceConfig{
-		Repo: r,
+		Repo:     r,
+		NATSConn: nc,
 	})
 	if err != nil {
 		return err

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -14,6 +14,7 @@ import (
 
 	libfossil "github.com/danmestas/go-libfossil"
 	"github.com/danmestas/go-libfossil/simio"
+	"github.com/dmestas/edgesync/leaf/agent/notify"
 	"github.com/nats-io/nats.go"
 )
 
@@ -69,6 +70,8 @@ type Agent struct {
 	irohSidecar    *sidecar     // nil when iroh is disabled
 	irohSock       string       // Unix socket path for iroh sidecar
 	irohEndpointID string       // local iroh endpoint ID (set after sidecar ready)
+	notifyRepo     *libfossil.Repo  // nil when notify is disabled
+	notifySvc      *notify.Service  // nil when notify is disabled
 }
 
 // New creates a new Agent from the given configuration.
@@ -214,8 +217,51 @@ func (a *Agent) Start() error {
 		return err
 	}
 
+	// Step 5: notify messaging service (after NATS is connected).
+	if err := a.startNotify(); err != nil {
+		a.logf("warning: notify service failed to start: %v", err)
+		// Non-fatal — agent still works without notify.
+	}
+
 	a.done = make(chan struct{})
 	go a.pollLoop(ctx)
+	return nil
+}
+
+// startNotify opens the notify.fossil repo and creates the notify Service
+// with the agent's NATS connection. Non-fatal if notify.fossil doesn't exist.
+func (a *Agent) startNotify() error {
+	if !a.config.NotifyEnabled {
+		return nil
+	}
+
+	path := a.config.NotifyRepoPath
+	r, err := libfossil.Open(path)
+	if err != nil {
+		return fmt.Errorf("open notify repo %s: %w", path, err)
+	}
+	a.notifyRepo = r
+
+	fromName := a.config.PeerID
+	from := a.irohEndpointID
+	if from == "" {
+		from = a.config.PeerID
+	}
+
+	svc, err := notify.NewService(notify.ServiceConfig{
+		Repo:     r,
+		NATSConn: a.conn,
+		From:     from,
+		FromName: fromName,
+	})
+	if err != nil {
+		r.Close()
+		a.notifyRepo = nil
+		return fmt.Errorf("create notify service: %w", err)
+	}
+	a.notifySvc = svc
+
+	a.logf("notify service started (repo=%s, nats=%v)", path, a.conn != nil)
 	return nil
 }
 
@@ -420,6 +466,12 @@ func (a *Agent) Stop() error {
 	if a.done != nil {
 		<-a.done
 	}
+	if a.notifySvc != nil {
+		a.notifySvc.Close()
+	}
+	if a.notifyRepo != nil {
+		a.notifyRepo.Close()
+	}
 	if a.irohSidecar != nil {
 		a.irohSidecar.shutdown()
 	}
@@ -434,6 +486,9 @@ func (a *Agent) Stop() error {
 	}
 	return nil
 }
+
+// NotifyService returns the notify messaging service, or nil if notify is not enabled.
+func (a *Agent) NotifyService() *notify.Service { return a.notifySvc }
 
 // IrohEndpointID returns the local iroh endpoint ID, or "" if iroh is not enabled
 // or the sidecar hasn't started yet.

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	libfossil "github.com/danmestas/go-libfossil"
@@ -114,6 +115,14 @@ type Config struct {
 	// used directly — content caching is handled internally by go-libfossil.
 	ContentCacheSize int64
 
+	// NotifyEnabled starts the notify messaging service alongside sync.
+	// Requires a notify.fossil repo adjacent to the main repo (or at NotifyRepoPath).
+	NotifyEnabled bool
+
+	// NotifyRepoPath is the path to the notify.fossil repo.
+	// Defaults to "<repo-dir>/notify.fossil" if empty.
+	NotifyRepoPath string
+
 	// Autosync controls automatic sync around commit (default: AutosyncOff).
 	Autosync AutosyncMode
 
@@ -156,6 +165,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.ContentCacheSize == 0 {
 		c.ContentCacheSize = 32 << 20 // 32 MiB
+	}
+	if c.NotifyEnabled && c.NotifyRepoPath == "" {
+		c.NotifyRepoPath = filepath.Join(filepath.Dir(c.RepoPath), "notify.fossil")
 	}
 }
 

--- a/leaf/agent/notify_integration_test.go
+++ b/leaf/agent/notify_integration_test.go
@@ -1,0 +1,269 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/go-libfossil"
+	_ "github.com/danmestas/go-libfossil/db/driver/modernc"
+	"github.com/dmestas/edgesync/leaf/agent/notify"
+	"github.com/nats-io/nats.go"
+)
+
+// TestNotifyOverNATS verifies that two notify Services can exchange messages
+// through an embedded NATS server — the same topology as two CLI clients
+// or two agents connected to the same hub.
+func TestNotifyOverNATS(t *testing.T) {
+	dir := t.TempDir()
+
+	// Start a shared NATS server (simulates the hub's embedded NATS).
+	natsURL := startEmbeddedNATS(t)
+
+	// Create two notify repos.
+	notifyPathA := filepath.Join(dir, "a-notify.fossil")
+	notifyPathB := filepath.Join(dir, "b-notify.fossil")
+
+	rA := initNotifyForTest(t, notifyPathA)
+	defer rA.Close()
+	rB := initNotifyForTest(t, notifyPathB)
+	defer rB.Close()
+
+	// Connect two NATS clients (simulates two peers on the same mesh).
+	ncA, err := nats.Connect(natsURL, nats.Name("agent-a"))
+	if err != nil {
+		t.Fatalf("connect A: %v", err)
+	}
+	defer ncA.Close()
+
+	ncB, err := nats.Connect(natsURL, nats.Name("agent-b"))
+	if err != nil {
+		t.Fatalf("connect B: %v", err)
+	}
+	defer ncB.Close()
+
+	// Create two Services.
+	svcA, err := notify.NewService(notify.ServiceConfig{
+		Repo:     rA,
+		NATSConn: ncA,
+		From:     "endpoint-a",
+		FromName: "agent-a",
+	})
+	if err != nil {
+		t.Fatalf("new service A: %v", err)
+	}
+	defer svcA.Close()
+
+	svcB, err := notify.NewService(notify.ServiceConfig{
+		Repo:     rB,
+		NATSConn: ncB,
+		From:     "endpoint-b",
+		FromName: "agent-b",
+	})
+	if err != nil {
+		t.Fatalf("new service B: %v", err)
+	}
+	defer svcB.Close()
+
+	// B watches for messages.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch := svcB.Watch(ctx, notify.WatchOpts{Project: "edgesync"})
+
+	// Let subscription propagate.
+	time.Sleep(100 * time.Millisecond)
+
+	// A sends a message.
+	msg, err := svcA.Send(notify.SendOpts{
+		Project:  "edgesync",
+		Body:     "hello from A",
+		Priority: notify.PriorityUrgent,
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	t.Logf("A sent: %s (thread %s)", msg.ID, msg.ThreadShort())
+
+	// B should receive it.
+	select {
+	case received := <-ch:
+		if received.Body != "hello from A" {
+			t.Errorf("body = %q, want %q", received.Body, "hello from A")
+		}
+		if received.Priority != notify.PriorityUrgent {
+			t.Errorf("priority = %q, want %q", received.Priority, notify.PriorityUrgent)
+		}
+		if received.FromName != "agent-a" {
+			t.Errorf("from_name = %q, want %q", received.FromName, "agent-a")
+		}
+		t.Logf("B received: %s", notify.FormatWatchLine(received))
+	case <-ctx.Done():
+		t.Fatal("timeout: B did not receive message from A")
+	}
+
+	// Verify A's repo has the message.
+	readBack, err := notify.ReadMessage(svcA.Repo(), msg.FilePath())
+	if err != nil {
+		t.Fatalf("read from A's repo: %v", err)
+	}
+	if readBack.Body != "hello from A" {
+		t.Errorf("repo body = %q, want %q", readBack.Body, "hello from A")
+	}
+}
+
+// TestNotifyBidirectional verifies A sends, B replies, A receives the reply.
+func TestNotifyBidirectional(t *testing.T) {
+	dir := t.TempDir()
+	natsURL := startEmbeddedNATS(t)
+
+	rA := initNotifyForTest(t, filepath.Join(dir, "a-notify.fossil"))
+	defer rA.Close()
+	rB := initNotifyForTest(t, filepath.Join(dir, "b-notify.fossil"))
+	defer rB.Close()
+
+	ncA, err := nats.Connect(natsURL, nats.Name("agent-a"))
+	if err != nil {
+		t.Fatalf("connect A: %v", err)
+	}
+	defer ncA.Close()
+
+	ncB, err := nats.Connect(natsURL, nats.Name("agent-b"))
+	if err != nil {
+		t.Fatalf("connect B: %v", err)
+	}
+	defer ncB.Close()
+
+	svcA, err := notify.NewService(notify.ServiceConfig{
+		Repo: rA, NATSConn: ncA, From: "endpoint-a", FromName: "agent-a",
+	})
+	if err != nil {
+		t.Fatalf("new service A: %v", err)
+	}
+	defer svcA.Close()
+
+	svcB, err := notify.NewService(notify.ServiceConfig{
+		Repo: rB, NATSConn: ncB, From: "endpoint-b", FromName: "agent-b",
+	})
+	if err != nil {
+		t.Fatalf("new service B: %v", err)
+	}
+	defer svcB.Close()
+
+	// A sends a question.
+	msg, err := svcA.Send(notify.SendOpts{
+		Project:  "edgesync",
+		Body:     "Deploy to prod?",
+		Priority: notify.PriorityActionRequired,
+		Actions:  []notify.Action{{ID: "yes", Label: "Yes"}, {ID: "no", Label: "No"}},
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	// A watches for replies on this thread.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	replyCh := svcA.Watch(ctx, notify.WatchOpts{
+		Project:     "edgesync",
+		ThreadShort: msg.ThreadShort(),
+	})
+	time.Sleep(100 * time.Millisecond)
+
+	// B replies with an action.
+	reply := notify.NewReply(msg, notify.ReplyOpts{
+		From: "endpoint-b", FromName: "dan-iphone", Body: "yes",
+	})
+	reply.ActionResponse = true
+	if err := notify.CommitMessage(rB, reply); err != nil {
+		t.Fatalf("commit reply: %v", err)
+	}
+	if err := notify.Publish(ncB, reply); err != nil {
+		t.Fatalf("publish reply: %v", err)
+	}
+
+	// A should receive the reply.
+	select {
+	case received := <-replyCh:
+		if received.Body != "yes" {
+			t.Errorf("reply body = %q, want %q", received.Body, "yes")
+		}
+		if !received.ActionResponse {
+			t.Error("reply should be an action response")
+		}
+		if received.FromName != "dan-iphone" {
+			t.Errorf("reply from = %q, want %q", received.FromName, "dan-iphone")
+		}
+		t.Logf("A received reply: %s", notify.FormatWatchLine(received))
+	case <-ctx.Done():
+		t.Fatal("timeout: A did not receive reply from B")
+	}
+}
+
+// TestNotifyAgentLifecycle verifies the agent starts and stops the notify Service.
+func TestNotifyAgentLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "main.fossil")
+	notifyPath := filepath.Join(dir, "notify.fossil")
+
+	// Create main repo.
+	r, err := libfossil.Create(repoPath, libfossil.CreateOpts{User: "test"})
+	if err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	r.Close()
+
+	// Create notify repo.
+	nr, err := notify.InitNotifyRepo(notifyPath)
+	if err != nil {
+		t.Fatalf("init notify: %v", err)
+	}
+	nr.Close()
+
+	// Start agent with notify enabled.
+	a, err := New(Config{
+		RepoPath:       repoPath,
+		NATSRole:       NATSRoleHub,
+		NotifyEnabled:  true,
+		NotifyRepoPath: notifyPath,
+		PeerID:         "test-agent",
+	})
+	if err != nil {
+		t.Fatalf("new agent: %v", err)
+	}
+
+	if err := a.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Verify notify service is running.
+	svc := a.NotifyService()
+	if svc == nil {
+		t.Fatal("notify service should not be nil when enabled")
+	}
+
+	// Send a message through the agent's notify service.
+	msg, err := svc.Send(notify.SendOpts{
+		Project: "edgesync",
+		Body:    "agent lifecycle test",
+	})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	t.Logf("sent via agent: %s", msg.ID)
+
+	// Stop should clean up.
+	if err := a.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+func initNotifyForTest(t *testing.T, path string) *libfossil.Repo {
+	t.Helper()
+	r, err := notify.InitNotifyRepo(path)
+	if err != nil {
+		t.Fatalf("init notify repo %s: %v", path, err)
+	}
+	return r
+}


### PR DESCRIPTION
## Summary

- **Agent integration**: notify Service starts inside the leaf agent when `NotifyEnabled: true`, using the agent's existing NATS connection (which runs over iroh QUIC tunnels)
- **CLI `--nats` flag**: `send`, `ask`, `watch` commands accept `--nats nats://host:port` (or `EDGESYNC_NATS` env) to connect to the agent's NATS for real-time delivery
- **3 integration tests**: unidirectional messaging, bidirectional ask/reply, and agent lifecycle

## What this enables

Two leaf agents on different machines (e.g., your Mac and Hetzner VPS) can now exchange notify messages over the existing iroh mesh. The CLI can connect to a running agent's NATS to send messages that get delivered to remote peers in real-time.

## Test plan

- [x] TestNotifyOverNATS — A sends, B receives via NATS
- [x] TestNotifyBidirectional — A asks with actions, B replies, A receives
- [x] TestNotifyAgentLifecycle — agent starts/stops with notify, sends message
- [x] Full regression suite (`make test`) passing
- [ ] Manual: run two agents with `--notify`, send message from one, verify receipt on other