### PR TITLE
leaf: enable JetStream in embedded NATS + fix OTLP URL/slog tee

### DIFF
--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -110,6 +110,7 @@ func New(cfg Config) (*Agent, error) {
 		upstream:   cfg.NATSUpstream,
 		irohPeers:  cfg.IrohPeers,
 		clientPort: cfg.NATSClientPort,
+		storeDir:   cfg.NATSStoreDir,
 	}
 
 	a := &Agent{

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -36,6 +36,12 @@ type Config struct {
 	// lets NATS choose a random localhost port.
 	NATSClientPort int
 
+	// NATSStoreDir is where JetStream persists streams and KV buckets.
+	// Empty falls back to "<cwd>/.nats-store". Callers that want isolated
+	// per-workspace state should pass an absolute path under the workspace
+	// (e.g. "<workspace>/.agent-infra/nats-store").
+	NATSStoreDir string
+
 	// NATSRole determines how the embedded NATS server participates in the
 	// mesh (peer, hub, or leaf). Default: peer.
 	NATSRole NATSRole

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	natsserver "github.com/nats-io/nats-server/v2/server"
@@ -42,6 +44,7 @@ type NATSMesh struct {
 	upstream   string   // optional external NATS URL
 	irohPeers  []string // remote EndpointIds
 	clientPort int      // optional fixed client port; 0 means random
+	storeDir   string   // JetStream on-disk store dir; empty falls back to ./.nats-store under CWD
 
 	// Set internally during Start.
 	reservedLeafPort int
@@ -193,6 +196,10 @@ func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 		Port:   -1, // random client port
 		NoLog:  true,
 		NoSigs: true,
+		// JetStream is always on so callers (notably agent-infra's task KV)
+		// can open streams and KV buckets without extra handshaking.
+		JetStream: true,
+		StoreDir:  jetStreamStoreDir(m.storeDir),
 	}
 	if m.clientPort > 0 {
 		opts.Port = m.clientPort
@@ -233,6 +240,22 @@ func (m *NATSMesh) buildServerOpts() *natsserver.Options {
 	}
 
 	return opts
+}
+
+// jetStreamStoreDir resolves the on-disk path where JetStream will persist
+// streams and KV buckets. When configured is non-empty it is used verbatim.
+// Otherwise we fall back to "<cwd>/.nats-store" — intentionally not /tmp,
+// since stale JetStream state from a prior run in /tmp would silently
+// corrupt a later workspace that reused the same bucket names.
+func jetStreamStoreDir(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	return filepath.Join(cwd, ".nats-store")
 }
 
 // shouldSolicit determines whether we should initiate a NATS tunnel to a peer.

--- a/leaf/agent/nats_mesh_test.go
+++ b/leaf/agent/nats_mesh_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,6 +67,73 @@ func freeTCPPort(t *testing.T) int {
 	}
 	defer ln.Close()
 	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func TestNATSMeshJetStreamEnabled(t *testing.T) {
+	storeDir := t.TempDir()
+	mesh := &NATSMesh{
+		role:     NATSRolePeer,
+		storeDir: storeDir,
+	}
+	opts := mesh.buildServerOpts()
+
+	if !opts.JetStream {
+		t.Errorf("opts.JetStream = false, want true")
+	}
+	if opts.StoreDir != storeDir {
+		t.Errorf("opts.StoreDir = %q, want %q", opts.StoreDir, storeDir)
+	}
+	if opts.JetStreamDomain != "" {
+		t.Errorf("opts.JetStreamDomain = %q, want empty", opts.JetStreamDomain)
+	}
+}
+
+func TestNATSMeshJetStreamRequiresStoreDir(t *testing.T) {
+	// When storeDir is empty, buildServerOpts should still enable JetStream
+	// but point it at a sensible fallback beneath the CWD so the caller
+	// doesn't accidentally share state with other workspaces via /tmp.
+	mesh := &NATSMesh{role: NATSRolePeer}
+	opts := mesh.buildServerOpts()
+
+	if !opts.JetStream {
+		t.Errorf("opts.JetStream = false, want true (always on)")
+	}
+	if opts.StoreDir == "" {
+		t.Errorf("opts.StoreDir is empty; want a non-empty fallback path")
+	}
+	if strings.HasPrefix(opts.StoreDir, "/tmp") || strings.HasPrefix(opts.StoreDir, "/var/folders") {
+		// Fallback should not live in a shared tmp dir that could collide
+		// with other workspaces or leave stale state behind.
+		t.Errorf("opts.StoreDir = %q; fallback must not live under /tmp or /var/folders", opts.StoreDir)
+	}
+}
+
+func TestNATSMeshJetStreamStartStop(t *testing.T) {
+	storeDir := t.TempDir()
+	mesh := &NATSMesh{
+		role:     NATSRolePeer,
+		storeDir: storeDir,
+	}
+	clientURL, err := mesh.Start(nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mesh.Stop()
+
+	nc, err := nats.Connect(clientURL, nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	// Confirm JetStream is actually reachable by creating a KV bucket.
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("JetStream: %v", err)
+	}
+	if _, err := js.CreateKeyValue(&nats.KeyValueConfig{Bucket: "smoke"}); err != nil {
+		t.Fatalf("CreateKeyValue: %v", err)
+	}
 }
 
 func TestNATSMeshRoleConfig(t *testing.T) {

--- a/leaf/cmd/leaf/main.go
+++ b/leaf/cmd/leaf/main.go
@@ -25,6 +25,7 @@ func main() {
 	repoPath := flag.String("repo", envOrDefault("LEAF_REPO", ""), "path to Fossil repository file (required)")
 	natsURL := flag.String("nats", envOrDefault("LEAF_NATS_URL", "nats://localhost:4222"), "NATS server URL")
 	natsClientPort := flag.Int("nats-client-port", envInt("LEAF_NATS_CLIENT_PORT", 0), "embedded NATS client listener port (0 means random)")
+	natsStoreDir := flag.String("nats-store-dir", envOrDefault("LEAF_NATS_STORE_DIR", ""), "JetStream on-disk store directory (default <cwd>/.nats-store)")
 	poll := flag.Duration("poll", 5*time.Second, "poll interval")
 	user := flag.String("user", envOrDefault("LEAF_USER", ""), "Fossil user name")
 	password := flag.String("password", envOrDefault("LEAF_PASSWORD", ""), "Fossil user password")
@@ -94,6 +95,7 @@ func main() {
 		RepoPath:         *repoPath,
 		NATSUpstream:     *natsURL,
 		NATSClientPort:   *natsClientPort,
+		NATSStoreDir:     *natsStoreDir,
 		PollInterval:     *poll,
 		User:             *user,
 		Password:         *password,

--- a/leaf/telemetry/setup.go
+++ b/leaf/telemetry/setup.go
@@ -6,7 +6,10 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
+	"os"
+	"strings"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel"
@@ -27,6 +30,19 @@ type TelemetryConfig struct {
 	ServiceName string
 	Endpoint    string
 	Headers     map[string]string
+}
+
+// stderrSink is the io.Writer used for the stderr leg of the tee'd slog
+// handler installed by Setup. It is a package-level var so tests can
+// substitute a buffer via setStderrSinkForTest.
+var stderrSink io.Writer = os.Stderr
+
+// setStderrSinkForTest swaps stderrSink and returns a restore function.
+// Only used from tests.
+func setStderrSinkForTest(w io.Writer) func() {
+	prev := stderrSink
+	stderrSink = w
+	return func() { stderrSink = prev }
 }
 
 // Setup initializes the OTel SDK (traces, metrics, logs) and configures
@@ -53,7 +69,7 @@ func Setup(ctx context.Context, cfg TelemetryConfig) (shutdown func(context.Cont
 	// Trace provider
 	traceOpts := []otlptracehttp.Option{}
 	if cfg.Endpoint != "" {
-		traceOpts = append(traceOpts, otlptracehttp.WithEndpoint(cfg.Endpoint))
+		traceOpts = append(traceOpts, traceEndpointOpt(cfg.Endpoint))
 	}
 	if len(cfg.Headers) > 0 {
 		traceOpts = append(traceOpts, otlptracehttp.WithHeaders(cfg.Headers))
@@ -72,7 +88,7 @@ func Setup(ctx context.Context, cfg TelemetryConfig) (shutdown func(context.Cont
 	// Metric provider
 	metricOpts := []otlpmetrichttp.Option{}
 	if cfg.Endpoint != "" {
-		metricOpts = append(metricOpts, otlpmetrichttp.WithEndpoint(cfg.Endpoint))
+		metricOpts = append(metricOpts, metricEndpointOpt(cfg.Endpoint))
 	}
 	if len(cfg.Headers) > 0 {
 		metricOpts = append(metricOpts, otlpmetrichttp.WithHeaders(cfg.Headers))
@@ -91,7 +107,7 @@ func Setup(ctx context.Context, cfg TelemetryConfig) (shutdown func(context.Cont
 	// Log provider + slog bridge
 	logOpts := []otlploghttp.Option{}
 	if cfg.Endpoint != "" {
-		logOpts = append(logOpts, otlploghttp.WithEndpoint(cfg.Endpoint))
+		logOpts = append(logOpts, logEndpointOpt(cfg.Endpoint))
 	}
 	if len(cfg.Headers) > 0 {
 		logOpts = append(logOpts, otlploghttp.WithHeaders(cfg.Headers))
@@ -107,8 +123,12 @@ func Setup(ctx context.Context, cfg TelemetryConfig) (shutdown func(context.Cont
 	global.SetLoggerProvider(lp)
 	shutdowns = append(shutdowns, lp.Shutdown)
 
-	logger := otelslog.NewLogger("edgesync-leaf")
-	slog.SetDefault(logger)
+	// Tee slog between stderr (always visible) and the OTel log bridge.
+	// Without the stderr leg, if the collector is unreachable or the batcher
+	// drops, slog.Error lines disappear and failures become invisible.
+	stderrH := slog.NewTextHandler(stderrSink, nil)
+	otelH := otelslog.NewHandler("edgesync-leaf", otelslog.WithLoggerProvider(lp))
+	slog.SetDefault(slog.New(teeHandler{primary: stderrH, secondary: otelH}))
 
 	return func(ctx context.Context) error {
 		var errs []error
@@ -119,4 +139,68 @@ func Setup(ctx context.Context, cfg TelemetryConfig) (shutdown func(context.Cont
 		}
 		return errors.Join(errs...)
 	}, nil
+}
+
+// hasScheme reports whether endpoint begins with "http://" or "https://".
+// The OTLP *HTTP exporters' WithEndpoint expects a bare host:port; a full
+// URL must go through WithEndpointURL instead.
+func hasScheme(endpoint string) bool {
+	return strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")
+}
+
+func traceEndpointOpt(endpoint string) otlptracehttp.Option {
+	if hasScheme(endpoint) {
+		return otlptracehttp.WithEndpointURL(endpoint)
+	}
+	return otlptracehttp.WithEndpoint(endpoint)
+}
+
+func metricEndpointOpt(endpoint string) otlpmetrichttp.Option {
+	if hasScheme(endpoint) {
+		return otlpmetrichttp.WithEndpointURL(endpoint)
+	}
+	return otlpmetrichttp.WithEndpoint(endpoint)
+}
+
+func logEndpointOpt(endpoint string) otlploghttp.Option {
+	if hasScheme(endpoint) {
+		return otlploghttp.WithEndpointURL(endpoint)
+	}
+	return otlploghttp.WithEndpoint(endpoint)
+}
+
+// teeHandler fans a single slog.Record out to two underlying handlers.
+// Used by Setup to keep stderr visibility while also feeding the OTel
+// log pipeline.
+type teeHandler struct {
+	primary   slog.Handler
+	secondary slog.Handler
+}
+
+func (h teeHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.primary.Enabled(ctx, l) || h.secondary.Enabled(ctx, l)
+}
+
+func (h teeHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Handlers mutate records internally, so hand each its own copy.
+	var errs []error
+	if h.primary.Enabled(ctx, r.Level) {
+		if err := h.primary.Handle(ctx, r.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if h.secondary.Enabled(ctx, r.Level) {
+		if err := h.secondary.Handle(ctx, r.Clone()); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (h teeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return teeHandler{primary: h.primary.WithAttrs(attrs), secondary: h.secondary.WithAttrs(attrs)}
+}
+
+func (h teeHandler) WithGroup(name string) slog.Handler {
+	return teeHandler{primary: h.primary.WithGroup(name), secondary: h.secondary.WithGroup(name)}
 }

--- a/leaf/telemetry/setup_test.go
+++ b/leaf/telemetry/setup_test.go
@@ -1,0 +1,154 @@
+//go:build !wasip1 && !js
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestSetup_EndpointWithScheme verifies Setup accepts an endpoint with an
+// http:// scheme without producing a "double http" URL parse error.
+func TestSetup_EndpointWithScheme(t *testing.T) {
+	ctx := context.Background()
+	cfg := TelemetryConfig{
+		ServiceName: "test-leaf",
+		Endpoint:    "http://signoz.example.com:4317",
+	}
+	shutdown, err := Setup(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Setup with http:// scheme returned error: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatalf("Setup returned nil shutdown fn")
+	}
+	// Shutdown immediately; exporters shouldn't dial on construction.
+	_ = shutdown(ctx)
+}
+
+// TestSetup_EndpointWithHTTPSScheme verifies https:// is handled symmetrically.
+func TestSetup_EndpointWithHTTPSScheme(t *testing.T) {
+	ctx := context.Background()
+	cfg := TelemetryConfig{
+		ServiceName: "test-leaf",
+		Endpoint:    "https://otel.example.com:4318",
+	}
+	shutdown, err := Setup(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Setup with https:// scheme returned error: %v", err)
+	}
+	_ = shutdown(ctx)
+}
+
+// TestSetup_EndpointHostPort verifies bare host:port still works
+// (the existing behavior pre-fix).
+func TestSetup_EndpointHostPort(t *testing.T) {
+	ctx := context.Background()
+	cfg := TelemetryConfig{
+		ServiceName: "test-leaf",
+		Endpoint:    "signoz.example.com:4317",
+	}
+	shutdown, err := Setup(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Setup with bare host:port returned error: %v", err)
+	}
+	_ = shutdown(ctx)
+}
+
+// TestSetup_EmptyEndpoint verifies an empty endpoint still falls back to
+// default/env handling without error.
+func TestSetup_EmptyEndpoint(t *testing.T) {
+	ctx := context.Background()
+	cfg := TelemetryConfig{
+		ServiceName: "test-leaf",
+		Endpoint:    "",
+	}
+	shutdown, err := Setup(ctx, cfg)
+	if err != nil {
+		t.Fatalf("Setup with empty endpoint returned error: %v", err)
+	}
+	_ = shutdown(ctx)
+}
+
+// TestTeeHandler_WritesToBothSinks verifies a record routed through teeHandler
+// reaches both attached handlers.
+func TestTeeHandler_WritesToBothSinks(t *testing.T) {
+	var aBuf, bBuf bytes.Buffer
+	a := slog.NewTextHandler(&aBuf, nil)
+	b := slog.NewTextHandler(&bBuf, nil)
+	h := teeHandler{primary: a, secondary: b}
+
+	logger := slog.New(h)
+	logger.Error("hello-tee", "k", "v")
+
+	if !strings.Contains(aBuf.String(), "hello-tee") {
+		t.Errorf("primary handler did not receive record: %q", aBuf.String())
+	}
+	if !strings.Contains(bBuf.String(), "hello-tee") {
+		t.Errorf("secondary handler did not receive record: %q", bBuf.String())
+	}
+	if !strings.Contains(aBuf.String(), "k=v") || !strings.Contains(bBuf.String(), "k=v") {
+		t.Errorf("attribute missing: primary=%q secondary=%q", aBuf.String(), bBuf.String())
+	}
+}
+
+// TestTeeHandler_WithAttrsAndGroup verifies WithAttrs/WithGroup propagate to
+// both underlying handlers.
+func TestTeeHandler_WithAttrsAndGroup(t *testing.T) {
+	var aBuf, bBuf bytes.Buffer
+	a := slog.NewTextHandler(&aBuf, nil)
+	b := slog.NewTextHandler(&bBuf, nil)
+	h := teeHandler{primary: a, secondary: b}
+
+	logger := slog.New(h).With("component", "leaf").WithGroup("sub")
+	logger.Info("grouped-msg", "x", 1)
+
+	for name, buf := range map[string]*bytes.Buffer{"primary": &aBuf, "secondary": &bBuf} {
+		s := buf.String()
+		if !strings.Contains(s, "grouped-msg") {
+			t.Errorf("%s: missing message: %q", name, s)
+		}
+		if !strings.Contains(s, "component=leaf") {
+			t.Errorf("%s: missing WithAttrs attr: %q", name, s)
+		}
+		if !strings.Contains(s, "sub.x=1") {
+			t.Errorf("%s: missing grouped attr: %q", name, s)
+		}
+	}
+}
+
+// TestSetup_DefaultLoggerWritesToStderr verifies that after Setup, the default
+// slog logger writes to the supplied stderr sink (so errors don't vanish into
+// the OTel void when the collector is unreachable).
+//
+// We inject the stderr sink via a package-level var hook to avoid having to
+// manipulate os.Stderr in tests.
+func TestSetup_DefaultLoggerWritesToStderr(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setStderrSinkForTest(&buf)
+	defer restore()
+
+	// Save & restore the real default logger so we don't pollute other tests.
+	prev := slog.Default()
+	defer slog.SetDefault(prev)
+
+	ctx := context.Background()
+	shutdown, err := Setup(ctx, TelemetryConfig{ServiceName: "test-leaf"})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	defer func() { _ = shutdown(ctx) }()
+
+	slog.Error("stderr-visible-error", "reason", "boom")
+
+	got := buf.String()
+	if !strings.Contains(got, "stderr-visible-error") {
+		t.Errorf("stderr sink did not receive slog.Error: %q", got)
+	}
+	if !strings.Contains(got, "reason=boom") {
+		t.Errorf("stderr sink missing attribute: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two changes to the leaf daemon, both discovered while wiring up `agent-infra/cmd/agent-tasks` integration tests against a real leaf.

- **JetStream on by default** ([e4776ef](https://github.com/danmestas/edgesync/commit/e4776ef913c6e663e9fb207d40246ef6ecd1d5b8)): embedded nats-server now sets `opts.JetStream=true` and threads a new `-nats-store-dir` flag through to `opts.StoreDir`. Without this, `js.CreateOrUpdateKeyValue` fails with `code=503 err_code=10076 jetstream not enabled`, and any caller that wants a KV bucket (tasks, presence, etc.) is dead on arrival. Unblocks `agent-infra-9z0`.
- **OTLP URL + stderr tee** ([a310daf](https://github.com/danmestas/edgesync/commit/a310daf5d41364c3c833f43b4db28efab916afd0)): two pre-existing telemetry bugs in `leaf/telemetry/setup.go`:
  1. `otlp*http.WithEndpoint` expects `host:port`, not a URL. When `OTEL_EXPORTER_OTLP_ENDPOINT` is a full URL the exporter double-prepends `http://` and construction fails. Now detects a leading scheme and routes through `WithEndpointURL`; applied symmetrically to trace/metric/log exporters.
  2. `slog.SetDefault(otelslog)` replaced the default handler with the OTel bridge only, so when the collector is down `slog.Error` lines leading to `os.Exit(1)` vanished. Introduces a tiny `teeHandler` fan-out to stderr `TextHandler` + `otelslog` so operators and test harnesses always see records.

## Test plan

- [x] Unit tests for URL-with-scheme / bare host:port / empty endpoint and tee Enabled/Handle/WithAttrs/WithGroup
- [x] `go test ./... -race` green
- [x] Smoke: leaf starts and `/healthz` returns 200 with `OTEL_EXPORTER_OTLP_ENDPOINT=http://signoz.inputwizard.com:4317` (unreachable) and with it unset
- [x] End-to-end: `agent-infra/cmd/agent-tasks` integration suite (25 subtests) green against a leaf built from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)