### PR TITLE
deps: bump rustls-webpki 0.103.10 → 0.103.13 (fix 2 low CVEs)

### DIFF
--- a/iroh-sidecar/Cargo.lock
+++ b/iroh-sidecar/Cargo.lock
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps transitive `rustls-webpki` (via `reqwest` in iroh-sidecar) from 0.103.10 → 0.103.13
- Resolves Dependabot alerts #36 (GHSA-xgp8-3hg3-c2mh — wildcard DNS name-constraint) and #37 (GHSA-965h-392x-2mh5 — URI name constraint)
- Both CVEs are low severity (CVSS 2.2); reachable only after cert misissuance post signature verification

## Test plan
- [x] `cargo update -p rustls-webpki` bumped the lock to 0.103.13
- [x] `cargo check` in iroh-sidecar passes
- [ ] CI builds pass
- [ ] Dependabot alerts auto-close once merged to default branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)