### PR TITLE
chore: point every libfossil reference at the new public path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     branches: [main]
 
 env:
-  GOPRIVATE: github.com/danmestas/go-libfossil
   GOWORK: "off"
 
 jobs:
@@ -19,9 +18,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Configure private module access
-        run: git config --global url."https://${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Vet
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  GOPRIVATE: github.com/danmestas/go-libfossil
-
 jobs:
   unit:
     name: Unit Tests
@@ -17,8 +14,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Configure private module access
-        run: git config --global url."https://${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - name: leaf
         run: cd leaf && go test ./... -short -count=1
       - name: bridge
@@ -32,8 +27,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Configure private module access
-        run: git config --global url."https://${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - name: Install Fossil
         run: sudo apt-get update && sudo apt-get install -y fossil
       - name: Sim unit tests
@@ -51,8 +44,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Configure private module access
-        run: git config --global url."https://${{ secrets.GO_MODULE_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - name: Build all binaries
         run: make build
       - name: Vet

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ go.work
 go.work.sum
 
 # Temporary clones for development
-.tmp-go-libfossil/
+.tmp-libfossil/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Fossil sync engine — replace Fossil's HTTP sync with NATS messaging or direct 
 See `MEMORY.md` for detailed project history, patterns, and decisions across sessions.
 
 See `docs/architecture/` for condensed architectural decision records (ARDs):
-- `core-library.md` — go-libfossil package architecture, blob format, xfer wire format, SQLite drivers
+- `core-library.md` — libfossil package architecture, blob format, xfer wire format, SQLite drivers
 - `sync-protocol.md` — xfer card protocol, client/server flow, clone, UV, config sync, private artifacts
 - `agent-deployment.md` — leaf agent, bridge, Docker, WASM targets, observability
 - `checkout-merge.md` — checkout/checkin, merge strategies, fork prevention, autosync, ci-lock
@@ -31,7 +31,7 @@ make setup-hooks        # Install pre-commit hook (~8s before each commit)
 go build -buildvcs=false ./cmd/edgesync/   # Dual VCS needs -buildvcs=false
 ```
 
-**CI:** GitHub Actions (`.github/workflows/ci.yml`) runs on push to main and PRs. Steps: `go vet`, unit tests (leaf + bridge in parallel), CLI build, CLI tests. Uses `GOWORK=off` and `GO_MODULE_TOKEN` secret for private go-libfossil access.
+**CI:** GitHub Actions (`.github/workflows/ci.yml`) runs on push to main and PRs. Steps: `go vet`, unit tests (leaf + bridge in parallel), CLI build, CLI tests. Uses `GOWORK=off`. All Go deps are public — no private-module auth needed.
 
 ## Go Modules (go.work)
 
@@ -40,23 +40,23 @@ Four modules in a workspace:
 - `leaf/` — leaf agent module
 - `bridge/` — bridge module
 - `dst/` — deterministic simulation tests
-- External dependency: `github.com/danmestas/go-libfossil` v0.2.x (standalone repo)
+- External dependency: `github.com/danmestas/libfossil` v0.1.x (public, standalone repo)
 
-For local go-libfossil development, copy `go.work.example` to `go.work` and clone go-libfossil at `../go-libfossil`.
+For local libfossil development, copy `go.work.example` to `go.work` and clone libfossil at `../libfossil`.
 
-**Important:** go-libfossil v0.2.0+ hides all implementation packages under `internal/`. EdgeSync imports only the root package handle API (`libfossil.Repo`, `libfossil.Transport`, etc.), plus `db/`, `simio/`, and `testutil/` which remain public.
+**Important:** libfossil hides all implementation packages under `internal/`. EdgeSync imports only the root package handle API (`libfossil.Repo`, `libfossil.Transport`, etc.), plus `db/`, `simio/`, and `testutil/` which remain public.
 
 ## Project Structure
 
 ### Entry Points
-- `cmd/edgesync/` — Unified CLI binary (embeds go-libfossil's `cli.RepoCmd` + EdgeSync-specific commands)
+- `cmd/edgesync/` — Unified CLI binary (embeds libfossil's `cli.RepoCmd` + EdgeSync-specific commands)
 - `leaf/cmd/leaf/` — Standalone leaf agent daemon
 - `bridge/cmd/bridge/` — Standalone bridge daemon
 - `sim/cmd/soak/` — Continuous soak test runner
 
-### Core Library: go-libfossil (external: github.com/danmestas/go-libfossil v0.2.x)
+### Core Library: libfossil (external: github.com/danmestas/libfossil v0.1.x)
 
-go-libfossil exposes an opaque `Repo` handle — all operations are methods on it. Implementation packages (blob, content, manifest, sync, xfer, etc.) are under `internal/` and not importable.
+libfossil exposes an opaque `Repo` handle — all operations are methods on it. Implementation packages (blob, content, manifest, sync, xfer, etc.) are under `internal/` and not importable.
 
 **Public API surface:**
 
@@ -80,7 +80,7 @@ go-libfossil exposes an opaque `Repo` handle — all operations are methods on i
 - `cli/` — Embeddable kong CLI commands (38 Fossil-compatible subcommands)
 - `observer/otel/` — Optional OTel observer (separate go.mod)
 
-**EdgeSync-specific commands (not in go-libfossil):**
+**EdgeSync-specific commands (not in libfossil):**
 - `sync start` / `sync now` — NATS agent daemon
 - `bridge serve` — NATS-to-HTTP bridge
 - `doctor` — Environment health check
@@ -88,7 +88,7 @@ go-libfossil exposes an opaque `Repo` handle — all operations are methods on i
 ### Agent/Bridge
 - `leaf/agent/` — `Config` (config.go), `New()`, `Start()`, `Stop()`, `SyncNow()`
   - `nats_mesh.go` — `NATSMesh` module: embedded NATS server + iroh tunnel establishment
-  - `serve_http.go` — composes mux with `/healthz` + `r.XferHandler()` (operational endpoints live here, not in go-libfossil)
+  - `serve_http.go` — composes mux with `/healthz` + `r.XferHandler()` (operational endpoints live here, not in libfossil)
   - `serve_nats.go` — NATS request/reply listener for leaf-to-leaf sync
   - Config fields: `NATSRole` (peer/hub/leaf), `NATSUpstream` (optional external NATS), `ServeHTTPAddr`, `ServeNATSEnabled`, `IrohEnabled`, `IrohPeers`, `IrohKeyPath`
   - CLI flags: `--repo`, `--nats`, `--nats-role`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`, `--iroh`, `--iroh-peer`, `--iroh-key`
@@ -102,7 +102,7 @@ go-libfossil exposes an opaque `Repo` handle — all operations are methods on i
   - `notify.go` — `Service` (Send, Watch, FormatWatchLine)
 - `cmd/edgesync/notify.go` — 7 CLI commands: init, send, ask, watch, threads, log, status
 - NATS subjects: `notify.<project>.<thread-short>` (separate from sync subjects)
-- Storage: dedicated `notify.fossil` repo, managed by go-libfossil (no `fossil` binary)
+- Storage: dedicated `notify.fossil` repo, managed by libfossil (no `fossil` binary)
 
 ### Simulation Testing
 - `dst/` — Deterministic single-threaded sim. `SimNetwork` (bridge mode), `PeerNetwork` (leaf-to-leaf). `MockFossil` delegates to `HandleSyncWithOpts`.
@@ -134,7 +134,7 @@ make test                                  # CI tests never need Doppler
 
 ### Observer Pattern
 
-`libfossil.SyncObserver` and `libfossil.CheckoutObserver` interfaces — lifecycle hooks for sync sessions, rounds, errors, server-side handling, and checkout operations. `leaf/telemetry/observer.go` implements them with OTel spans and metrics. go-libfossil's root package has **no OTel dependency** — the optional `observer/otel/` sub-module provides an OTel implementation with its own go.mod.
+`libfossil.SyncObserver` and `libfossil.CheckoutObserver` interfaces — lifecycle hooks for sync sessions, rounds, errors, server-side handling, and checkout operations. `leaf/telemetry/observer.go` implements them with OTel spans and metrics. libfossil's root package has **no OTel dependency** — the optional `observer/otel/` sub-module provides an OTel implementation with its own go.mod.
 
 ### Honeycomb Dashboard
 
@@ -159,7 +159,7 @@ cd ~/EdgeSync && git pull && cd deploy && sudo docker compose up -d --build
 | Tailscale HTTP | `http://100.78.32.45:9000` | Tailnet only |
 | Tailscale NATS | `nats://100.78.32.45:4222` | Tailnet only |
 
-- `deploy/Dockerfile` — multi-stage build, uses `GOWORK=off` (copies leaf/, depends on published go-libfossil)
+- `deploy/Dockerfile` — multi-stage build, uses `GOWORK=off` (copies leaf/, depends on published libfossil)
 - `deploy/docker-compose.yml` — NATS on Tailscale IP, leaf on port 9000 (8080/8090 occupied by Coolify/Caddy)
 - Cloudflare Tunnel config: `~/.cloudflared/config.yml` on VPS, service `cloudflared-fossil`
 - Repo files: `deploy/data/*.fossil` (host volume mount)
@@ -174,7 +174,7 @@ cd ~/EdgeSync && git pull && cd deploy && sudo docker compose up -d --build
 - **simio.CryptoRand{}**: Use for production callsites of `repo.Create` and `db.SeedConfig`
 - **Pre-commit hook**: `make setup-hooks` installs ~8s test gate
 - **HandleSync vs HandleSyncWithOpts**: Use `r.HandleSync()` in production, `r.HandleSyncWithOpts(ctx, req, HandleOpts{Buggify})` for DST
-- **go-libfossil is transport-agnostic**: No operational endpoints (healthz, metrics) in go-libfossil. Use `XferHandler()` to compose custom muxes. Operational concerns live in `leaf/agent/serve_http.go`.
+- **libfossil is transport-agnostic**: No operational endpoints (healthz, metrics) in libfossil. Use `XferHandler()` to compose custom muxes. Operational concerns live in `leaf/agent/serve_http.go`.
 
 ## Fossil Sync Protocol
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,7 +1,7 @@
 # EdgeSync Memory
 
 ## Project Structure
-- Go workspace (`go.work`) with 5 modules: root, `go-libfossil/`, `leaf/`, `bridge/`, `dst/`
+- Go workspace (`go.work`) with 5 modules: root, `libfossil/`, `leaf/`, `bridge/`, `dst/`
 - `sim/` is a package in the root module (not its own module)
 - Dual VCS: git + fossil checkout — use `-buildvcs=false` for all builds
 - Git repo: github.com/danmestas/EdgeSync (private)
@@ -54,8 +54,8 @@
 ## Config Locations
 - agent.Config in `leaf/agent/config.go` — includes ServeHTTPAddr, ServeNATSEnabled
 - bridge.Config in `bridge/bridge/config.go`
-- SyncOpts in `go-libfossil/sync/session.go` — has BuggifyChecker field
-- HandleOpts in `go-libfossil/sync/handler.go` — has BuggifyChecker field
+- SyncOpts in `libfossil/sync/session.go` — has BuggifyChecker field
+- HandleOpts in `libfossil/sync/handler.go` — has BuggifyChecker field
 
 ## Key Patterns
 - `simio.CryptoRand{}` for production callsites of `repo.Create` and `db.SeedConfig`

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ setup-hooks:
 	@echo "Skip with: git commit --no-verify"
 
 # --- Sim (Integration Simulation) — run locally, requires fossil ---
-# Note: DST tests now live in go-libfossil (github.com/danmestas/go-libfossil/dst)
+# Note: DST tests now live in libfossil (github.com/danmestas/libfossil/dst)
 
 # Quick: 1 seed, normal severity
 sim:
@@ -93,7 +93,7 @@ test-iroh: iroh-sidecar
 # --- Dependency update ---
 
 update-libfossil:
-	GOPRIVATE=github.com/danmestas/go-libfossil go get github.com/danmestas/go-libfossil@latest
-	GOPRIVATE=github.com/danmestas/go-libfossil go get github.com/danmestas/go-libfossil/db/driver/modernc@latest
-	GOPRIVATE=github.com/danmestas/go-libfossil go get github.com/danmestas/go-libfossil/db/driver/ncruces@latest
+	go get github.com/danmestas/libfossil@latest
+	go get github.com/danmestas/libfossil/db/driver/modernc@latest
+	go get github.com/danmestas/libfossil/db/driver/ncruces@latest
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318 bin/leaf --repo my.fossil --nats nats
 ```
 cmd/edgesync/          Unified CLI binary (50 subcommands)
 
-go-libfossil/          Core library — Go port of Fossil internals
+libfossil/             Core library — Go port of Fossil internals
   annotate/            Line-level blame/annotate
   bisect/              Binary search for regressions
   blob/                Blob compression (Fossil's 4-byte prefix + zlib)
@@ -119,7 +119,7 @@ docs/                  Documentation
 | Module | Path | Purpose |
 |--------|------|---------|
 | `github.com/dmestas/edgesync` | `.` | Root: CLI, sim/, soak runner |
-| `github.com/dmestas/edgesync/go-libfossil` | `go-libfossil/` | Core library |
+| `github.com/danmestas/libfossil` | `libfossil/` | Core library (public, v0.1.x) |
 | `github.com/dmestas/edgesync/leaf` | `leaf/` | Leaf agent |
 | `github.com/dmestas/edgesync/bridge` | `bridge/` | Bridge |
 | `github.com/dmestas/edgesync/dst` | `dst/` | Deterministic sim tests |

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.26-alpine AS build
 RUN apk add --no-cache gcc musl-dev git
 WORKDIR /src
-COPY go-libfossil/ go-libfossil/
+COPY libfossil/ libfossil/
 COPY leaf/ leaf/
 RUN cd leaf && \
-    go mod edit -replace github.com/danmestas/go-libfossil=/src/go-libfossil \
-                -replace github.com/danmestas/go-libfossil/db/driver/modernc=/src/go-libfossil/db/driver/modernc \
-                -replace github.com/danmestas/go-libfossil/db/driver/ncruces=/src/go-libfossil/db/driver/ncruces && \
+    go mod edit -replace github.com/danmestas/libfossil=/src/libfossil \
+                -replace github.com/danmestas/libfossil/db/driver/modernc=/src/libfossil/db/driver/modernc \
+                -replace github.com/danmestas/libfossil/db/driver/ncruces=/src/libfossil/db/driver/ncruces && \
     GOWORK=off go build -buildvcs=false -o /leaf ./cmd/leaf/
 
 FROM alpine:3.20

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -70,7 +70,7 @@ Start broad, go deep as needed:
 2. **[docs/leaf-agent.md](leaf-agent.md)** -- Leaf agent usage, flags, config
 3. **[docs/bridge.md](bridge.md)** -- Bridge usage and deployment
 4. **Architecture docs** (in `docs/architecture/`):
-   - `core-library.md` -- go-libfossil package design, blob format, SQLite drivers
+   - `core-library.md` -- libfossil package design, blob format, SQLite drivers
    - `sync-protocol.md` -- xfer card protocol, client/server flow, UV sync
    - `testing-strategy.md` -- test tiers (unit, DST, sim, interop), BUGGIFY
    - `agent-deployment.md` -- Docker, Hetzner VPS, Cloudflare Tunnel
@@ -80,7 +80,7 @@ Start broad, go deep as needed:
 ## Things to Know
 
 - **`-buildvcs=false`** is required for raw `go build` (dual VCS: git + fossil). The Makefile handles this for you.
-- **Five Go modules** in a workspace (`go.work`): root, go-libfossil, leaf, bridge, dst. Use `go test ./go-libfossil/...` etc.
+- **Five Go modules** in a workspace (`go.work`): root, libfossil, leaf, bridge, dst. Use `go test ./libfossil/...` etc.
 - **Three SQLite drivers**: modernc (default, pure Go), ncruces (WASM-based), mattn (CGo). Switch via build tags.
 - **`fossil/` and `libfossil/`** directories are gitignored -- upstream C reference checkouts for porting. They exist on some dev machines but aren't tracked.
 - **Pre-commit hook** runs ~8s of tests. Skip with `git commit --no-verify` (emergency only).

--- a/docs/architecture/agent-deployment.md
+++ b/docs/architecture/agent-deployment.md
@@ -2,7 +2,7 @@
 
 ## Leaf Agent Architecture
 
-The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil repo via go-libfossil, connects to NATS, and syncs artifacts on a poll loop. It acts as both sync client and server.
+The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil repo via libfossil, connects to NATS, and syncs artifacts on a poll loop. It acts as both sync client and server.
 
 **Lifecycle:** `New(Config)` -> `Start()` -> `Stop()`. A single poll goroutine is the sole executor of `doSync()`. `SyncNow()` is a non-blocking signal (buffered channel, size 1) that coalesces if a sync is already running. This avoids concurrent SQLite access.
 
@@ -82,7 +82,7 @@ Third transport option alongside NATS and HTTP. Enables direct peer-to-peer sync
 
 ## HTTP Serving
 
-`serve_http.go` in `leaf/agent/` composes an HTTP mux with `/healthz` (200 OK, JSON status) and `sync.XferHandler()` for Fossil's `/xfer` endpoint. Operational endpoints live in the agent, not in go-libfossil (which is transport-agnostic).
+`serve_http.go` in `leaf/agent/` composes an HTTP mux with `/healthz` (200 OK, JSON status) and `sync.XferHandler()` for Fossil's `/xfer` endpoint. Operational endpoints live in the agent, not in libfossil (which is transport-agnostic).
 
 Stock `fossil clone` and `fossil sync` work against the leaf's HTTP endpoint.
 
@@ -90,7 +90,7 @@ Stock `fossil clone` and `fossil sync` work against the leaf's HTTP endpoint.
 
 Stack lives in `deploy/`. Two containers: NATS + leaf agent.
 
-**Dockerfile:** Multi-stage build. Build stage: `golang:1.25-alpine` with CGO (modernc SQLite). Run stage: `alpine:3.20` (~20-30MB). Uses `GOWORK=off`, copies only `go-libfossil/` and `leaf/`.
+**Dockerfile:** Multi-stage build. Build stage: `golang:1.26-alpine` with CGO (modernc SQLite). Run stage: `alpine:3.20` (~20-30MB). Uses `GOWORK=off`, copies only `libfossil/` and `leaf/`.
 
 **Compose services:**
 
@@ -132,7 +132,7 @@ Two targets, same agent API (`New` -> `Start` -> `Stop`):
 
 ### Observer Pattern
 
-`sync.Observer` interface in go-libfossil -- zero OTel dependency. Lifecycle hooks injected via `SyncOpts.Observer` and `CloneOpts.Observer`. Nil observer uses `nopObserver` (zero-cost, ~2ns indirect call).
+`sync.Observer` interface in libfossil -- zero OTel dependency. Lifecycle hooks injected via `SyncOpts.Observer` and `CloneOpts.Observer`. Nil observer uses `nopObserver` (zero-cost, ~2ns indirect call).
 
 ```go
 type Observer interface {
@@ -150,7 +150,7 @@ type Observer interface {
 
 ### OTel Integration
 
-All OTel code lives in `leaf/telemetry/` (build-tagged `!wasip1 && !js`). WASM gets no-op stubs. go-libfossil and bridge modules have zero OTel dependencies.
+All OTel code lives in `leaf/telemetry/` (build-tagged `!wasip1 && !js`). WASM gets no-op stubs. libfossil and bridge modules have zero OTel dependencies.
 
 **Setup:** `telemetry.Setup()` initializes TracerProvider + MeterProvider with OTLP exporters. Falls back to standard `OTEL_*` env vars. No endpoint = no-op (zero overhead).
 
@@ -188,4 +188,4 @@ Four modules in EdgeSync's `go.work`:
 | `bridge/` | No | Yes | NATS-HTTP translator |
 | `dst/` | No | No | Deterministic simulation |
 
-go-libfossil is an external dependency at `github.com/danmestas/go-libfossil` (standalone repo). For local development, copy `go.work.example` to `go.work` and clone go-libfossil at `../go-libfossil`.
+libfossil is an external dependency at `github.com/danmestas/libfossil` (public, standalone repo). For local development, copy `go.work.example` to `go.work` and clone libfossil at `../libfossil`.

--- a/docs/architecture/checkout-merge.md
+++ b/docs/architecture/checkout-merge.md
@@ -2,7 +2,7 @@
 
 ## Checkout Architecture
 
-The `go-libfossil/checkout/` package is a clean-room port of libfossil's 43 public checkout functions into ~30 methods on `*Checkout`. All filesystem I/O goes through `simio.Env` (Storage, Clock, Rand) -- no build tags, platform-agnostic, WASM-ready.
+The `libfossil/checkout/` package is a clean-room port of libfossil's 43 public checkout functions into ~30 methods on `*Checkout`. All filesystem I/O goes through `simio.Env` (Storage, Clock, Rand) -- no build tags, platform-agnostic, WASM-ready.
 
 ```go
 type Checkout struct {
@@ -20,7 +20,7 @@ Key accessors: `Version()` returns current RID + UUID. `Dir()` returns root path
 
 **`simio.Storage` extension** -- `ReadDir(path string) ([]fs.DirEntry, error)` added for `ScanChanges` directory walking.
 
-**Observer** -- separate `checkout.Observer` interface (extract/scan/commit lifecycle hooks). OTel implementation in `leaf/telemetry/checkout_observer.go`. go-libfossil stays OTel-free.
+**Observer** -- separate `checkout.Observer` interface (extract/scan/commit lifecycle hooks). OTel implementation in `leaf/telemetry/checkout_observer.go`. libfossil stays OTel-free.
 
 ## Checkout Operations
 
@@ -122,30 +122,30 @@ Sequence: pre-pull with ci-lock request, check lock result, inject `WouldFork` a
 
 ## Stash, Undo, Annotate, Bisect
 
-### Stash (`go-libfossil/stash/`)
+### Stash (`libfossil/stash/`)
 
 Schema: `stash` + `stashfile` tables in checkout DB. `stash.hash` = checkout manifest UUID at save time. `stashfile.delta` = delta from baseline to working content. Save computes deltas via `delta/` package, reverts working dir. Pop/apply call `undoSave()` first.
 
-### Undo (`go-libfossil/undo/`)
+### Undo (`libfossil/undo/`)
 
 Single-level undo/redo via `undo`, `undo_vfile`, `undo_vmerge` tables. State machine: `undo_available` in vvar (0=none, 1=undo, 2=redo). Swap mechanism: vfile <-> undo_vfile, vmerge <-> undo_vmerge, restore file content. Called before: checkout, revert, add, rm, rename, stash pop/apply.
 
-### Annotate (`go-libfossil/annotate/`)
+### Annotate (`libfossil/annotate/`)
 
 Walk parent chain via `plink` + `mlink`, diff each ancestor with Myers, push `iVers` markers back. Track renames via `mlink.fnid` + `filename.name`. Options: `--limit`, `--origin`, `--version`.
 
-### Bisect (`go-libfossil/bisect/`)
+### Bisect (`libfossil/bisect/`)
 
 State in vvar: `bisect-good`, `bisect-bad`, `bisect-log`. BFS path-finding over `plink` (unweighted, matches Fossil's `path_shortest()`). Auto-next on good/bad/skip. Converges when good and bad are adjacent.
 
-### Branch (`go-libfossil/tag/`)
+### Branch (`libfossil/tag/`)
 
 Branches are propagating `sym-<name>` tags. Creation = checkin with `sym-<name>` (propagating) + `branch=<name>` (singleton) via `CheckinOpts.Tags`. Closing = control artifact cancelling the sym tag + adding `closed`.
 
 ## Key Constraints
 
-- **go-libfossil is transport-agnostic** -- no transport imports, no operational endpoints. Fork detection and PreCommitCheck are primitives; the agent owns the workflow.
+- **libfossil is transport-agnostic** -- no transport imports, no operational endpoints. Fork detection and PreCommitCheck are primitives; the agent owns the workflow.
 - **Fossil-compatible schema** -- vfile, vmerge, vvar, stash, undo tables match Fossil's layout for interoperability.
 - **simio.Env everywhere** -- all I/O through Storage/Clock/Rand. No build tags in checkout package.
 - **TigerStyle assertions** -- precondition panics for nil/invalid arguments on all public methods.
-- **Observer pattern** -- lifecycle hooks in go-libfossil, OTel implementation in leaf/telemetry.
+- **Observer pattern** -- lifecycle hooks in libfossil, OTel implementation in leaf/telemetry.

--- a/docs/architecture/core-library.md
+++ b/docs/architecture/core-library.md
@@ -1,6 +1,6 @@
-# go-libfossil Core Library
+# libfossil Core Library
 
-Pure-Go reimplementation of Fossil's core operations. Standalone repo at `github.com/danmestas/go-libfossil` (private, v0.2.x). No CGo in the default build. Every operation must produce `.fossil` files that `fossil rebuild --verify` accepts.
+Pure-Go reimplementation of Fossil's core operations. Standalone repo at `github.com/danmestas/libfossil` (public, v0.1.x). No CGo in the default build. Every operation must produce `.fossil` files that `fossil rebuild --verify` accepts.
 
 ## Repository & Module Structure
 
@@ -8,13 +8,13 @@ Extracted from EdgeSync monorepo (April 2026) via `git filter-repo` with history
 
 | Module | Purpose |
 |---|---|
-| `github.com/danmestas/go-libfossil` | Root — opaque handle API, CLI, tests |
-| `github.com/danmestas/go-libfossil/db/driver/modernc` | Default SQLite driver |
-| `github.com/danmestas/go-libfossil/db/driver/ncruces` | WASM-compatible SQLite driver |
+| `github.com/danmestas/libfossil` | Root — opaque handle API, CLI, tests |
+| `github.com/danmestas/libfossil/db/driver/modernc` | Default SQLite driver |
+| `github.com/danmestas/libfossil/db/driver/ncruces` | WASM-compatible SQLite driver |
 
 Optional sub-module: `observer/otel/` — OTel observer implementation (separate go.mod, zero OTel deps in root).
 
-Versioning: lockstep `v0.x` tags across all sub-modules. Tags: `v0.2.5`, `db/driver/modernc/v0.2.5`, `db/driver/ncruces/v0.2.5`.
+Versioning: lockstep `v0.x` tags across all sub-modules. Tags: `v0.1.0`, `db/driver/modernc/v0.1.0`, `db/driver/ncruces/v0.1.0`.
 
 ## Encapsulation & Public API
 
@@ -127,7 +127,7 @@ GOWORK=off go test -tags test_ncruces ./...           # ncruces
 
 ## TigerStyle Conventions
 
-Applied across all 20 go-libfossil packages. Zero new features -- hardening only.
+Applied across all 20 libfossil packages. Zero new features -- hardening only.
 
 ### Assertions
 

--- a/docs/architecture/notify-messaging.md
+++ b/docs/architecture/notify-messaging.md
@@ -10,7 +10,7 @@ Three components, phased delivery:
 
 | Component | Stack | Status |
 |-----------|-------|--------|
-| Go CLI (`edgesync notify`) | go-libfossil, nats.go, Kong | **Shipped (Phase 1)** |
+| Go CLI (`edgesync notify`) | libfossil, nats.go, Kong | **Shipped (Phase 1)** |
 | Hetzner hub relay | Existing leaf agent + new NATS subjects | Planned (Phase 2) |
 | Expo app (iOS + macOS) | React Native, NATS-over-iroh | Planned (Phase 3) |
 
@@ -78,7 +78,7 @@ notify.>                        # Firehose
 <project>/media/           # UV files (Phase 2)
 ```
 
-`notify.fossil` is a dedicated Fossil repo created via `InitNotifyRepo()`. Managed entirely by go-libfossil — no `fossil` binary dependency. Messages are versioned checkins; media attachments use UV (unversioned files).
+`notify.fossil` is a dedicated Fossil repo created via `InitNotifyRepo()`. Managed entirely by libfossil — no `fossil` binary dependency. Messages are versioned checkins; media attachments use UV (unversioned files).
 
 ## Identity & Trust
 
@@ -103,7 +103,7 @@ cmd/edgesync/
 - No `NewActionReply` — callers use `NewReply` + set `ActionResponse = true`
 - Service holds `*libfossil.Repo` and `*nats.Conn` directly, doesn't own their lifecycle
 
-**Store internals:** `store.go` queries Fossil's `filename`, `mlink`, `blob` tables directly and decompresses the blob format (4-byte BE size + zlib). This bypasses go-libfossil's public API because `r.ReadFile()` doesn't exist yet. If added, migrate.
+**Store internals:** `store.go` queries Fossil's `filename`, `mlink`, `blob` tables directly and decompresses the blob format (4-byte BE size + zlib). This bypasses libfossil's public API because `r.ReadFile()` doesn't exist yet. If added, migrate.
 
 ## CLI Interface
 
@@ -156,7 +156,7 @@ Go backend compiled via gomobile, localhost HTTP/SSE server, React Native (Expo)
 ├────── localhost HTTP ────────┤
 │  Go Framework (gomobile)    │  Logic layer — notify.Service, NATS, iroh
 │  HTTP server + SSE          │
-│  go-libfossil + nats.go     │
+│  libfossil + nats.go        │
 └─────────────────────────────┘
 ```
 
@@ -215,7 +215,7 @@ gomobile exports three top-level functions callable from Swift:
 ```
 edgesync-notify-app/
   go/
-    go.mod              # imports go-libfossil + edgesync/leaf/agent/notify
+    go.mod              # imports libfossil + edgesync/leaf/agent/notify
     server.go           # localhost HTTP + SSE server
     bridge.go           # wraps notify.Service for HTTP handlers
     bridge_test.go      # httptest-based tests
@@ -292,13 +292,13 @@ npx expo prebuild
 npx expo run:ios
 ```
 
-CI runs `go test ./go/` and `npx tsc --noEmit`. Full iOS build is local only. CI requires `GO_MODULE_TOKEN` for private module access.
+CI runs `go test ./go/` and `npx tsc --noEmit`. Full iOS build is local only. libfossil is a public module, so no `GO_MODULE_TOKEN` or GOPRIVATE plumbing is required.
 
 ### Dependencies
 
 | Package | Purpose |
 |---------|---------|
-| `go-libfossil` | Fossil repo operations |
+| `libfossil` | Fossil repo operations |
 | `edgesync/leaf/agent/notify` | Message types, store, pub/sub, Service |
 | `nats.go` | NATS client |
 | `gomobile` | Compile Go to iOS/macOS framework |

--- a/docs/architecture/repo-operations.md
+++ b/docs/architecture/repo-operations.md
@@ -2,7 +2,7 @@
 
 ## Unified CLI
 
-Single binary `edgesync` built with [kong](https://github.com/alecthomas/kong) struct-tag dispatch. Replaces the need for the `fossil` binary for basic repo operations. One file per command in `cmd/edgesync/`, each delegating to go-libfossil packages.
+Single binary `edgesync` built with [kong](https://github.com/alecthomas/kong) struct-tag dispatch. Replaces the need for the `fossil` binary for basic repo operations. One file per command in `cmd/edgesync/`, each delegating to libfossil packages.
 
 Global flags: `-R <path>` (repo file), `-C <path>` (checkout dir), `-v` (verbose). Repo discovery walks parent directories for `.fslckout` / `_FOSSIL_` when `-R` is omitted.
 
@@ -57,7 +57,7 @@ Special case: `bgcolor` tag also updates `event.bgcolor` at each descendant.
 
 ## Full-Text Search
 
-Package `go-libfossil/search/` with FTS5 trigram index stored inside the repo DB.
+Package `libfossil/search/` with FTS5 trigram index stored inside the repo DB.
 
 | Decision | Choice |
 |----------|--------|
@@ -73,7 +73,7 @@ Indexing expands delta chains via `content.Expand()`, skips phantoms and binarie
 
 ## Verify & Rebuild
 
-Package `go-libfossil/verify/` with two entry points:
+Package `libfossil/verify/` with two entry points:
 
 - **`Verify(r)`** -- read-only, report-all (never stops early), returns structured `Report` with typed `Issue` values.
 - **`Rebuild(r)`** -- drop-and-recompute all derived tables in a single transaction. Rollback on any error.
@@ -100,7 +100,7 @@ Existing `repo.Verify()` is deprecated and delegates to `verify.Verify()`, retur
 
 ## Auth & Capabilities
 
-Package `go-libfossil/auth/`. Repo-sovereign authentication using Fossil's existing `user` table and HMAC login scheme. No wire protocol changes.
+Package `libfossil/auth/`. Repo-sovereign authentication using Fossil's existing `user` table and HMAC login scheme. No wire protocol changes.
 
 ### Login Verification
 
@@ -140,7 +140,7 @@ Compact JSON base64url-encoded: `{"url","login","password","caps"}`. Password is
 
 ## Shun & Purge
 
-Package `go-libfossil/shun/`. Shunning is **local state** -- does not propagate via sync. Shunned artifacts are already excluded from igot/gimme exchanges in `sync/client.go` and `sync/handler.go`.
+Package `libfossil/shun/`. Shunning is **local state** -- does not propagate via sync. Shunned artifacts are already excluded from igot/gimme exchanges in `sync/client.go` and `sync/handler.go`.
 
 ### API
 

--- a/docs/architecture/sync-protocol.md
+++ b/docs/architecture/sync-protocol.md
@@ -2,7 +2,7 @@
 
 ## Transport-Agnostic Design
 
-The sync engine (`go-libfossil/sync/`) operates entirely through a `Transport` interface with a single method:
+The sync engine (`libfossil/sync/`) operates entirely through a `Transport` interface with a single method:
 
 ```go
 type Transport interface {
@@ -114,7 +114,7 @@ Mirrors Fossil's per-request `onremote` temp table (xfer.c:1011-1012, 1056-1057)
 
 **Implementation:** `remoteHas map[string]remoteHasEntry` on the handler struct, where `remoteHasEntry{isPrivate bool}` records the client's announced private status. Lazily initialized (nil until first igot received). Lifecycle is per-request -- no cross-request persistence.
 
-**Private-status-aware filtering (divergence from Fossil):** Fossil's `onremote` is a simple `rid INTEGER PRIMARY KEY` -- no private flag. Fossil doesn't need one because its server-side igot handler calls `content_make_public(rid)` / `content_make_private(rid)` to synchronize private status during igot processing (xfer.c:1472-1476). go-libfossil deliberately does NOT mutate server private status from client igots ("server is authoritative"). This means private/public transitions must propagate through igot *emission*: the filter only skips when the client's announced status matches the server's current status.
+**Private-status-aware filtering (divergence from Fossil):** Fossil's `onremote` is a simple `rid INTEGER PRIMARY KEY` -- no private flag. Fossil doesn't need one because its server-side igot handler calls `content_make_public(rid)` / `content_make_private(rid)` to synchronize private status during igot processing (xfer.c:1472-1476). libfossil deliberately does NOT mutate server private status from client igots ("server is authoritative"). This means private/public transitions must propagate through igot *emission*: the filter only skips when the client's announced status matches the server's current status.
 
 - `emitIGots()` (public blobs): skip when `ok && !e.isPrivate` -- client has it as public
 - `emitPrivateIGots()` (private blobs): skip when `ok && e.isPrivate` -- client has it as private
@@ -232,6 +232,6 @@ Two-pass architecture matching Fossil's `manifest_crosslink_begin`/`manifest_cro
 - **SHA3 UUIDs:** 64-char = SHA3-256 (Fossil 2.0+), 40-char = SHA1 (legacy).
 - **Performance targets:** Compute within 3x of C, I/O within 5x.
 - **No CGo:** Pure Go, behavioral equivalence validated by Fossil CLI as test oracle.
-- **go-libfossil is transport-agnostic:** No operational endpoints (healthz, metrics). Operational concerns live in `leaf/agent/serve_http.go`.
+- **libfossil is transport-agnostic:** No operational endpoints (healthz, metrics). Operational concerns live in `leaf/agent/serve_http.go`.
 - **Stale phantom eviction:** After 3 consecutive unresolved rounds, phantoms are evicted to prevent convergence deadlock.
 - **Auth contract:** User + Password both set = login card with SHA1 auth. Either empty = no login card (unauthenticated "nobody").

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -4,7 +4,7 @@
 
 | Tier | Location | Infrastructure | Speed | What It Proves |
 |------|----------|---------------|-------|----------------|
-| Unit | `go-libfossil/*/` | None | <1s | Package-level correctness |
+| Unit | `libfossil/*/` | None | <1s | Package-level correctness |
 | DST (deterministic sim) | `dst/` | In-process only | Fast (thousands of seeds in CI) | Protocol logic, convergence, message ordering |
 | Integration sim | `sim/` | Real NATS + fault proxy + real Fossil | ~15-60s per run | NATS integration, HTTP encoding, production code paths |
 | Equivalence | `sim/equivalence_test.go` | Fossil CLI | <15s | Round-trip: Checkin -> sync -> fossil open -> verify files |

--- a/docs/bridge.md
+++ b/docs/bridge.md
@@ -141,7 +141,7 @@ All leaves for the same project share the same NATS subject. The bridge handles 
 
 ## Dependencies
 
-- `go-libfossil` — xfer codec, sync.HTTPTransport
+- `libfossil` — xfer codec, sync.HTTPTransport
 - `github.com/nats-io/nats.go` — NATS client
 - `github.com/nats-io/nats-server/v2` — embedded NATS server (test only)
 

--- a/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
+++ b/docs/superpowers/specs/2026-04-08-nats-over-iroh-design.md
@@ -1,7 +1,7 @@
 # NATS-over-iroh: P2P Presence and Messaging
 
 **Date:** 2026-04-08
-**Target repo:** EdgeSync (agent + sidecar), no go-libfossil changes
+**Target repo:** EdgeSync (agent + sidecar), no libfossil changes
 **Linear:** EDG-59
 
 ## Problem
@@ -186,7 +186,7 @@ Stop():
 
 ## What Does NOT Change
 
-- **go-libfossil** — transport-agnostic, no changes
+- **libfossil** — transport-agnostic, no changes
 - **NATSTransport** (`leaf/agent/nats.go`) — still does request/reply on subjects, connects to localhost
 - **ServeNATS** (`leaf/agent/serve_nats.go`) — still subscribes and handles sync requests
 - **IrohTransport** (`leaf/agent/iroh.go`) — kept for backwards compat with peers that don't have embedded NATS. Deprecate once NATS-over-iroh is stable (follow-up ticket) — having two paths to reach iroh peers increases cognitive load

--- a/go.work.example
+++ b/go.work.example
@@ -1,5 +1,5 @@
-// Copy this file to go.work for local development against a local go-libfossil checkout.
-// Assumes go-libfossil is cloned at ../go-libfossil relative to this repo.
+// Copy this file to go.work for local development against a local libfossil checkout.
+// Assumes libfossil is cloned at ../libfossil relative to this repo.
 // Do NOT commit go.work — it is gitignored.
 
 go 1.26.0
@@ -12,7 +12,7 @@ use (
 )
 
 replace (
-	github.com/danmestas/go-libfossil => ../go-libfossil
-	github.com/danmestas/go-libfossil/db/driver/modernc => ../go-libfossil/db/driver/modernc
-	github.com/danmestas/go-libfossil/db/driver/ncruces => ../go-libfossil/db/driver/ncruces
+	github.com/danmestas/libfossil => ../libfossil
+	github.com/danmestas/libfossil/db/driver/modernc => ../libfossil/db/driver/modernc
+	github.com/danmestas/libfossil/db/driver/ncruces => ../libfossil/db/driver/ncruces
 )


### PR DESCRIPTION
## Summary

Follow-up to [`4996f19`](https://github.com/danmestas/EdgeSync/commit/4996f19) which migrated imports (`go-libfossil` → `libfossil`). This PR sweeps every remaining non-source reference so the repo is internally consistent with the new public module path.

- **CI simplification**: `libfossil` is public now, so `.github/workflows/{ci,test}.yml` drop `GOPRIVATE` env vars and the `git config url.<...>.insteadOf` rewrite steps. All Go deps (including indirect `go-sqlite3-opfs`) are public — no token needed.
- **Makefile**: `update-libfossil` target drops GOPRIVATE; DST-tests comment points at new path.
- **Dockerfile + go.work.example**: local clone path `go-libfossil/` → `libfossil/`.
- **Docs**: `CLAUDE.md`, README, MEMORY, `docs/GETTING-STARTED.md`, `docs/bridge.md`, and 7 `docs/architecture/*.md` files updated. Version markers where quoted went from `v0.2.x` → `v0.1.x` (the public release reset the tag series).

## Test plan

- [x] `cd leaf && go build ./...` — green
- [x] `cd bridge && go build ./...` — green
- [x] `go build ./cmd/edgesync/` — green
- [x] `grep -rln "go-libfossil"` — only binaries (`edgesync`, `leaf/leaf`, `soak`) and two untracked personal design docs remain; all tracked source + config files are clean
- [ ] CI run on this branch passes the new simplified workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)