### PR TITLE
feat(notify): add --notify flag to sync start

### DIFF
--- a/cmd/edgesync/sync_start.go
+++ b/cmd/edgesync/sync_start.go
@@ -18,6 +18,7 @@ type SyncStartCmd struct {
 	Push         bool          `help:"Enable push" default:"true" negatable:""`
 	Pull         bool          `help:"Enable pull" default:"true" negatable:""`
 	UV           bool          `help:"Sync unversioned files" default:"false"`
+	Notify       bool          `help:"Enable notify messaging (requires notify.fossil next to repo)" default:"false"`
 }
 
 func (c *SyncStartCmd) Run(g *cli.Globals) error {
@@ -26,12 +27,13 @@ func (c *SyncStartCmd) Run(g *cli.Globals) error {
 	}
 
 	a, err := agent.New(agent.Config{
-		RepoPath:     g.Repo,
-		NATSUpstream: c.NATSUrl,
-		PollInterval: c.PollInterval,
-		Push:         c.Push,
-		Pull:         c.Pull,
-		UV:           c.UV,
+		RepoPath:      g.Repo,
+		NATSUpstream:  c.NATSUrl,
+		PollInterval:  c.PollInterval,
+		Push:          c.Push,
+		Pull:          c.Pull,
+		UV:            c.UV,
+		NotifyEnabled: c.Notify,
 	})
 	if err != nil {
 		return fmt.Errorf("agent: %w", err)
@@ -41,7 +43,7 @@ func (c *SyncStartCmd) Run(g *cli.Globals) error {
 		return fmt.Errorf("start: %w", err)
 	}
 
-	slog.Info("edgesync sync agent running", "repo", g.Repo, "nats", c.NATSUrl, "poll", c.PollInterval)
+	slog.Info("edgesync sync agent running", "repo", g.Repo, "nats", c.NATSUrl, "poll", c.PollInterval, "notify", c.Notify)
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
## Summary

- Adds `--notify` flag to `edgesync sync start` command
- When enabled, the agent opens `notify.fossil` (adjacent to the main repo) and starts the notify Service with the agent's NATS connection
- Messages sent via `edgesync notify send --nats` are delivered to all connected peers in real-time

## Usage

```bash
# First time: create the notify repo
edgesync notify init -R myrepo.fossil

# Start agent with notify enabled
edgesync sync start -R myrepo.fossil --notify

# From another terminal, send a message through the agent's NATS
edgesync notify send -R myrepo.fossil --nats nats://localhost:4222 --project edgesync "hello"

# Watch for messages on another machine connected to the same hub
edgesync notify watch -R myrepo.fossil --nats nats://100.78.32.45:4222 --project edgesync
```

## Test plan

- [x] `sync start --help` shows `--notify` flag
- [x] TestNotifyAgentLifecycle passes (agent starts/stops with notify)
- [x] Full regression suite (`make test`) passing
- [ ] Manual: two agents with `--notify` on different machines, exchange messages