### PR TITLE
agent: expose mesh ClientURL and LeafAddr via Agent accessors

### DIFF
--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -502,6 +502,30 @@ func (a *Agent) IrohEndpointID() string { return a.irohEndpointID }
 // IrohSocketPath returns the Unix socket path for the iroh sidecar, or "" if iroh is not enabled.
 func (a *Agent) IrohSocketPath() string { return a.irohSock }
 
+// MeshClientURL returns the NATS client URL the agent's embedded mesh
+// server accepts client connections on. Empty when the agent has not
+// run Start, or was constructed via NewFromParts (no mesh). Callers
+// publish to this URL when they want to share the agent's NATS bus
+// (e.g. for orchestration messages distinct from sync traffic).
+func (a *Agent) MeshClientURL() string {
+	if a.mesh == nil {
+		return ""
+	}
+	return a.mesh.ClientURL()
+}
+
+// MeshLeafAddr returns the leaf-node listen address (host:port) where
+// other agents' meshes can solicit upstream. Empty for NATSRoleLeaf
+// agents (which never accept) and when the agent was constructed via
+// NewFromParts. Callers pass this address as NATSUpstream when wiring
+// remote agents into this agent's mesh.
+func (a *Agent) MeshLeafAddr() string {
+	if a.mesh == nil {
+		return ""
+	}
+	return a.mesh.LeafAddr()
+}
+
 // SyncNow triggers an immediate sync round. It is non-blocking: if a sync
 // trigger is already pending, the call is a no-op.
 func (a *Agent) SyncNow() {

--- a/leaf/agent/agent_test.go
+++ b/leaf/agent/agent_test.go
@@ -192,6 +192,33 @@ func TestAgentStartAndStop(t *testing.T) {
 	}
 }
 
+// TestAgentMeshURLs_AfterStart locks in that MeshClientURL and
+// MeshLeafAddr return non-empty values for a peer-role agent after
+// Start. Callers (e.g. orchestrators that want to expose the agent's
+// NATS to remote agents) depend on this contract.
+func TestAgentMeshURLs_AfterStart(t *testing.T) {
+	repoPath := createTestRepo(t)
+
+	a, err := New(Config{
+		RepoPath:     repoPath,
+		PollInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := a.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer a.Stop()
+
+	if got := a.MeshClientURL(); got == "" {
+		t.Error("MeshClientURL after Start: empty")
+	}
+	if got := a.MeshLeafAddr(); got == "" {
+		t.Error("MeshLeafAddr after Start (peer role): empty")
+	}
+}
+
 func TestAgentNewBadRepoPath(t *testing.T) {
 	natsURL := startEmbeddedNATS(t)
 

--- a/leaf/agent/nats_mesh.go
+++ b/leaf/agent/nats_mesh.go
@@ -65,6 +65,15 @@ func (m *NATSMesh) LeafAddr() string {
 	return m.leafAddr
 }
 
+// ClientURL returns the NATS client URL the embedded server accepts
+// connections on. Empty until Start has run. Useful for callers that want
+// to publish to the mesh from external goroutines or expose this URL as
+// the upstream for other agents' meshes (via NATSUpstream / leaf-node
+// solicit).
+func (m *NATSMesh) ClientURL() string {
+	return m.clientURL
+}
+
 // ReserveLeafPort pre-allocates an ephemeral TCP port for the NATS leaf node
 // listener. The sidecar needs this address at launch (--nats-addr), which
 // happens before Start. The listener is closed immediately — NATS rebinds it.

--- a/leaf/agent/nats_mesh_test.go
+++ b/leaf/agent/nats_mesh_test.go
@@ -35,6 +35,32 @@ func TestNATSMeshStartStop(t *testing.T) {
 	t.Logf("mesh started at %s, publish OK", clientURL)
 }
 
+// TestNATSMeshClientURL_AccessorMatches verifies the public ClientURL
+// accessor returns the same value Start returned. Callers reach the
+// accessor when they hold the *NATSMesh after Start; without it the
+// URL is unrecoverable.
+func TestNATSMeshClientURL_AccessorMatches(t *testing.T) {
+	mesh := &NATSMesh{role: NATSRolePeer}
+	startURL, err := mesh.Start(nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mesh.Stop()
+	if got := mesh.ClientURL(); got != startURL {
+		t.Fatalf("ClientURL: got %q want %q", got, startURL)
+	}
+}
+
+// TestNATSMeshClientURL_BeforeStartIsEmpty locks in that ClientURL
+// returns empty before Start runs. Callers can use this to gate work
+// that depends on the mesh being up.
+func TestNATSMeshClientURL_BeforeStartIsEmpty(t *testing.T) {
+	mesh := &NATSMesh{role: NATSRolePeer}
+	if got := mesh.ClientURL(); got != "" {
+		t.Fatalf("ClientURL before Start: got %q want empty", got)
+	}
+}
+
 func TestNATSMeshUsesConfiguredClientPort(t *testing.T) {
 	port := freeTCPPort(t)
 	mesh := &NATSMesh{


### PR DESCRIPTION
## Summary

- Add `(*NATSMesh).ClientURL()` public getter for the existing private `clientURL` field.
- Add `(*Agent).MeshClientURL()` and `(*Agent).MeshLeafAddr()` accessors that wrap the mesh getters with a nil-mesh guard (returns empty for agents constructed via `NewFromParts`).

## Why

`NATSMesh.LeafAddr()` was already public but `agent.Agent.mesh` is private — so external callers can't reach the leaf-node URL needed to peer remote agents into this agent's mesh. Same gap for `ClientURL`: the mesh stored it internally but exposed nothing.

The use case is the sibling [agent-infra](https://github.com/danmestas/agent-infra) repo, where the orchestrator's hub agent runs an embedded NATS via leaf.Agent's mesh. With these accessors, the hub agent's mesh becomes THE NATS bus that peer leaves solicit upstream from — eliminating a redundant external NATS server and the two-hop subject-interest propagation chain that was intermittently breaking request/reply sync patterns.

## Test plan

- [x] `go test ./leaf/agent/ -run NATSMesh` passes (new + existing tests)
- [x] `go test ./leaf/agent/ -run AgentMeshURLs` passes
- [x] `make test` green across all modules
- [x] No behavior change for existing callers — accessors are pure additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)