### PR TITLE
Add configurable leaf NATS client port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ libfossil exposes an opaque `Repo` handle — all operations are methods on it. 
   - `serve_http.go` — composes mux with `/healthz` + `r.XferHandler()` (operational endpoints live here, not in libfossil)
   - `serve_nats.go` — NATS request/reply listener for leaf-to-leaf sync
   - Config fields: `NATSRole` (peer/hub/leaf), `NATSUpstream` (optional external NATS), `ServeHTTPAddr`, `ServeNATSEnabled`, `IrohEnabled`, `IrohPeers`, `IrohKeyPath`
-  - CLI flags: `--repo`, `--nats`, `--nats-role`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`, `--iroh`, `--iroh-peer`, `--iroh-key`
+  - CLI flags: `--repo`, `--nats`, `--nats-client-port`, `--nats-role`, `--poll`, `--serve-http`, `--serve-nats`, `--uv`, `--push`, `--pull`, `--user`, `--password`, `--iroh`, `--iroh-peer`, `--iroh-key`
 - `bridge/bridge/` — `Config` (config.go), `New()`, `Start()`, `Stop()`
 
 ### Notify Messaging

--- a/docs/architecture/agent-deployment.md
+++ b/docs/architecture/agent-deployment.md
@@ -13,6 +13,7 @@ The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil re
 | `RepoPath` | (required) | `--repo` | `LEAF_REPO` |
 | `NATSRole` | `"peer"` | `--nats-role` | |
 | `NATSUpstream` | `""` (embedded only) | `--nats` | `LEAF_NATS_URL` |
+| `NATSClientPort` | `0` (random) | `--nats-client-port` | `LEAF_NATS_CLIENT_PORT` |
 | `PollInterval` | `5s` | `--poll` | |
 | `User` | `""` (anonymous) | `--user` | |
 | `Password` | `""` | `--password` | |

--- a/docs/leaf-agent.md
+++ b/docs/leaf-agent.md
@@ -21,6 +21,7 @@ The leaf agent opens a Fossil repository, runs an embedded NATS server, and sync
 |------|---------|---------|-------------|
 | `--repo` | `LEAF_REPO` | (required) | Path to `.fossil` repo file |
 | `--nats` | `LEAF_NATS_URL` | `""` | Optional upstream NATS URL (embedded server joins as leaf) |
+| `--nats-client-port` | `LEAF_NATS_CLIENT_PORT` | `0` | Embedded NATS client listener port (`0` chooses a random localhost port) |
 | `--nats-role` | | `peer` | Mesh role: `peer`, `hub`, or `leaf` |
 | `--poll` | | `5s` | Poll interval |
 | `--user` | `LEAF_USER` | (anonymous) | Sync user |

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -106,9 +106,10 @@ func New(cfg Config) (*Agent, error) {
 	// startIrohSidecar (which establishes tunnels and populates
 	// tunnelPorts) before starting the NATS server.
 	mesh := &NATSMesh{
-		role:      cfg.NATSRole,
-		upstream:  cfg.NATSUpstream,
-		irohPeers: cfg.IrohPeers,
+		role:       cfg.NATSRole,
+		upstream:   cfg.NATSUpstream,
+		irohPeers:  cfg.IrohPeers,
+		clientPort: cfg.NATSClientPort,
 	}
 
 	a := &Agent{

--- a/leaf/agent/agent_test.go
+++ b/leaf/agent/agent_test.go
@@ -40,19 +40,23 @@ func TestConfigDefaults(t *testing.T) {
 
 func TestConfigDefaultsPreserveExplicit(t *testing.T) {
 	c := Config{
-		RepoPath:      "/tmp/test.fossil",
-		NATSUpstream:  "nats://custom:4223",
-		NATSRole:      NATSRoleHub,
-		PollInterval:  10 * time.Second,
-		User:          "alice",
-		Push:          true,
-		Pull:          false,
-		SubjectPrefix: "edgesync",
+		RepoPath:       "/tmp/test.fossil",
+		NATSUpstream:   "nats://custom:4223",
+		NATSClientPort: 5222,
+		NATSRole:       NATSRoleHub,
+		PollInterval:   10 * time.Second,
+		User:           "alice",
+		Push:           true,
+		Pull:           false,
+		SubjectPrefix:  "edgesync",
 	}
 	c.applyDefaults()
 
 	if c.NATSUpstream != "nats://custom:4223" {
 		t.Errorf("NATSUpstream = %q, want %q", c.NATSUpstream, "nats://custom:4223")
+	}
+	if c.NATSClientPort != 5222 {
+		t.Errorf("NATSClientPort = %d, want 5222", c.NATSClientPort)
 	}
 	if c.NATSRole != NATSRoleHub {
 		t.Errorf("NATSRole = %q, want %q", c.NATSRole, NATSRoleHub)
@@ -95,6 +99,16 @@ func TestConfigValidateOK(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsInvalidNATSClientPort(t *testing.T) {
+	for _, port := range []int{-1, 65536} {
+		c := Config{RepoPath: "/tmp/test.fossil", NATSClientPort: port}
+		c.applyDefaults()
+		if err := c.validate(); err == nil {
+			t.Fatalf("validate with NATSClientPort=%d returned nil", port)
+		}
+	}
+}
+
 // createTestRepo creates a temporary Fossil repo and returns its path.
 // The repo is cleaned up when the test ends.
 func createTestRepo(t *testing.T) string {
@@ -134,8 +148,8 @@ func TestAgentNewAndStop(t *testing.T) {
 	natsURL := startEmbeddedNATS(t)
 
 	a, err := New(Config{
-		RepoPath: repoPath,
-		NATSUpstream:  natsURL,
+		RepoPath:     repoPath,
+		NATSUpstream: natsURL,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -159,7 +173,7 @@ func TestAgentStartAndStop(t *testing.T) {
 
 	a, err := New(Config{
 		RepoPath:     repoPath,
-		NATSUpstream:      natsURL,
+		NATSUpstream: natsURL,
 		PollInterval: 50 * time.Millisecond,
 	})
 	if err != nil {
@@ -182,8 +196,8 @@ func TestAgentNewBadRepoPath(t *testing.T) {
 	natsURL := startEmbeddedNATS(t)
 
 	_, err := New(Config{
-		RepoPath: "/nonexistent/path/to/repo.fossil",
-		NATSUpstream:  natsURL,
+		RepoPath:     "/nonexistent/path/to/repo.fossil",
+		NATSUpstream: natsURL,
 	})
 	if err == nil {
 		t.Fatal("expected error for bad repo path, got nil")
@@ -197,7 +211,7 @@ func TestAgentSyncNowNonBlocking(t *testing.T) {
 
 	a, err := New(Config{
 		RepoPath:     repoPath,
-		NATSUpstream:      natsURL,
+		NATSUpstream: natsURL,
 		PollInterval: 10 * time.Second, // long interval so only SyncNow triggers
 	})
 	if err != nil {

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	// joins as a leaf node. Empty means standalone mesh (no upstream).
 	NATSUpstream string
 
+	// NATSClientPort is the local embedded NATS client listener port. Zero
+	// lets NATS choose a random localhost port.
+	NATSClientPort int
+
 	// NATSRole determines how the embedded NATS server participates in the
 	// mesh (peer, hub, or leaf). Default: peer.
 	NATSRole NATSRole
@@ -181,6 +185,9 @@ func (c *Config) validate() error {
 		// valid
 	default:
 		return fmt.Errorf("agent: config: invalid NATSRole %q (must be peer, hub, or leaf)", c.NATSRole)
+	}
+	if c.NATSClientPort < 0 || c.NATSClientPort > 65535 {
+		return fmt.Errorf("agent: config: NATSClientPort %d out of range", c.NATSClientPort)
 	}
 	return nil
 }

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -38,9 +38,10 @@ type SidecarInfo struct {
 // to tell the sidecar where NATS will listen, establishes tunnels to get
 // remote ports, then starts NATS with all ports configured.
 type NATSMesh struct {
-	role      NATSRole
-	upstream  string   // optional external NATS URL
-	irohPeers []string // remote EndpointIds
+	role       NATSRole
+	upstream   string   // optional external NATS URL
+	irohPeers  []string // remote EndpointIds
+	clientPort int      // optional fixed client port; 0 means random
 
 	// Set internally during Start.
 	reservedLeafPort int
@@ -192,6 +193,9 @@ func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 		Port:   -1, // random client port
 		NoLog:  true,
 		NoSigs: true,
+	}
+	if m.clientPort > 0 {
+		opts.Port = m.clientPort
 	}
 
 	switch m.role {

--- a/leaf/agent/nats_mesh_test.go
+++ b/leaf/agent/nats_mesh_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -30,6 +32,40 @@ func TestNATSMeshStartStop(t *testing.T) {
 	}
 	nc.Flush()
 	t.Logf("mesh started at %s, publish OK", clientURL)
+}
+
+func TestNATSMeshUsesConfiguredClientPort(t *testing.T) {
+	port := freeTCPPort(t)
+	mesh := &NATSMesh{
+		role:       NATSRolePeer,
+		clientPort: port,
+	}
+	clientURL, err := mesh.Start(nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mesh.Stop()
+
+	want := fmt.Sprintf("nats://127.0.0.1:%d", port)
+	if clientURL != want {
+		t.Fatalf("clientURL = %q, want %q", clientURL, want)
+	}
+
+	nc, err := nats.Connect(clientURL, nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	nc.Close()
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
 }
 
 func TestNATSMeshRoleConfig(t *testing.T) {

--- a/leaf/cmd/leaf/main.go
+++ b/leaf/cmd/leaf/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -23,6 +24,7 @@ var version = "dev"
 func main() {
 	repoPath := flag.String("repo", envOrDefault("LEAF_REPO", ""), "path to Fossil repository file (required)")
 	natsURL := flag.String("nats", envOrDefault("LEAF_NATS_URL", "nats://localhost:4222"), "NATS server URL")
+	natsClientPort := flag.Int("nats-client-port", envInt("LEAF_NATS_CLIENT_PORT", 0), "embedded NATS client listener port (0 means random)")
 	poll := flag.Duration("poll", 5*time.Second, "poll interval")
 	user := flag.String("user", envOrDefault("LEAF_USER", ""), "Fossil user name")
 	password := flag.String("password", envOrDefault("LEAF_PASSWORD", ""), "Fossil user password")
@@ -90,7 +92,8 @@ func main() {
 
 	cfg := agent.Config{
 		RepoPath:         *repoPath,
-		NATSUpstream:          *natsURL,
+		NATSUpstream:     *natsURL,
+		NATSClientPort:   *natsClientPort,
 		PollInterval:     *poll,
 		User:             *user,
 		Password:         *password,
@@ -199,6 +202,18 @@ func envBool(key string) bool {
 		return true
 	}
 	return false
+}
+
+func envInt(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return i
 }
 
 // stringSlice implements flag.Value for repeatable string flags.


### PR DESCRIPTION
## Summary
- add `NATSClientPort` to the leaf agent config and NATSMesh server options
- expose `--nats-client-port` / `LEAF_NATS_CLIENT_PORT` on the leaf CLI
- document the new flag and add regression coverage for fixed client ports

## Verification
- `go test ./...` from `leaf/`
- `make test`