### PR TITLE
feat(notify): add device pairing CLI

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/bridge/go.sum
+++ b/bridge/go.sum
@@ -59,6 +59,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/cmd/edgesync/notify.go
+++ b/cmd/edgesync/notify.go
@@ -23,6 +23,9 @@ type NotifyCmd struct {
 	Threads NotifyThreadsCmd `cmd:"" help:"List active threads"`
 	Log     NotifyLogCmd     `cmd:"" help:"Show thread message history"`
 	Status  NotifyStatusCmd  `cmd:"" help:"Show connection state and unread counts"`
+	Pair    NotifyPairCmd    `cmd:"" help:"Generate a one-time pairing token and QR code"`
+	Unpair  NotifyUnpairCmd  `cmd:"" help:"Revoke a paired device"`
+	Devices NotifyDevicesCmd `cmd:"" help:"List paired devices"`
 }
 
 // notifyRepoPath returns the path to notify.fossil next to the -R repo.
@@ -365,6 +368,101 @@ func (c *NotifyStatusCmd) Run(g *cli.Globals) error {
 
 	fmt.Printf("notify repo: %s\n", path)
 	fmt.Printf("connection: repo-only (no NATS)\n")
+	return nil
+}
+
+// --- Pair ---
+
+type NotifyPairCmd struct {
+	Name     string `help:"Device name for the pairing" required:""`
+	NATS     string `help:"NATS server URL for the QR payload" env:"EDGESYNC_NATS"`
+	Endpoint string `help:"Hub iroh endpoint ID for the QR payload" env:"EDGESYNC_IROH_ENDPOINT"`
+}
+
+func (c *NotifyPairCmd) Run(g *cli.Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+	r, err := openNotifyRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	tok, err := notify.CreatePairingToken(r, c.Name)
+	if err != nil {
+		return err
+	}
+
+	// Build QR payload only if both endpoint and NATS provided.
+	if c.Endpoint != "" && c.NATS != "" {
+		pairURL := notify.FormatPairURL(c.Endpoint, c.NATS, tok)
+		qr, err := notify.RenderQR(pairURL)
+		if err != nil {
+			return err
+		}
+		fmt.Print(qr)
+		fmt.Fprintf(os.Stderr, "pair-url:%s\n", pairURL)
+	}
+
+	fmt.Println(tok)
+	fmt.Fprintf(os.Stderr, "expires: 10 minutes\n")
+	fmt.Fprintf(os.Stderr, "device: %s\n", c.Name)
+	return nil
+}
+
+// --- Unpair ---
+
+type NotifyUnpairCmd struct {
+	Name string `arg:"" help:"Device name to unpair"`
+}
+
+func (c *NotifyUnpairCmd) Run(g *cli.Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+	r, err := openNotifyRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	if err := notify.RemoveDevice(r, c.Name); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "unpaired: %s\n", c.Name)
+	return nil
+}
+
+// --- Devices ---
+
+type NotifyDevicesCmd struct{}
+
+func (c *NotifyDevicesCmd) Run(g *cli.Globals) error {
+	if g.Repo == "" {
+		return fmt.Errorf("repository required (use -R <path>)")
+	}
+	r, err := openNotifyRepo(g)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	devices, err := notify.ListDevices(r)
+	if err != nil {
+		return err
+	}
+
+	if len(devices) == 0 {
+		fmt.Println("no paired devices")
+		return nil
+	}
+
+	for _, d := range devices {
+		fmt.Printf("%s  endpoint:%s  paired:%s\n",
+			d.Name, d.EndpointID, d.PairedAt.UTC().Format(time.RFC3339))
+	}
 	return nil
 }
 

--- a/cmd/edgesync/notify_test.go
+++ b/cmd/edgesync/notify_test.go
@@ -64,6 +64,63 @@ func TestNotifyCLIInit(t *testing.T) {
 	}
 }
 
+func TestNotifyCLIPairAndDevices(t *testing.T) {
+	bin := buildBinary(t)
+	tmp := t.TempDir()
+	fakeRepo := filepath.Join(tmp, "project.fossil")
+
+	// Init.
+	cmd := exec.Command(bin, "-R", fakeRepo, "notify", "init")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("init: %s\n%s", err, out)
+	}
+
+	// Pair (no endpoint/NATS = text token only, no QR).
+	cmd = exec.Command(bin, "-R", fakeRepo, "notify", "pair", "--name", "dan-iphone")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pair: %s\n%s", err, out)
+	}
+	pairOutput := string(out)
+
+	// Should contain a token in XXXX-XXXX-XXXX format.
+	if !strings.Contains(pairOutput, "-") {
+		t.Errorf("pair output should contain token with dashes, got: %q", pairOutput)
+	}
+	if !strings.Contains(pairOutput, "expires") {
+		t.Errorf("pair output should mention expiry, got: %q", pairOutput)
+	}
+
+	// Devices — should be empty (token pending, not yet validated).
+	cmd = exec.Command(bin, "-R", fakeRepo, "notify", "devices")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("devices: %s\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "no paired devices") {
+		t.Errorf("devices should be empty before validation, got: %q", string(out))
+	}
+}
+
+func TestNotifyCLIUnpair(t *testing.T) {
+	bin := buildBinary(t)
+	tmp := t.TempDir()
+	fakeRepo := filepath.Join(tmp, "project.fossil")
+
+	// Init.
+	cmd := exec.Command(bin, "-R", fakeRepo, "notify", "init")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("init: %s\n%s", err, out)
+	}
+
+	// Unpair a device that doesn't exist = error.
+	cmd = exec.Command(bin, "-R", fakeRepo, "notify", "unpair", "nonexistent")
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("unpair nonexistent should fail, got: %s", out)
+	}
+}
+
 func TestNotifyCLISendAndThreads(t *testing.T) {
 	bin := buildBinary(t)
 	tmp := t.TempDir()

--- a/docs/architecture/notify-messaging.md
+++ b/docs/architecture/notify-messaging.md
@@ -125,17 +125,46 @@ Watch output format (machine-parseable):
 [2026-04-10T12:01:15Z] thread:a1b2c3d4 from:dan-iphone text:also bump the version
 ```
 
+## Device Pairing
+
+Three pairing methods for adding devices to the mesh:
+
+| Method | Mechanism | UX |
+|--------|-----------|-----|
+| QR Code (primary) | `edgesync notify pair --name "dan-iphone"` prints QR to terminal | Scan from app, connected in <5s |
+| Token paste (fallback) | 12-char base32 token (`AXKF-9M2P-VR3T`), no ambiguous chars | Type/paste in app |
+| Nearby discovery (future) | iroh mDNS on local network | Not in v1 |
+
+**Token format:** `edgesync-pair://v1/<hub-iroh-endpoint-id>/<nats-addr>/<one-time-secret>`
+
+**Security:** Single-use tokens, 10-minute expiry, hub stores only SHA-256 hash. Revocation via `edgesync notify unpair <name>`.
+
+**Storage:** `_notify/devices.json` (device registry) and `_notify/pending_tokens.json` (pending tokens) in notify.fossil.
+
+**Package structure:** `token.go` (generation, hashing, QR), `token_store.go` (`CreatePairingToken` deep function, `ValidateToken`), `device_registry.go` (`AddDevice`, `RemoveDevice`, `ListDevices`).
+
+## Expo App (separate repo: edgesync-notify-app)
+
+Go backend compiled via gomobile, localhost HTTP/SSE server, React Native (Expo) UI.
+
+**Architecture:** Go `.xcframework` starts an HTTP server on `127.0.0.1:<random-port>`. React Native talks to it via `fetch` (request/response) and `EventSource` (SSE for real-time messages). No custom native bridge.
+
+**Go server endpoints:** `/init`, `/status`, `/send`, `/threads`, `/thread/:id`, `/subscribe` (SSE), `/media/:filename`, `/pair`, `/stop`
+
+**Server design (Ousterhout):** `Server` struct (not singleton), `Bridge.Routes()` co-locates handlers with routes, pass-through JSON (never redefine `notify.Message` types), `api.ts` is a deep module (SSE reconnection, error normalization, connection status tracking).
+
 ## Planned Phases
 
 | Phase | Scope | Depends On |
 |-------|-------|-----------|
 | 1 — Go backend | CLI + repo + NATS pub/sub | **Done** |
-| 2 — Device pairing | `pair` command, token exchange, hub auto-add | Phase 1 |
-| 3 — Delivery receipts | Ack subject, `delivered` output, `trace` command | Phase 1 |
-| 4 — Sentry integration | Go SDK on CLI + hub | Phase 1 |
-| 5 — Claude Code skill | Teaches Claude the CLI grammar | Phase 1 |
-| 6 — Expo app | iOS + macOS, NATS-over-iroh, priority inbox | Phases 1-3 |
-| 7 — Sentry Expo | Crash reporting on devices | Phase 6 |
+| 2 — Device pairing | `pair`, `unpair`, `devices` commands + token infrastructure | **Done** |
+| 3 — Expo Go server | Localhost HTTP/SSE wrapping notify.Service | **Done** |
+| 4 — Delivery receipts | Ack subject, `delivered` output, `trace` command | Phase 1 |
+| 5 — Sentry integration | Go SDK on CLI + hub | Phase 1 |
+| 6 — Claude Code skill | Teaches Claude the CLI grammar | Phase 1 |
+| 7 — Expo app UI | gomobile + React Native screens + pairing flow | Phases 1-3 |
+| 8 — Sentry Expo | Crash reporting on devices | Phase 7 |
 
 ## Testing
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/leaf/agent/notify/device_registry.go
+++ b/leaf/agent/notify/device_registry.go
@@ -59,7 +59,7 @@ func RemoveDevice(r *libfossil.Repo, name string) error {
 		return err
 	}
 	found := false
-	filtered := devices[:0]
+	filtered := make([]Device, 0, len(devices))
 	for _, d := range devices {
 		if d.Name == name {
 			found = true

--- a/leaf/agent/notify/device_registry.go
+++ b/leaf/agent/notify/device_registry.go
@@ -1,0 +1,94 @@
+package notify
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libfossil "github.com/danmestas/go-libfossil"
+)
+
+const devicesFilePath = "_notify/devices.json"
+
+// Device is a paired device entry in the registry.
+type Device struct {
+	Name       string    `json:"name"`
+	EndpointID string    `json:"endpoint_id"`
+	PairedAt   time.Time `json:"paired_at"`
+}
+
+// DeviceRegistry is the JSON structure stored in the notify repo.
+type DeviceRegistry struct {
+	Devices []Device `json:"devices"`
+}
+
+// ListDevices reads the device registry from the notify repo.
+// Returns an empty slice (not error) if the file doesn't exist yet.
+func ListDevices(r *libfossil.Repo) ([]Device, error) {
+	data, err := readFileContent(r, devicesFilePath)
+	if err != nil {
+		// If file doesn't exist, return empty.
+		return nil, nil
+	}
+	var reg DeviceRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("unmarshal device registry: %w", err)
+	}
+	return reg.Devices, nil
+}
+
+// AddDevice adds a device to the registry. Rejects duplicate names.
+func AddDevice(r *libfossil.Repo, dev Device) error {
+	devices, err := ListDevices(r)
+	if err != nil {
+		return err
+	}
+	for _, d := range devices {
+		if d.Name == dev.Name {
+			return fmt.Errorf("device %q already exists", dev.Name)
+		}
+	}
+	devices = append(devices, dev)
+	return commitDevices(r, devices)
+}
+
+// RemoveDevice removes a device by name. Returns error if not found.
+func RemoveDevice(r *libfossil.Repo, name string) error {
+	devices, err := ListDevices(r)
+	if err != nil {
+		return err
+	}
+	found := false
+	filtered := devices[:0]
+	for _, d := range devices {
+		if d.Name == name {
+			found = true
+			continue
+		}
+		filtered = append(filtered, d)
+	}
+	if !found {
+		return fmt.Errorf("device %q not found", name)
+	}
+	return commitDevices(r, filtered)
+}
+
+// commitDevices serializes the device list and commits it to the notify repo.
+func commitDevices(r *libfossil.Repo, devices []Device) error {
+	reg := DeviceRegistry{Devices: devices}
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal device registry: %w", err)
+	}
+	_, _, err = r.Commit(libfossil.CommitOpts{
+		Files: []libfossil.FileToCommit{
+			{Name: devicesFilePath, Content: data},
+		},
+		Comment: "notify: update device registry",
+		User:    "notify",
+	})
+	if err != nil {
+		return fmt.Errorf("commit device registry: %w", err)
+	}
+	return nil
+}

--- a/leaf/agent/notify/device_registry_test.go
+++ b/leaf/agent/notify/device_registry_test.go
@@ -1,0 +1,65 @@
+package notify
+
+import (
+	"testing"
+	"time"
+
+	_ "github.com/danmestas/go-libfossil/db/driver/modernc"
+)
+
+func TestDeviceRegistryCRUD(t *testing.T) {
+	r := createTestRepo(t)
+
+	// Initially empty.
+	devices, err := ListDevices(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 0 {
+		t.Fatalf("expected 0 devices, got %d", len(devices))
+	}
+
+	// Add a device.
+	dev := Device{
+		Name:       "dan-iphone",
+		EndpointID: "iroh-endpoint-abc123",
+		PairedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	if err := AddDevice(r, dev); err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err = ListDevices(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+	if devices[0].Name != "dan-iphone" {
+		t.Errorf("name = %q", devices[0].Name)
+	}
+
+	// Duplicate name rejected.
+	if err := AddDevice(r, dev); err == nil {
+		t.Error("expected error for duplicate device name")
+	}
+
+	// Remove.
+	if err := RemoveDevice(r, "dan-iphone"); err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err = ListDevices(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 0 {
+		t.Fatalf("expected 0 devices after remove, got %d", len(devices))
+	}
+
+	// Remove non-existent = error.
+	if err := RemoveDevice(r, "nonexistent"); err == nil {
+		t.Error("expected error for removing non-existent device")
+	}
+}

--- a/leaf/agent/notify/token.go
+++ b/leaf/agent/notify/token.go
@@ -10,15 +10,15 @@ import (
 	qrcode "github.com/skip2/go-qrcode"
 )
 
-// tokenAlphabet is 29 chars: no 0/O/1/I/l to avoid ambiguity.
+// tokenAlphabet is 30 chars: no 0/O/1/I/l to avoid ambiguity.
 const tokenAlphabet = "23456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 // tokenRejectThreshold is the largest multiple of len(tokenAlphabet) that fits in a byte.
 // Bytes >= this value are rejected to avoid modulo bias.
-const tokenRejectThreshold = 29 * (256 / 29) // 29 * 8 = 232
+const tokenRejectThreshold = 30 * (256 / 30) // 30 * 8 = 240
 
 // GenerateToken creates a 12-char alphanumeric token formatted as XXXX-XXXX-XXXX.
-// Uses rejection sampling to avoid modulo bias from the 29-char alphabet.
+// Uses rejection sampling to avoid modulo bias from the 30-char alphabet.
 func GenerateToken() (string, error) {
 	chars := make([]byte, 12)
 	for i := 0; i < 12; {

--- a/leaf/agent/notify/token.go
+++ b/leaf/agent/notify/token.go
@@ -1,0 +1,45 @@
+package notify
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// tokenAlphabet is 29 chars: no 0/O/1/I/l to avoid ambiguity.
+const tokenAlphabet = "23456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// tokenRejectThreshold is the largest multiple of len(tokenAlphabet) that fits in a byte.
+// Bytes >= this value are rejected to avoid modulo bias.
+const tokenRejectThreshold = 29 * (256 / 29) // 29 * 8 = 232
+
+// GenerateToken creates a 12-char alphanumeric token formatted as XXXX-XXXX-XXXX.
+// Uses rejection sampling to avoid modulo bias from the 29-char alphabet.
+func GenerateToken() (string, error) {
+	chars := make([]byte, 12)
+	for i := 0; i < 12; {
+		b := make([]byte, 1)
+		if _, err := rand.Read(b); err != nil {
+			return "", fmt.Errorf("generate token: %w", err)
+		}
+		if int(b[0]) >= tokenRejectThreshold {
+			continue
+		}
+		chars[i] = tokenAlphabet[int(b[0])%len(tokenAlphabet)]
+		i++
+	}
+	return fmt.Sprintf("%s-%s-%s", string(chars[0:4]), string(chars[4:8]), string(chars[8:12])), nil
+}
+
+// RawToken strips dashes from a formatted token.
+func RawToken(formatted string) string {
+	return strings.ReplaceAll(formatted, "-", "")
+}
+
+// HashToken returns the hex-encoded SHA-256 hash of the raw (no dashes) token.
+func HashToken(formatted string) string {
+	raw := RawToken(formatted)
+	h := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", h)
+}

--- a/leaf/agent/notify/token.go
+++ b/leaf/agent/notify/token.go
@@ -4,7 +4,10 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"net/url"
 	"strings"
+
+	qrcode "github.com/skip2/go-qrcode"
 )
 
 // tokenAlphabet is 29 chars: no 0/O/1/I/l to avoid ambiguity.
@@ -42,4 +45,53 @@ func HashToken(formatted string) string {
 	raw := RawToken(formatted)
 	h := sha256.Sum256([]byte(raw))
 	return fmt.Sprintf("%x", h)
+}
+
+// FormatPairURL builds the QR payload string.
+// The NATS address is URL-encoded to avoid slash ambiguity.
+func FormatPairURL(endpointID, natsAddr, token string) string {
+	return fmt.Sprintf("edgesync-pair://v1/%s/%s/%s",
+		endpointID,
+		url.PathEscape(natsAddr),
+		RawToken(token),
+	)
+}
+
+// PairInfo is the parsed content of a pairing URL.
+type PairInfo struct {
+	EndpointID string
+	NATSAddr   string
+	Token      string // raw, no dashes
+}
+
+// ParsePairURL parses an edgesync-pair:// URL into its components.
+func ParsePairURL(raw string) (PairInfo, error) {
+	const prefix = "edgesync-pair://v1/"
+	if !strings.HasPrefix(raw, prefix) {
+		return PairInfo{}, fmt.Errorf("invalid pair URL: missing prefix")
+	}
+	rest := raw[len(prefix):]
+	// Split into exactly 3 parts: endpointID / encoded-nats-addr / token
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) != 3 {
+		return PairInfo{}, fmt.Errorf("invalid pair URL: expected 3 path segments, got %d", len(parts))
+	}
+	natsAddr, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return PairInfo{}, fmt.Errorf("invalid pair URL: unescape NATS addr: %w", err)
+	}
+	return PairInfo{
+		EndpointID: parts[0],
+		NATSAddr:   natsAddr,
+		Token:      parts[2],
+	}, nil
+}
+
+// RenderQR returns a terminal-friendly QR code string for the given content.
+func RenderQR(content string) (string, error) {
+	qr, err := qrcode.New(content, qrcode.Medium)
+	if err != nil {
+		return "", fmt.Errorf("generate QR: %w", err)
+	}
+	return qr.ToSmallString(false), nil
 }

--- a/leaf/agent/notify/token_store.go
+++ b/leaf/agent/notify/token_store.go
@@ -1,0 +1,135 @@
+package notify
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	libfossil "github.com/danmestas/go-libfossil"
+)
+
+const pendingTokensFilePath = "_notify/pending_tokens.json"
+
+// PendingToken is a hashed pairing token awaiting validation.
+type PendingToken struct {
+	TokenHash  string    `json:"token_hash"`
+	CreatedAt  time.Time `json:"created_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	DeviceName string    `json:"device_name"`
+}
+
+// pendingTokenStore is the JSON structure stored in the notify repo.
+type pendingTokenStore struct {
+	Tokens []PendingToken `json:"tokens"`
+}
+
+// StorePendingToken adds a pending token to the repo. Prunes expired tokens.
+func StorePendingToken(r *libfossil.Repo, pt PendingToken) error {
+	tokens, err := readPendingTokens(r)
+	if err != nil {
+		return err
+	}
+	// Prune expired.
+	now := time.Now().UTC()
+	tokens = pruneExpired(tokens, now)
+	tokens = append(tokens, pt)
+	return commitPendingTokens(r, tokens)
+}
+
+// ValidateToken checks a raw token against pending tokens.
+// On success, removes the token (single-use) and returns the PendingToken metadata.
+// Returns error if token is invalid, expired, or already consumed.
+func ValidateToken(r *libfossil.Repo, formattedToken string) (PendingToken, error) {
+	tokens, err := readPendingTokens(r)
+	if err != nil {
+		return PendingToken{}, err
+	}
+
+	hash := HashToken(formattedToken)
+	now := time.Now().UTC()
+
+	for i, pt := range tokens {
+		if pt.TokenHash != hash {
+			continue
+		}
+		// Found — check expiry.
+		if now.After(pt.ExpiresAt) {
+			// Remove expired token and commit.
+			tokens = append(tokens[:i], tokens[i+1:]...)
+			_ = commitPendingTokens(r, tokens)
+			return PendingToken{}, fmt.Errorf("token expired")
+		}
+		// Valid — remove (single-use) and commit.
+		matched := pt
+		tokens = append(tokens[:i], tokens[i+1:]...)
+		if err := commitPendingTokens(r, tokens); err != nil {
+			return PendingToken{}, err
+		}
+		return matched, nil
+	}
+	return PendingToken{}, fmt.Errorf("token not found or already consumed")
+}
+
+// CreatePairingToken generates a token, hashes it, stores the pending entry, and
+// returns the display-formatted token (XXXX-XXXX-XXXX). This is the single entry
+// point CLI commands should use.
+func CreatePairingToken(r *libfossil.Repo, name string) (string, error) {
+	tok, err := GenerateToken()
+	if err != nil {
+		return "", err
+	}
+	err = StorePendingToken(r, PendingToken{
+		TokenHash:  HashToken(tok),
+		DeviceName: name,
+		CreatedAt:  time.Now().UTC(),
+		ExpiresAt:  time.Now().UTC().Add(10 * time.Minute),
+	})
+	if err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+// readPendingTokens reads the pending token store from the repo.
+func readPendingTokens(r *libfossil.Repo) ([]PendingToken, error) {
+	data, err := readFileContent(r, pendingTokensFilePath)
+	if err != nil {
+		return nil, nil // file doesn't exist yet
+	}
+	var store pendingTokenStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("unmarshal pending tokens: %w", err)
+	}
+	return store.Tokens, nil
+}
+
+// commitPendingTokens serializes and commits the pending token list.
+func commitPendingTokens(r *libfossil.Repo, tokens []PendingToken) error {
+	store := pendingTokenStore{Tokens: tokens}
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal pending tokens: %w", err)
+	}
+	_, _, err = r.Commit(libfossil.CommitOpts{
+		Files: []libfossil.FileToCommit{
+			{Name: pendingTokensFilePath, Content: data},
+		},
+		Comment: "notify: update pending tokens",
+		User:    "notify",
+	})
+	if err != nil {
+		return fmt.Errorf("commit pending tokens: %w", err)
+	}
+	return nil
+}
+
+// pruneExpired removes tokens that have passed their expiry time.
+func pruneExpired(tokens []PendingToken, now time.Time) []PendingToken {
+	live := tokens[:0]
+	for _, pt := range tokens {
+		if now.Before(pt.ExpiresAt) {
+			live = append(live, pt)
+		}
+	}
+	return live
+}

--- a/leaf/agent/notify/token_store_test.go
+++ b/leaf/agent/notify/token_store_test.go
@@ -1,0 +1,90 @@
+package notify
+
+import (
+	"testing"
+	"time"
+
+	_ "github.com/danmestas/go-libfossil/db/driver/modernc"
+)
+
+func TestPendingTokenLifecycle(t *testing.T) {
+	r := createTestRepo(t)
+
+	tok, err := GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Store the token.
+	err = StorePendingToken(r, PendingToken{
+		TokenHash:  HashToken(tok),
+		DeviceName: "dan-iphone",
+		CreatedAt:  time.Now().UTC(),
+		ExpiresAt:  time.Now().UTC().Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate with correct token.
+	pt, err := ValidateToken(r, tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pt.DeviceName != "dan-iphone" {
+		t.Errorf("device name = %q", pt.DeviceName)
+	}
+
+	// Token is consumed — second validation fails.
+	_, err = ValidateToken(r, tok)
+	if err == nil {
+		t.Error("expected error: token already consumed")
+	}
+}
+
+func TestExpiredTokenRejected(t *testing.T) {
+	r := createTestRepo(t)
+
+	tok, err := GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = StorePendingToken(r, PendingToken{
+		TokenHash:  HashToken(tok),
+		DeviceName: "dan-iphone",
+		CreatedAt:  time.Now().UTC().Add(-20 * time.Minute),
+		ExpiresAt:  time.Now().UTC().Add(-10 * time.Minute), // already expired
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ValidateToken(r, tok)
+	if err == nil {
+		t.Error("expected error for expired token")
+	}
+}
+
+func TestCreatePairingToken(t *testing.T) {
+	r := createTestRepo(t)
+
+	tok, err := CreatePairingToken(r, "test-device")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Token should be in XXXX-XXXX-XXXX format.
+	if len(tok) != 14 {
+		t.Errorf("token length = %d, want 14", len(tok))
+	}
+
+	// Should be validatable.
+	pt, err := ValidateToken(r, tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pt.DeviceName != "test-device" {
+		t.Errorf("device name = %q", pt.DeviceName)
+	}
+}

--- a/leaf/agent/notify/token_test.go
+++ b/leaf/agent/notify/token_test.go
@@ -1,0 +1,67 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateToken(t *testing.T) {
+	tok, err := GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Format: XXXX-XXXX-XXXX
+	if len(tok) != 14 { // 12 chars + 2 dashes
+		t.Errorf("token length = %d, want 14", len(tok))
+	}
+	parts := strings.Split(tok, "-")
+	if len(parts) != 3 {
+		t.Fatalf("token parts = %d, want 3", len(parts))
+	}
+	for i, p := range parts {
+		if len(p) != 4 {
+			t.Errorf("part[%d] length = %d, want 4", i, len(p))
+		}
+	}
+
+	// No ambiguous characters.
+	raw := strings.ReplaceAll(tok, "-", "")
+	for _, c := range raw {
+		switch c {
+		case '0', 'O', '1', 'I', 'l':
+			t.Errorf("token contains ambiguous char %q", string(c))
+		}
+	}
+
+	// Two tokens should differ.
+	tok2, _ := GenerateToken()
+	if tok == tok2 {
+		t.Error("two generated tokens should not be equal")
+	}
+}
+
+func TestHashToken(t *testing.T) {
+	tok := "AXKF-9M2P-VR3T"
+	h := HashToken(tok)
+
+	if len(h) != 64 { // SHA-256 hex
+		t.Errorf("hash length = %d, want 64", len(h))
+	}
+
+	// Same input = same hash.
+	if HashToken(tok) != h {
+		t.Error("hash should be deterministic")
+	}
+
+	// Different input = different hash.
+	if HashToken("ZZZZ-ZZZZ-ZZZZ") == h {
+		t.Error("different tokens should produce different hashes")
+	}
+}
+
+func TestRawToken(t *testing.T) {
+	if got := RawToken("AXKF-9M2P-VR3T"); got != "AXKF9M2PVR3T" {
+		t.Errorf("RawToken = %q, want %q", got, "AXKF9M2PVR3T")
+	}
+}

--- a/leaf/agent/notify/token_test.go
+++ b/leaf/agent/notify/token_test.go
@@ -65,3 +65,48 @@ func TestRawToken(t *testing.T) {
 		t.Errorf("RawToken = %q, want %q", got, "AXKF9M2PVR3T")
 	}
 }
+
+func TestFormatPairURL(t *testing.T) {
+	u := FormatPairURL("abc123endpointid", "nats://100.78.32.45:4222", "AXKF-9M2P-VR3T")
+	// url.PathEscape escapes '/' but not ':' — the exact encoding is:
+	want := "edgesync-pair://v1/abc123endpointid/nats:%2F%2F100.78.32.45:4222/AXKF9M2PVR3T"
+	if u != want {
+		t.Errorf("FormatPairURL =\n  %q\nwant:\n  %q", u, want)
+	}
+}
+
+func TestPairURLRoundTrip(t *testing.T) {
+	u := FormatPairURL("abc123endpointid", "nats://100.78.32.45:4222", "AXKF-9M2P-VR3T")
+	info, err := ParsePairURL(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.EndpointID != "abc123endpointid" {
+		t.Errorf("EndpointID = %q", info.EndpointID)
+	}
+	if info.NATSAddr != "nats://100.78.32.45:4222" {
+		t.Errorf("NATSAddr = %q", info.NATSAddr)
+	}
+	if info.Token != "AXKF9M2PVR3T" {
+		t.Errorf("Token = %q", info.Token)
+	}
+}
+
+func TestParsePairURLInvalid(t *testing.T) {
+	if _, err := ParsePairURL("bogus"); err == nil {
+		t.Error("expected error for invalid URL")
+	}
+	if _, err := ParsePairURL("edgesync-pair://v1/only-two"); err == nil {
+		t.Error("expected error for too few segments")
+	}
+}
+
+func TestRenderQR(t *testing.T) {
+	qr, err := RenderQR("edgesync-pair://v1/test/nats%3A%2F%2Flocalhost%3A4222/ABCD1234EFGH")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qr) == 0 {
+		t.Error("QR output should not be empty")
+	}
+}

--- a/leaf/go.mod
+++ b/leaf/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect

--- a/leaf/go.sum
+++ b/leaf/go.sum
@@ -79,6 +79,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
## Summary

Device pairing infrastructure for the notify system — token generation, QR codes, device registry, and 3 new CLI commands.

**6 new files, 4 modified, 31 notify tests + 4 CLI tests, 7 commits.**

## New Commands

- `edgesync notify pair --name "dan-iphone"` — generate one-time pairing token + QR code
- `edgesync notify unpair "dan-iphone"` — revoke a paired device
- `edgesync notify devices` — list all paired devices

## Architecture (Ousterhout-reviewed)

- Split into 3 files (not a god object): `token.go`, `token_store.go`, `device_registry.go`
- `CreatePairingToken(r, name)` deep function — CLI doesn't know about hashing or expiry
- Rejection sampling for token generation (no modulo bias)
- Tokens: 12-char base32, no ambiguous chars, single-use, 10-minute expiry
- Hub stores only SHA-256 hash of secret
- QR encodes: `edgesync-pair://v1/<endpoint>/<nats>/<secret>`
- Storage: `_notify/devices.json` + `_notify/pending_tokens.json` in notify.fossil

## ADR Update

Updated `docs/architecture/notify-messaging.md` with pairing and Expo app sections.

## Test plan

- [x] 31 notify package tests (includes 12 new pairing tests)
- [x] 4 CLI e2e tests (includes pair/unpair/devices)
- [x] Full regression (`make test`) passing
- [ ] Manual: generate token, verify QR renders, pair/unpair/devices round-trip