### PR TITLE
docs: update README module paths to github.com/danmestas/EdgeSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ docs/                  Documentation
 
 | Module | Path | Purpose |
 |--------|------|---------|
-| `github.com/dmestas/edgesync` | `.` | Root: CLI, sim/, soak runner |
-| `github.com/danmestas/libfossil` | `libfossil/` | Core library (public, v0.1.x) |
-| `github.com/dmestas/edgesync/leaf` | `leaf/` | Leaf agent |
-| `github.com/dmestas/edgesync/bridge` | `bridge/` | Bridge |
-| `github.com/dmestas/edgesync/dst` | `dst/` | Deterministic sim tests |
+| `github.com/danmestas/EdgeSync` | `.` | Root: CLI, sim/, soak runner |
+| `github.com/danmestas/libfossil` | `libfossil/` | Core library (public, v0.3.x) |
+| `github.com/danmestas/EdgeSync/leaf` | `leaf/` | Leaf agent |
+| `github.com/danmestas/EdgeSync/bridge` | `bridge/` | Bridge |
+| `github.com/danmestas/EdgeSync/dst` | `dst/` | Deterministic sim tests |
 
 ## SQLite Drivers
 


### PR DESCRIPTION
## Summary
- Update Go Modules table in README to use `github.com/danmestas/EdgeSync` (matching the renamed module path from 34c4b67)
- Bump documented libfossil version from v0.1.x → v0.3.x to match what agent-infra currently pins

## Test plan
- [x] `grep -r "github.com/dmestas/edgesync" README.md` returns no matches
- [x] Module paths in README table match actual go.mod declarations
- [ ] Reviewer confirms v0.3.x is correct for libfossil (vs the prior v0.1.x doc claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)