### PR TITLE
docs: Hugo+hextra docs site with Cloudflare Workers deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ docs/site/resources/
 docs/site/.hugo_build.lock
 docs/site/static/llms.txt
 docs/site/static/llms-full.txt
+# Leftover Hugo binary downloaded by build-docs.sh when system hugo isn't on PATH
+/hugo
+/LICENSE
 
 # Wrangler / Node
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,13 @@ go.work.sum
 
 # Temporary clones for development
 .tmp-libfossil/
+
+# Hugo / docs site build artifacts (regenerated on Cloudflare deploy)
+docs/site/public/
+docs/site/resources/
+docs/site/.hugo_build.lock
+docs/site/static/llms.txt
+docs/site/static/llms-full.txt
+
+# Wrangler / Node
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ docs/site/static/llms-full.txt
 
 # Wrangler / Node
 node_modules/
+.wrangler/

--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -1,0 +1,4 @@
+---
+title: EdgeSync
+layout: landing
+---

--- a/docs/site/content/docs/_index.md
+++ b/docs/site/content/docs/_index.md
@@ -1,0 +1,15 @@
+---
+title: Documentation
+cascade:
+  type: docs
+---
+
+EdgeSync is a NATS-native sync engine for [Fossil SCM](https://fossil-scm.org) repositories. Leaf agents exchange blobs and notifications over NATS messaging — with optional bridge mode for talking to unmodified Fossil servers over HTTP.
+
+## What you'll find here
+
+- **[Quickstart](./quickstart)** — install the binary and stand up a two-node mesh in five minutes.
+- **[Concepts](./concepts)** — the leaf agent, bridge, NATS mesh roles, iroh tunneling, and notify messaging.
+- **[Architecture](./architecture)** — how the leaf agent embeds NATS and libfossil, the role-based topology, and the sync wire protocol.
+- **[Deployment](./deployment)** — running EdgeSync on a VPS with Docker Compose, Tailscale, and Cloudflare Tunnel.
+- **[Notify](./notify)** — bidirectional messaging for human-in-the-loop AI workflows: project-scoped subjects, threads, and the conversation model.

--- a/docs/site/content/docs/architecture.md
+++ b/docs/site/content/docs/architecture.md
@@ -1,0 +1,125 @@
+---
+title: Architecture
+weight: 20
+---
+
+<svg viewBox="0 0 640 280" role="img" aria-labelledby="es-arch-title es-arch-desc" preserveAspectRatio="xMidYMid meet" style="display:block;width:100%;height:auto;margin:0 auto 1.5rem;color:currentColor;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;max-width:720px">
+  <title id="es-arch-title">EdgeSync architecture</title>
+  <desc id="es-arch-desc">Apps (cli, daemon, mobile) call the leaf agent, which embeds libfossil and a NATS server. The agent persists to a .fossil SQLite repo and exchanges sync rounds with peer leaves over NATS, optionally tunneled through iroh QUIC, with a bridge translating to HTTP for legacy Fossil servers.</desc>
+  <style>
+    .a-rule { stroke: currentColor; stroke-width: 1; opacity: 0.4; }
+    .a-box  { fill: none; stroke: currentColor; stroke-width: 1; opacity: 0.7; }
+    .a-head { font-size: 11px; letter-spacing: 1.4px; text-transform: uppercase; opacity: 0.65; }
+    .a-item { font-size: 13px; }
+    .a-flow line { stroke: #c63a0f; stroke-width: 1.5; fill: none; }
+    .a-arrow { fill: #c63a0f; }
+    .a-flow-label { font-size: 10px; fill: #c63a0f; letter-spacing: 0.6px; text-transform: uppercase; }
+  </style>
+  <defs>
+    <marker id="es-arch-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="a-arrow" d="M0,0 L10,5 L0,10 Z"/>
+    </marker>
+  </defs>
+  <g class="a-rule">
+    <line x1="40" y1="38" x2="160" y2="38"/>
+    <line x1="240" y1="38" x2="400" y2="38"/>
+    <line x1="480" y1="38" x2="600" y2="38"/>
+  </g>
+  <g class="a-head" fill="currentColor">
+    <text x="100" y="28" text-anchor="middle">apps</text>
+    <text x="320" y="28" text-anchor="middle">leaf agent</text>
+    <text x="540" y="28" text-anchor="middle">mesh</text>
+  </g>
+  <g class="a-item" fill="currentColor">
+    <text x="100" y="76" text-anchor="middle">cli</text>
+    <text x="100" y="100" text-anchor="middle">daemon</text>
+    <text x="100" y="124" text-anchor="middle">mobile</text>
+  </g>
+  <rect class="a-box" x="240" y="60" width="160" height="100"/>
+  <g class="a-item" fill="currentColor">
+    <text x="320" y="88" text-anchor="middle">libfossil</text>
+    <text x="320" y="112" text-anchor="middle">NATS server</text>
+    <text x="320" y="136" text-anchor="middle">notify</text>
+  </g>
+  <rect class="a-box" x="490" y="60" width="100" height="100"/>
+  <g class="a-item" fill="currentColor">
+    <text x="540" y="88" text-anchor="middle">peer</text>
+    <text x="540" y="112" text-anchor="middle">iroh</text>
+    <text x="540" y="136" text-anchor="middle">bridge</text>
+  </g>
+  <rect class="a-box" x="240" y="200" width="160" height="40"/>
+  <g class="a-item" fill="currentColor">
+    <text x="320" y="225" text-anchor="middle">.fossil (SQLite)</text>
+  </g>
+  <g class="a-flow">
+    <line x1="160" y1="100" x2="234" y2="100" marker-end="url(#es-arch-arrow)"/>
+    <line x1="400" y1="88" x2="486" y2="88" marker-end="url(#es-arch-arrow)"/>
+    <line x1="490" y1="136" x2="404" y2="136" marker-end="url(#es-arch-arrow)"/>
+    <line x1="320" y1="160" x2="320" y2="196" marker-end="url(#es-arch-arrow)"/>
+  </g>
+  <g class="a-flow-label">
+    <text x="197" y="92" text-anchor="middle">calls</text>
+    <text x="443" y="80" text-anchor="middle">sync</text>
+    <text x="447" y="154" text-anchor="middle">events</text>
+    <text x="334" y="183" text-anchor="start">persist</text>
+  </g>
+</svg>
+
+## Overview
+
+EdgeSync is a thin layer on top of [libfossil](https://github.com/danmestas/libfossil) that adds NATS-based sync, an embedded NATS server, optional iroh QUIC tunneling, and a bidirectional messaging channel. The leaf agent is the only required process; the bridge is optional.
+
+## Module layout
+
+EdgeSync is a Go workspace (`go.work`) with four modules:
+
+- **Root (`./`)** — hosts `cmd/edgesync/` (the unified CLI binary), `sim/` (integration simulator with real NATS + TCP fault proxy), and `dst/` shims.
+- **`leaf/`** — the leaf agent. `leaf/agent/` has the daemon (`agent.go`), config (`config.go`), the embedded NATS mesh (`nats_mesh.go`), HTTP serving (`serve_http.go`), and NATS-side sync listener (`serve_nats.go`). `leaf/agent/notify/` is the messaging subsystem.
+- **`bridge/`** — the NATS-to-HTTP translator. `bridge/bridge/` defines `Config`, `New()`, `Start()`, `Stop()`. Used only when interoperating with an unmodified upstream Fossil server.
+- **`dst/`** — deterministic simulation tests. `SimNetwork` (bridge mode), `PeerNetwork` (leaf-to-leaf). Shares `simio/` abstractions with libfossil.
+
+The CLI in `cmd/edgesync/` embeds libfossil's `cli.RepoCmd` (38 Fossil-compatible subcommands) plus EdgeSync-specific commands: `sync start`, `sync now`, `bridge serve`, `notify {init,send,ask,watch,threads,log,status}`, `doctor`.
+
+## Sync wire protocol
+
+EdgeSync reuses Fossil's `/xfer` card protocol verbatim — same blobs, same `igot`/`gimme`/`file`/`cfile` cards, same UV (unversioned) sync. The only thing EdgeSync changes is the *transport*:
+
+| | Upstream Fossil | EdgeSync |
+| --- | --- | --- |
+| Wire format | xfer cards | xfer cards (identical) |
+| Encoding | zlib over POST body | zlib over NATS message payload |
+| Endpoint | `POST /xfer` | NATS subject (request/reply) |
+| Auth | login card | login card (same) |
+| Stateless rounds | yes | yes |
+
+This is why bridge mode works: each side is just `xfer` cards in a different envelope. The bridge re-frames between an HTTP body and a NATS message without re-parsing the cards themselves.
+
+## Embedded NATS server
+
+Every leaf agent runs its own NATS server in-process. The role flag selects topology:
+
+- **`peer`** — full server, accepts and initiates connections to other peers
+- **`hub`** — full server, accepts inbound leaf connections (NATS leafnode protocol)
+- **`leaf`** — outbound only, connects to a hub
+
+This means a developer can run two leaves on `localhost` with no broker installed. In production, one VPS typically runs as `hub` and edge devices run as `leaf`. See the [Browser WASM key findings](https://github.com/danmestas/EdgeSync) for the embedded-server constraints (notably `DontListen` + `nats.InProcessServer` for in-browser leaves).
+
+## Iroh transport
+
+Iroh is opt-in. When `--iroh` is set, the leaf agent:
+
+1. Loads or generates a node key (`--iroh-key`)
+2. Establishes QUIC streams to peers from `--iroh-peer` tickets
+3. Multiplexes NATS leafnode protocol over those streams
+
+This lets two leaves behind separate NATs talk to each other without a relay server's intermediation in steady state (relays are only used for hole-punching).
+
+## Observability
+
+The leaf agent and sim tests emit traces, metrics, and logs via OpenTelemetry. Telemetry is **optional** — when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset, the OTel observer is nil and the no-op observer (zero-cost) is used. Secrets for OTel export are managed via [Doppler](https://doppler.com).
+
+The observer pattern is libfossil's: implement `SyncObserver` and `CheckoutObserver`, hand the implementation to the agent at construction time. EdgeSync's `leaf/telemetry/observer.go` provides an OTel-backed implementation.
+
+## Determinism
+
+The `dst/` module runs many leaf agents under a deterministic event loop with a seeded PRNG and a `simio.SimClock`. `BUGGIFY` (probabilistic fault injection) gates failure paths in production code so the simulator can exercise them without changing the production code path. See [libfossil's testing docs](https://libfossil-docs.daniel-mestas.workers.dev/docs/testing/) for the seed sweep workflow — EdgeSync inherits it directly.

--- a/docs/site/content/docs/concepts.md
+++ b/docs/site/content/docs/concepts.md
@@ -1,0 +1,70 @@
+---
+title: Concepts
+weight: 15
+---
+
+EdgeSync is a small set of orthogonal pieces. Read this once and the rest of the docs will make sense.
+
+## Leaf agent
+
+The **leaf agent** is the only required process. It is a long-running Go daemon that:
+
+1. **Owns a `.fossil` repo** — opens the SQLite database directly via [libfossil](https://github.com/danmestas/libfossil), no `fossil` binary required.
+2. **Embeds a NATS server** — every agent runs its own NATS server in-process, configured per role (peer, hub, leaf). Two agents on the same host can mesh without a separate broker.
+3. **Optionally serves HTTP** — exposes Fossil's `/xfer` protocol on a port so unmodified Fossil clients can clone and pull as if it were a regular Fossil server.
+4. **Optionally serves NATS sync** — listens on a NATS subject for sync requests from other leaves, bypassing HTTP entirely.
+
+The agent runs as a single binary with flags. Configuration lives in CLI flags and environment variables; there is no config file.
+
+## Bridge
+
+The **bridge** is an optional process that translates between NATS messages and HTTP `/xfer` cards. You only need it when one side of a sync is an unmodified Fossil server (the upstream `fossil` binary) that does not speak NATS.
+
+```
+NATS leaf agent ─NATS─► bridge ─HTTP /xfer─► fossil server
+```
+
+Bridge mode is useful for migrations: you can swap one side of a sync to EdgeSync without changing the other.
+
+## NATS mesh roles
+
+When you start a leaf agent you pick a role with `--nats-role`:
+
+- **`peer`** — full NATS server, equal to other peers. Use this for symmetric meshes (laptop ↔ laptop, server ↔ server).
+- **`hub`** — accepts inbound leaf connections. Use this for a central VPS that many edge devices connect to.
+- **`leaf`** — connects outward to a hub via NATS leafnode protocol. Use this for an edge device behind NAT.
+
+You can also point at an external NATS server with `--nats-upstream nats://host:4222` if you already run NATS infrastructure.
+
+## Iroh tunneling
+
+For peers that cannot reach each other over plain TCP (NAT-bound laptops, home networks, mobile devices), EdgeSync can run NATS leafnode connections over [iroh](https://iroh.computer/) QUIC streams.
+
+```sh
+edgesync sync start --iroh --iroh-key node.key --iroh-peer <ticket>
+```
+
+Iroh handles relay-fallback hole-punching automatically. The first time you start with `--iroh`, the agent generates a key and prints a connection ticket; share that ticket with peers.
+
+## Notify
+
+The **notify** subsystem is a separate concern from repo sync. It provides project-scoped messaging primitives for human-in-the-loop AI workflows:
+
+- Messages have a project, thread, optional priority, and optional action button.
+- Storage lives in a dedicated `notify.fossil` repo — independent of your code repos.
+- Wire protocol uses NATS pub-sub on subjects like `notify.<project>.<thread-short>`.
+- A `pair`/`unpair` flow with QR codes lets mobile clients enroll without typing IP:port.
+
+See [Notify](./notify) for the full data model and CLI reference.
+
+## What goes where
+
+| Concern | Lives in |
+| --- | --- |
+| Repo storage and sync logic | [libfossil](https://github.com/danmestas/libfossil) (external dependency) |
+| NATS server + sync glue | `leaf/agent/` |
+| HTTP `/xfer` serving | `leaf/agent/serve_http.go` |
+| NATS↔HTTP translation | `bridge/` |
+| Bidirectional messaging | `leaf/agent/notify/` |
+| Deterministic simulation | `dst/` (sibling module) |
+| CLI binary | `cmd/edgesync/` |

--- a/docs/site/content/docs/deployment.md
+++ b/docs/site/content/docs/deployment.md
@@ -1,0 +1,100 @@
+---
+title: Deployment
+weight: 30
+---
+
+A working production recipe for EdgeSync, derived from the reference deployment at `sync.craftdesign.group`. The shape: one VPS running NATS + a leaf agent, exposed publicly via Cloudflare Tunnel and privately via Tailscale.
+
+## Topology
+
+```
+public internet
+      │
+      ▼ HTTPS
+Cloudflare Tunnel ──► VPS:9000 (leaf HTTP /xfer)
+                         │
+                         ▼
+                  leaf agent ◄────► NATS:4222 (Tailscale-only)
+                         │
+                         ▼
+                   .fossil repo (volume mount)
+
+tailnet ──────────────► VPS:9000 (HTTP)
+                  └───► VPS:4222 (NATS)
+```
+
+## Files
+
+The reference deployment lives in `deploy/`:
+
+```
+deploy/
+├── Dockerfile              # multi-stage Go build, GOWORK=off
+├── docker-compose.yml      # NATS on Tailscale IP, leaf on :9000
+└── data/                   # host volume mount with .fossil files
+```
+
+### Dockerfile
+
+The leaf binary is built standalone (libfossil pulled from the public Go module proxy) so no private-module auth is needed. The build uses `GOWORK=off` because Docker copies only `leaf/`, not the whole workspace.
+
+### docker-compose.yml
+
+Two containers:
+
+- **`nats`** — official `nats:latest` image, bound to the host's Tailscale interface only (`100.78.32.45:4222`)
+- **`leaf`** — built from `Dockerfile`, exposed on `:9000`
+
+Ports `8080` and `8090` are intentionally avoided because they are occupied by Coolify and Caddy on the reference VPS. Adjust as needed.
+
+### Cloudflare Tunnel
+
+```yaml
+# ~/.cloudflared/config.yml on the VPS
+tunnel: <tunnel-id>
+credentials-file: /home/user/.cloudflared/<tunnel-id>.json
+ingress:
+  - hostname: sync.craftdesign.group
+    service: http://localhost:9000
+  - service: http_status:404
+```
+
+Run as a systemd service: `cloudflared-fossil`.
+
+## Update flow
+
+```sh
+# On the VPS
+cd ~/EdgeSync && git pull
+cd deploy && sudo docker compose up -d --build
+```
+
+This rebuilds the leaf container with the latest code and restarts both services. NATS does not need to restart for a leaf upgrade.
+
+## Endpoints
+
+| Endpoint | URL | Access |
+| --- | --- | --- |
+| Public HTTPS | `https://sync.craftdesign.group` | Cloudflare Tunnel (anyone with the URL) |
+| Tailscale HTTP | `http://100.78.32.45:9000` | Tailnet only |
+| Tailscale NATS | `nats://100.78.32.45:4222` | Tailnet only |
+
+## Mobile clients
+
+For Expo / React Native clients (e.g. `edgesync-notify-app`), you'll typically:
+
+1. Run a NATS leafnode on the VPS bound to port `7422` (separate from the regular `4222` so leafnode auth can be scoped)
+2. Open the leafnode port to your tailnet (`ufw route allow ...`)
+3. In the app, configure the NATS leafnode URL and pair via QR (see [Notify](./notify))
+
+## Observability
+
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` and (if exporting to Honeycomb) the API key. EdgeSync uses [Doppler](https://doppler.com) to manage OTel secrets without committing `.env` files:
+
+```sh
+doppler run -- docker compose up -d --build
+```
+
+When the env var is unset the agent runs with a no-op observer — telemetry is zero-cost when not configured.
+
+The reference Honeycomb dashboard ("EdgeSync Sim — Operational Overview") tracks sync latency, convergence, file throughput, and errors across the dataset `edgesync-sim` in the `test` environment.

--- a/docs/site/content/docs/notify.md
+++ b/docs/site/content/docs/notify.md
@@ -1,0 +1,111 @@
+---
+title: Notify
+weight: 40
+---
+
+EdgeSync's notify subsystem is a separate channel for project-scoped, bidirectional messaging. It is designed for human-in-the-loop AI workflows: an agent pings a human, the human replies from a phone, the agent acts on the reply.
+
+## Why a separate channel?
+
+Repo sync moves blobs between agents to converge `.fossil` state. Notify moves *messages* between agents and humans to coordinate work outside the repo. They share infrastructure (the same NATS mesh) but have different lifecycles, retention, and storage.
+
+| | Repo sync | Notify |
+| --- | --- | --- |
+| Subjects | sync request/reply | `notify.<project>.<thread-short>` (pub-sub) |
+| Storage | `*.fossil` (your code repos) | `notify.fossil` (dedicated) |
+| Durability | full repo history | log + thread index |
+| Retention | forever | configurable per-project |
+
+## Data model
+
+Each message has:
+
+- **project** — namespace string (e.g. `edgesync`, `client-x-deploy`)
+- **thread** — opaque short ID; replies share the thread
+- **body** — markdown text
+- **priority** — `low` / `normal` / `high`
+- **action** — optional structured action (button label + payload)
+- **author** — who sent it (agent name or human handle)
+
+A **thread** is the conversational unit. Sending a fresh message creates a new thread; replying targets an existing one.
+
+## CLI
+
+Initialize storage (creates `notify.fossil` if missing):
+
+```sh
+edgesync notify init --project my-project
+```
+
+Send a one-shot notification:
+
+```sh
+edgesync notify send \
+  --project my-project \
+  --priority high \
+  --body "Deploy failed: see logs at /var/log/deploy.log"
+```
+
+Ask a question (waits for a reply):
+
+```sh
+edgesync notify ask \
+  --project my-project \
+  --body "Approve the prod migration?" \
+  --action approve --action reject
+```
+
+Watch incoming messages on a project:
+
+```sh
+edgesync notify watch --project my-project
+```
+
+List threads:
+
+```sh
+edgesync notify threads --project my-project
+```
+
+Read a thread:
+
+```sh
+edgesync notify log --project my-project --thread <id>
+```
+
+Status (subscriber liveness, last activity):
+
+```sh
+edgesync notify status --project my-project
+```
+
+## NATS subjects
+
+Notify uses pub-sub on subjects of the form:
+
+```
+notify.<project>.<thread-short>
+```
+
+`<thread-short>` is the first eight characters of the thread ID, so a wildcard subscribe `notify.my-project.>` catches all threads in a project. Subscribers dedupe on the full message ID.
+
+## Pairing mobile clients
+
+The pairing flow lets a phone enroll with a leaf agent without typing IP:port. On the agent:
+
+```sh
+edgesync pair --project my-project
+```
+
+This prints a QR code (and a fallback URL). The mobile app scans the QR, exchanges a one-time token, and stores a long-lived device record in the agent's device registry. From then on, the device receives notifications for that project over its NATS leafnode connection.
+
+To revoke:
+
+```sh
+edgesync devices --project my-project    # list paired devices
+edgesync unpair --project my-project --device <id>
+```
+
+## Storage
+
+Notify storage is a regular libfossil-managed `.fossil` file at `notify.fossil` (or wherever `--notify-repo` points). It uses Fossil's unversioned-content (UV) tables for the message log and a regular versioned tree for the thread index. This means the existing sync machinery handles notify replication for free — a notify repo can be replicated to other leaves the same way a code repo is.

--- a/docs/site/content/docs/quickstart.md
+++ b/docs/site/content/docs/quickstart.md
@@ -1,0 +1,83 @@
+---
+title: Quickstart
+weight: 10
+---
+
+A five-minute tour of EdgeSync: install the binary, point it at a `.fossil` repo, and stand up a two-node mesh.
+
+## Install
+
+```sh
+go install github.com/danmestas/EdgeSync/cmd/edgesync@latest
+edgesync --help
+```
+
+The binary is pure-Go and CGo-free thanks to the [libfossil](https://github.com/danmestas/libfossil) library underneath — drop it on any Linux/macOS/Windows host with no runtime dependency.
+
+Verify your environment:
+
+```sh
+edgesync doctor
+```
+
+## Create a repository
+
+EdgeSync embeds libfossil's CLI, so the standard repo commands work directly:
+
+```sh
+edgesync new my-project.fossil
+edgesync open my-project.fossil checkout/
+cd checkout/
+echo '# Hello' > README.md
+edgesync ci -m "initial commit"
+```
+
+## Start the leaf agent
+
+The leaf agent is a long-running daemon that watches a repo and syncs it with peers over NATS:
+
+```sh
+edgesync sync start \
+  --repo my-project.fossil \
+  --serve-http :9000 \
+  --poll 5s
+```
+
+What this does:
+
+- Embeds a NATS server inside the agent process
+- Serves the Fossil `/xfer` endpoint on `:9000` so other Fossil clients can clone over HTTP
+- Polls the repo every 5 seconds for local changes to gossip out
+
+## Add a peer over iroh
+
+For NAT-traversing peer-to-peer sync, generate an iroh ticket on one node and pass it to another:
+
+```sh
+# Node A
+edgesync sync start --repo a.fossil --iroh --iroh-key node-a.key
+
+# Node B (paste the ticket from node A's logs)
+edgesync sync start --repo b.fossil --iroh --iroh-peer <ticket-from-a>
+```
+
+The two leaves now exchange blobs over a QUIC tunnel — no port forwarding, no central server.
+
+## Send a notification
+
+EdgeSync ships with a separate notify channel for project-scoped messaging (designed for human-in-the-loop AI workflows):
+
+```sh
+edgesync notify init --project my-project
+edgesync notify send --project my-project --body "deploy succeeded"
+edgesync notify watch --project my-project
+```
+
+See [Notify](./notify) for thread structure, replies, and the pairing flow for mobile clients.
+
+## Next steps
+
+- [Concepts](./concepts) — the moving pieces and how they fit together
+- [Architecture](./architecture) — wire protocol, role topology, and observability
+- [Deployment](./deployment) — Docker Compose recipe for production
+- [Notify](./notify) — bidirectional messaging deep dive

--- a/docs/site/go.mod
+++ b/docs/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/danmestas/EdgeSync/docs/site
+
+go 1.26.2
+
+require github.com/imfing/hextra v0.12.2 // indirect

--- a/docs/site/go.sum
+++ b/docs/site/go.sum
@@ -1,0 +1,2 @@
+github.com/imfing/hextra v0.12.2 h1:qa+cHQ1LC/7ys9EhRNnHrRBAHu83Tm8rhh1oWO2a7cc=
+github.com/imfing/hextra v0.12.2/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -34,6 +34,11 @@ menu:
         icon: github
 
 params:
+  # Default version for local dev. Overwritten at build time by scripts/sync-version.sh
+  # (which reads `git describe --tags --abbrev=0`). Falls back to this value when no
+  # git tag is reachable (e.g. before the first release).
+  version: "0.0.0-dev"
+
   navbar:
     displayTitle: true
     displayLogo: false

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -1,0 +1,61 @@
+title: EdgeSync
+baseURL: "https://edgesync-docs.daniel-mestas.workers.dev/"
+
+module:
+  imports:
+    - path: github.com/imfing/hextra
+
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+  highlight:
+    noClasses: false
+
+menu:
+  main:
+    - name: Docs
+      pageRef: /docs
+      weight: 1
+    - name: Architecture
+      pageRef: /docs/architecture
+      weight: 2
+    - name: Deployment
+      pageRef: /docs/deployment
+      weight: 3
+    - name: Search
+      weight: 4
+      params:
+        type: search
+    - name: GitHub
+      weight: 5
+      url: "https://github.com/danmestas/EdgeSync"
+      params:
+        icon: github
+
+params:
+  navbar:
+    displayTitle: true
+    displayLogo: false
+
+  theme:
+    default: system
+    displayToggle: true
+
+  search:
+    enable: true
+    type: flexsearch
+    flexsearch:
+      index: content
+      tokenize: forward
+
+  footer:
+    displayCopyright: true
+    displayPoweredBy: false
+
+  editURL:
+    enable: true
+    base: "https://github.com/danmestas/EdgeSync/edit/main/docs/site/content"
+
+  page:
+    width: wide

--- a/docs/site/layouts/_partials/navbar-title.html
+++ b/docs/site/layouts/_partials/navbar-title.html
@@ -1,0 +1,13 @@
+{{- /* Project override: keeps Hextra's title + adds a small version tag. */ -}}
+{{- $logoLink := .Site.Params.navbar.logo.link | default .Site.Home.RelPermalink -}}
+{{- $displayTitle := (.Site.Params.navbar.displayTitle | default true) -}}
+{{- $version := .Site.Params.version -}}
+
+<a class="hx:flex hx:items-center hx:hover:opacity-75 hx:ltr:mr-auto hx:rtl:ml-auto" href="{{ $logoLink }}">
+  {{- if $displayTitle }}
+    <span class="hx:mr-2 hx:font-extrabold hx:inline hx:select-none">{{- .Site.Title -}}</span>
+  {{- end }}
+  {{- with $version }}
+    <span class="hx:text-xs hx:font-mono hx:opacity-60 hx:select-none">v{{ . }}</span>
+  {{- end }}
+</a>

--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -389,6 +389,7 @@ footer a { color: inherit; border-bottom-color: var(--mute); }
 <header class="topbar">
   <div class="name">edgesync</div>
   <div class="meta">
+    <span>v <b>{{ .Site.Params.version }}</b></span>
     <span>status <b>alpha</b></span>
     <span><a href="https://github.com/danmestas/EdgeSync">github</a></span>
     <span><a href="/docs/">docs</a></span>
@@ -406,7 +407,7 @@ footer a { color: inherit; border-bottom-color: var(--mute); }
       <tr><td>Language</td>     <td>Go (modules <code>github.com/danmestas/EdgeSync/{leaf,bridge}</code>)</td></tr>
       <tr><td>Built on</td>     <td><a href="https://github.com/danmestas/libfossil">libfossil</a> &middot; <a href="https://nats.io">NATS</a> embedded &middot; <a href="https://iroh.computer">iroh</a> (optional)</td></tr>
       <tr><td>Binaries</td>     <td>3 (edgesync &middot; leaf &middot; bridge)</td></tr>
-      <tr><td>Status</td>       <td>alpha &middot; pre-release &middot; wire protocol stable, CLI may shift</td></tr>
+      <tr><td>Status</td>       <td>v{{ .Site.Params.version }} &middot; alpha &middot; pre-release &middot; wire protocol stable, CLI may shift</td></tr>
     </tbody>
   </table>
 </section>
@@ -571,7 +572,7 @@ $ edgesync notify init --project my-project    # enable messaging</pre>
 </main>
 
 <footer>
-  <div>edgesync &nbsp;&middot;&nbsp; alpha &nbsp;&middot;&nbsp; 2026 &nbsp;&middot;&nbsp; <a href="https://github.com/danmestas/EdgeSync">github.com/danmestas/EdgeSync</a></div>
+  <div>edgesync &nbsp;&middot;&nbsp; v{{ .Site.Params.version }} &nbsp;&middot;&nbsp; alpha &nbsp;&middot;&nbsp; 2026 &nbsp;&middot;&nbsp; <a href="https://github.com/danmestas/EdgeSync">github.com/danmestas/EdgeSync</a></div>
 </footer>
 
 <script>

--- a/docs/site/layouts/index.html
+++ b/docs/site/layouts/index.html
@@ -1,0 +1,608 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="EdgeSync — NATS-native sync engine for Fossil SCM repositories. Mesh topology, optional iroh tunneling, bidirectional messaging built in.">
+<meta name="color-scheme" content="light dark">
+<title>EdgeSync — NATS-native Fossil sync engine</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --paper:  #f5f1e6;
+  --paper-2:#ece7d8;
+  --ink:    #14110b;
+  --mute:   #5e5b53;
+  --rule:   #14110b;
+  --ember:  #c63a0f;
+  --measure: 76ch;
+  --gap:   clamp(2.25rem, 5vw, 3.5rem);
+  --mono: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Consolas, "Courier New", monospace;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 16px; -webkit-text-size-adjust: 100%; }
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font: 400 clamp(15px, 1.05vw, 17px)/1.7 var(--mono);
+  font-feature-settings: "tnum" 1, "calt" 1, "ss01" 1;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+.skip { position: absolute; left: -9999px; }
+.skip:focus {
+  position: fixed; top: 0.75rem; left: 0.75rem;
+  background: var(--ember); color: var(--paper);
+  padding: 0.5rem 0.75rem; z-index: 10; text-decoration: none;
+}
+header.topbar {
+  border-bottom: 1px solid var(--rule);
+  padding: clamp(0.625rem, 2.5vw, 0.75rem) clamp(1rem, 4vw, 1.5rem);
+  display: flex; justify-content: space-between; align-items: baseline;
+  gap: 1rem; flex-wrap: wrap;
+  font-size: 0.78125rem;
+  letter-spacing: 0.04em;
+}
+.topbar a { color: inherit; text-decoration: none; border-bottom: 1px solid currentColor; }
+.topbar a:hover { color: var(--ember); }
+.topbar .name { font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; }
+.topbar .meta { color: var(--mute); display: flex; gap: 1.25rem; flex-wrap: wrap; }
+.topbar .meta span { display: inline-flex; gap: 0.4rem; }
+.topbar .meta b { color: var(--ink); font-weight: 500; }
+
+main {
+  max-width: 88ch;
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1rem, 4vw, 1.5rem) clamp(3rem, 6vw, 4.5rem);
+  overflow-wrap: anywhere;
+}
+
+.title {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  padding-bottom: clamp(2rem, 4vw, 2.75rem);
+  margin-bottom: clamp(2rem, 4vw, 3rem);
+  border-bottom: 1px solid var(--rule);
+}
+.title h1 {
+  font-size: clamp(2.75rem, 13vw, 6.5rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 0.92;
+}
+.title .lead {
+  font-size: clamp(1rem, 1.2vw, 1.0625rem);
+  max-width: var(--measure);
+  color: var(--ink);
+  line-height: 1.6;
+}
+.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78125rem;
+  margin-top: 0.5rem;
+  letter-spacing: 0.02em;
+}
+.spec td { padding: 0.35rem 0; border-top: 1px dashed var(--rule); vertical-align: top; }
+.spec td:first-child {
+  width: 12rem;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.6875rem;
+  padding-top: 0.5rem;
+}
+.spec tr:first-child td { border-top: 1px solid var(--rule); }
+.spec tr:last-child td { border-bottom: 1px solid var(--rule); }
+
+section { margin-top: var(--gap); }
+section > .num {
+  display: block;
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--mute);
+  margin-bottom: 0.4rem;
+}
+h2 {
+  font-size: clamp(1.125rem, 1.6vw, 1.3125rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+h2 .anchor {
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--mute);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+p { max-width: var(--measure); margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+strong { font-weight: 700; }
+
+a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--ink);
+}
+a:hover { color: var(--ember); border-bottom-color: var(--ember); }
+
+code {
+  font: inherit;
+  font-size: 0.94em;
+  background: var(--paper-2);
+  padding: 0.05em 0.35em;
+}
+
+ol, ul { padding-left: 0; max-width: var(--measure); list-style: none; }
+ol li, ul li {
+  margin-bottom: 0.875rem;
+  padding-left: 2.75rem;
+  position: relative;
+  line-height: 1.65;
+}
+ol { counter-reset: item; }
+ol li {
+  counter-increment: item;
+}
+ol li::before {
+  content: counter(item, decimal-leading-zero);
+  position: absolute;
+  left: 0;
+  top: 0.05em;
+  font-weight: 700;
+  font-size: 0.78125rem;
+  letter-spacing: 0.04em;
+  color: var(--ember);
+  width: 2rem;
+}
+ul li::before {
+  content: "—";
+  position: absolute;
+  left: 0.5rem;
+  color: var(--mute);
+}
+
+.code-block {
+  margin-bottom: 1rem;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+.code-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem 0.35rem 0.85rem;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mute);
+}
+pre {
+  padding: 0.875rem 1.25rem;
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+  font-family: var(--mono);
+  color: var(--ink);
+}
+pre.ascii {
+  background: transparent;
+  border: 1px solid var(--rule);
+  padding: clamp(0.75rem, 2.5vw, 1.25rem);
+  font-size: clamp(0.7rem, 1.7vw, 0.8125rem);
+  line-height: 1.45;
+  color: var(--ink);
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+
+.diagram {
+  display: block;
+  width: 100%;
+  min-width: 30rem;
+  height: auto;
+  margin-bottom: 0.5rem;
+  font-family: var(--mono);
+  color: var(--ink);
+}
+.diagram .rule { stroke: var(--rule); stroke-width: 1; opacity: 0.5; }
+.diagram .box { fill: none; stroke: var(--rule); stroke-width: 1; }
+.diagram .head {
+  font-size: 11px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  fill: var(--mute);
+}
+.diagram .item { font-size: 13px; fill: var(--ink); }
+.diagram .stack { font-size: 12px; fill: var(--mute); font-style: italic; }
+.diagram .flow line { stroke: var(--ember); stroke-width: 1.5; fill: none; }
+.diagram .arrowhead { fill: var(--ember); }
+.diagram .flow-label {
+  font-size: 10px;
+  fill: var(--ember);
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+.diagram .peer-dot { fill: var(--ember); opacity: 0.8; }
+.diagram .mesh-link {
+  stroke: var(--ember);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  fill: none;
+  opacity: 0.7;
+}
+
+.copy-btn {
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--ink);
+  font: inherit;
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.55rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.copy-btn:hover, .copy-btn:focus-visible { background: var(--ink); color: var(--paper); outline: none; }
+.copy-btn[data-state="copied"] { color: var(--ember); border-color: var(--ember); background: var(--paper); }
+
+.table-scroll {
+  margin: 0 calc(-1 * clamp(0rem, 2vw, 0.5rem));
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+table.cmp {
+  width: 100%;
+  min-width: 30rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+table.cmp th, table.cmp td {
+  text-align: left;
+  padding: 0.625rem 0.875rem;
+  vertical-align: top;
+  border-bottom: 1px dashed var(--rule);
+}
+table.cmp thead th {
+  border-bottom: 1px solid var(--rule);
+  border-top: 1px solid var(--rule);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  background: var(--paper-2);
+}
+table.cmp td:first-child, table.cmp th:first-child {
+  padding-left: 0.875rem;
+  width: 30%;
+  font-weight: 500;
+  color: var(--mute);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+table.cmp td:last-child, table.cmp th:last-child { padding-right: 0.875rem; }
+table.cmp .col-self { color: var(--ember); font-weight: 700; }
+table.cmp tbody tr:last-child td { border-bottom: 1px solid var(--rule); }
+
+.fineprint {
+  font-size: 0.75rem;
+  color: var(--mute);
+  margin-top: 0.5rem;
+  letter-spacing: 0.02em;
+}
+
+footer {
+  border-top: 1px solid var(--rule);
+  margin-top: var(--gap);
+  padding: 1.5rem 0;
+  font-size: 0.78125rem;
+  color: var(--mute);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  letter-spacing: 0.04em;
+}
+footer a { color: inherit; border-bottom-color: var(--mute); }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper:  #15140f;
+    --paper-2:#1f1d17;
+    --ink:    #ece8dc;
+    --mute:   #908b80;
+    --rule:   #ece8dc;
+    --ember:  #ff5a26;
+  }
+}
+@media print {
+  body { background: white; color: black; font-size: 11pt; line-height: 1.5; }
+  .code-block, pre { background: white; color: black; border: 1px solid black; }
+  a { color: black; border-bottom: 0; text-decoration: underline; }
+  a::after { content: " (" attr(href) ")"; font-size: 0.85em; color: #555; }
+  .copy-btn, .skip { display: none; }
+  section { break-inside: avoid; }
+}
+@media (max-width: 540px) {
+  header.topbar { flex-direction: column; align-items: flex-start; gap: 0.5rem; }
+  .topbar .meta { gap: 0.75rem; row-gap: 0.35rem; }
+  .spec td:first-child { width: 8rem; font-size: 0.625rem; }
+  .spec td { padding: 0.4rem 0; }
+  table.cmp { font-size: 0.6875rem; min-width: 0; table-layout: auto; }
+  table.cmp th, table.cmp td { padding: 0.45rem 0.4rem; }
+  table.cmp tbody td { white-space: normal; word-break: normal; overflow-wrap: break-word; }
+  table.cmp thead th {
+    font-size: 0.5rem;
+    letter-spacing: 0.06em;
+    padding: 0.5rem 0.3rem;
+    white-space: nowrap;
+  }
+  table.cmp td:first-child, table.cmp th:first-child {
+    padding-left: 0.55rem;
+    width: 28%;
+    font-size: 0.5625rem;
+    letter-spacing: 0.04em;
+  }
+  table.cmp td:last-child, table.cmp th:last-child { padding-right: 0.55rem; }
+  ol li, ul li { padding-left: 2.25rem; }
+  ol li::before { width: 1.75rem; }
+  footer { flex-direction: column; gap: 0.5rem; align-items: flex-start; }
+  .copy-btn { font-size: 0.5625rem; padding: 0.1rem 0.4rem; }
+  pre { font-size: 0.78rem; padding: 0.75rem 0.9rem; }
+  .code-bar { padding: 0.3rem 0.4rem 0.3rem 0.7rem; }
+}
+@media (max-width: 380px) {
+  .topbar .name { letter-spacing: 0.12em; }
+  .spec td:first-child { width: 7rem; }
+  table.cmp { font-size: 0.625rem; }
+  table.cmp th, table.cmp td { padding: 0.4rem 0.25rem; }
+  table.cmp thead th { font-size: 0.4375rem; padding: 0.45rem 0.2rem; }
+  table.cmp td:first-child, table.cmp th:first-child { font-size: 0.5rem; padding-left: 0.4rem; width: 26%; }
+}
+</style>
+</head>
+<body>
+
+<a href="#main" class="skip">skip to content</a>
+
+<header class="topbar">
+  <div class="name">edgesync</div>
+  <div class="meta">
+    <span>status <b>alpha</b></span>
+    <span><a href="https://github.com/danmestas/EdgeSync">github</a></span>
+    <span><a href="/docs/">docs</a></span>
+  </div>
+</header>
+
+<main id="main">
+
+<section class="title">
+  <h1>edgesync</h1>
+  <p class="lead">A NATS-native sync engine for Fossil SCM repositories. Mesh topology. Optional iroh tunneling. Bidirectional messaging built in.</p>
+  <table class="spec">
+    <tbody>
+      <tr><td>Project</td>      <td>edgesync &mdash; NATS-native Fossil sync engine</td></tr>
+      <tr><td>Language</td>     <td>Go (modules <code>github.com/danmestas/EdgeSync/{leaf,bridge}</code>)</td></tr>
+      <tr><td>Built on</td>     <td><a href="https://github.com/danmestas/libfossil">libfossil</a> &middot; <a href="https://nats.io">NATS</a> embedded &middot; <a href="https://iroh.computer">iroh</a> (optional)</td></tr>
+      <tr><td>Binaries</td>     <td>3 (edgesync &middot; leaf &middot; bridge)</td></tr>
+      <tr><td>Status</td>       <td>alpha &middot; pre-release &middot; wire protocol stable, CLI may shift</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <span class="num">&sect;01</span>
+  <h2>Install <span class="anchor">install</span></h2>
+  <div class="code-block">
+    <div class="code-bar">
+      <span>shell</span>
+      <button type="button" class="copy-btn" data-copy="install" aria-label="Copy install command">copy</button>
+    </div>
+    <pre id="install">$ go install github.com/danmestas/EdgeSync/cmd/edgesync@latest
+$ edgesync doctor</pre>
+  </div>
+  <p>One static binary, no CGo. The <code>doctor</code> subcommand checks your environment (Go version, SQLite driver, NATS reachability) and prints a clean report.</p>
+</section>
+
+<section>
+  <span class="num">&sect;02</span>
+  <h2>What it is <span class="anchor">overview</span></h2>
+  <p>EdgeSync is a sync engine for <a href="https://fossil-scm.org">Fossil SCM</a> repositories that swaps Fossil's HTTP-based <code>/xfer</code> protocol for NATS messaging. The leaf agent reads and writes <code>.fossil</code> SQLite files via the <a href="https://github.com/danmestas/libfossil">libfossil</a> library, and exchanges blobs with peer agents over an embedded NATS mesh.</p>
+  <p>There is no central server in the default topology &mdash; each agent runs its own NATS server in-process, and gossip happens leaf-to-leaf. An optional <strong>bridge</strong> process translates between NATS and HTTP <code>/xfer</code> for talking to unmodified upstream Fossil servers.</p>
+  <ul>
+    <li><strong>Mesh-first sync.</strong> Every leaf is both client and server. Add a peer with one CLI flag.</li>
+    <li><strong>libfossil under the hood.</strong> <code>.fossil</code> files stay readable by the upstream <code>fossil</code> binary &mdash; nothing proprietary in the storage format.</li>
+    <li><strong>Optional iroh tunneling.</strong> Two leaves behind separate NATs find each other over QUIC. No port forwarding, no relay infrastructure to operate.</li>
+    <li><strong>Notify channel.</strong> A separate, project-scoped pub-sub for human-in-the-loop messaging. Pair a phone with a QR code, get push alerts on commits, deploys, or agent questions.</li>
+  </ul>
+</section>
+
+<section>
+  <span class="num">&sect;03</span>
+  <h2>Why you might want it <span class="anchor">why</span></h2>
+  <p>Three shapes of problem where EdgeSync is the right tool.</p>
+  <p><strong>You're running many small Fossil repos across edge devices.</strong> Robotics fleets, retail kiosks, CDN nodes, on-prem appliances &mdash; anywhere the topology is "many small sites, intermittent connectivity, no central server." EdgeSync's mesh-first design means a new device pairs with one peer and converges with the rest of the fleet from there.</p>
+  <p><strong>You need bidirectional messaging alongside repo sync.</strong> Most version-control stacks bolt chat or notifications on as a separate service. EdgeSync ships <code>notify</code> as a first-class channel using the same NATS mesh: an agent commits and the human's phone gets a push, the human replies and the agent acts on it.</p>
+  <p><strong>You want zero infrastructure.</strong> Embedded NATS server + iroh transport = no broker to operate, no central server to scale, no CDN to point clients at. Two laptops on a coffee-shop wifi can sync to each other directly.</p>
+</section>
+
+<section>
+  <span class="num">&sect;04</span>
+  <h2>How it fits together <span class="anchor">architecture</span></h2>
+  <div class="table-scroll">
+    <svg class="diagram" viewBox="0 0 640 280" role="img" aria-labelledby="es-arch-title es-arch-desc" preserveAspectRatio="xMidYMid meet">
+      <title id="es-arch-title">EdgeSync architecture</title>
+      <desc id="es-arch-desc">Apps (cli, daemon, mobile) call the leaf agent, which embeds libfossil and a NATS server. The agent persists to a .fossil SQLite repo and exchanges sync rounds with peer leaves over NATS, optionally tunneled through iroh QUIC, with a bridge translating to HTTP for legacy Fossil servers.</desc>
+
+      <defs>
+        <marker id="es-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path class="arrowhead" d="M0,0 L10,5 L0,10 Z"/>
+        </marker>
+      </defs>
+
+      <g class="rule">
+        <line x1="40" y1="38" x2="160" y2="38"/>
+        <line x1="240" y1="38" x2="400" y2="38"/>
+        <line x1="480" y1="38" x2="600" y2="38"/>
+      </g>
+
+      <g class="head">
+        <text x="100" y="28" text-anchor="middle">apps</text>
+        <text x="320" y="28" text-anchor="middle">leaf agent</text>
+        <text x="540" y="28" text-anchor="middle">mesh</text>
+      </g>
+
+      <g class="item">
+        <text x="100" y="76" text-anchor="middle">cli</text>
+        <text x="100" y="100" text-anchor="middle">daemon</text>
+        <text x="100" y="124" text-anchor="middle">mobile</text>
+      </g>
+
+      <rect class="box" x="240" y="60" width="160" height="100"/>
+      <g class="item">
+        <text x="320" y="88" text-anchor="middle">libfossil</text>
+        <text x="320" y="112" text-anchor="middle">NATS server</text>
+        <text x="320" y="136" text-anchor="middle">notify</text>
+      </g>
+
+      <rect class="box" x="490" y="60" width="100" height="100"/>
+      <g class="item">
+        <text x="540" y="88" text-anchor="middle">peer</text>
+        <text x="540" y="112" text-anchor="middle">iroh</text>
+        <text x="540" y="136" text-anchor="middle">bridge</text>
+      </g>
+
+      <rect class="box" x="240" y="200" width="160" height="40"/>
+      <g class="item">
+        <text x="320" y="225" text-anchor="middle">.fossil (SQLite)</text>
+      </g>
+
+      <g class="flow">
+        <line x1="160" y1="100" x2="234" y2="100" marker-end="url(#es-arrow)"/>
+        <line x1="400" y1="88" x2="486" y2="88" marker-end="url(#es-arrow)"/>
+        <line x1="490" y1="136" x2="404" y2="136" marker-end="url(#es-arrow)"/>
+        <line x1="320" y1="160" x2="320" y2="196" marker-end="url(#es-arrow)"/>
+      </g>
+
+      <g class="flow-label">
+        <text x="197" y="92" text-anchor="middle">calls</text>
+        <text x="443" y="80" text-anchor="middle">sync</text>
+        <text x="447" y="154" text-anchor="middle">events</text>
+        <text x="334" y="183" text-anchor="start">persist</text>
+      </g>
+    </svg>
+  </div>
+  <p class="fineprint">The leaf agent embeds <code>libfossil</code> (Fossil repo I/O), a full NATS server (peer/hub/leaf role configurable), and the notify pub-sub. Mesh column lists the three transport options &mdash; pick any combination per agent. Persistence is always a regular <code>.fossil</code> SQLite file readable by the upstream <code>fossil</code> binary.</p>
+</section>
+
+<section>
+  <span class="num">&sect;05</span>
+  <h2>Compared to neighbors <span class="anchor">comparison</span></h2>
+  <div class="table-scroll">
+  <table class="cmp">
+    <thead>
+      <tr>
+        <th></th>
+        <th class="col-self">EdgeSync</th>
+        <th>upstream fossil server</th>
+        <th>git + chat stack</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Topology</td>       <td class="col-self">mesh (peer/hub/leaf)</td> <td>client/server</td>             <td>client/server</td></tr>
+      <tr><td>NAT traversal</td>  <td class="col-self">iroh QUIC (built-in)</td> <td>none</td>                      <td>depends on host</td></tr>
+      <tr><td>Bidir messaging</td><td class="col-self">notify (built-in)</td>    <td>forum/wiki (in-repo)</td>      <td>separate service</td></tr>
+      <tr><td>Storage format</td> <td class="col-self">.fossil (compatible)</td> <td>.fossil</td>                   <td>.git</td></tr>
+      <tr><td>Static binary</td>  <td class="col-self">yes</td>                  <td>yes</td>                       <td>varies</td></tr>
+      <tr><td>Runtime deps</td>   <td class="col-self">none</td>                 <td>none</td>                      <td>varies</td></tr>
+      <tr><td>API stability</td>  <td class="col-self">alpha</td>                <td>stable</td>                    <td>stable</td></tr>
+    </tbody>
+  </table>
+  </div>
+  <p class="fineprint">EdgeSync is not a Fossil replacement &mdash; it reuses the <code>.fossil</code> format and the <code>/xfer</code> wire protocol via libfossil. The comparison above is about <em>operating shape</em>, not feature parity with the upstream Fossil server (which still wins on web UI, wiki, forum, tickets).</p>
+</section>
+
+<section>
+  <span class="num">&sect;06</span>
+  <h2>What it is not <span class="anchor">limits</span></h2>
+  <p><strong>Not a Fossil replacement.</strong> EdgeSync moves <code>.fossil</code> blobs around. The format and protocol come from the upstream Fossil project; EdgeSync just changes the envelope. Run the upstream <code>fossil</code> binary alongside if you need the web UI, wiki, forum, or ticket system.</p>
+  <p><strong>Alpha.</strong> The wire protocol (Fossil <code>/xfer</code> cards) is stable, but EdgeSync's CLI flags, agent config schema, and notify message shape may change before v1.</p>
+  <p><strong>Not a database sync engine.</strong> EdgeSync replicates <code>.fossil</code> repositories, not arbitrary SQLite databases. If you want general SQLite replication, look at <a href="https://litestream.io">Litestream</a> or <a href="https://github.com/superfly/litefs">LiteFS</a>.</p>
+  <p><strong>No web UI yet.</strong> The leaf agent serves <code>/xfer</code> for sync but does not render HTML. Use upstream <code>fossil</code> bound to a local repo if you need a UI.</p>
+</section>
+
+<section>
+  <span class="num">&sect;07</span>
+  <h2>Get going <span class="anchor">start</span></h2>
+  <div class="code-block">
+    <div class="code-bar">
+      <span>shell</span>
+      <button type="button" class="copy-btn" data-copy="quickstart" aria-label="Copy quickstart commands">copy</button>
+    </div>
+    <pre id="quickstart">$ go install github.com/danmestas/EdgeSync/cmd/edgesync@latest
+$ edgesync new my-project.fossil               # create a repo
+$ edgesync sync start --repo my-project.fossil --serve-http :9000
+$ edgesync notify init --project my-project    # enable messaging</pre>
+  </div>
+  <p>Walkthrough: <a href="/docs/quickstart/">/docs/quickstart</a> &middot; Concepts: <a href="/docs/concepts/">/docs/concepts</a> &middot; Architecture: <a href="/docs/architecture/">/docs/architecture</a> &middot; Deployment: <a href="/docs/deployment/">/docs/deployment</a> &middot; Notify: <a href="/docs/notify/">/docs/notify</a> &middot; Source: <a href="https://github.com/danmestas/EdgeSync">github.com/danmestas/EdgeSync</a>.</p>
+</section>
+
+</main>
+
+<footer>
+  <div>edgesync &nbsp;&middot;&nbsp; alpha &nbsp;&middot;&nbsp; 2026 &nbsp;&middot;&nbsp; <a href="https://github.com/danmestas/EdgeSync">github.com/danmestas/EdgeSync</a></div>
+</footer>
+
+<script>
+(function () {
+  var btns = document.querySelectorAll(".copy-btn");
+  btns.forEach(function (b) {
+    b.addEventListener("click", function () {
+      var t = document.getElementById(b.dataset.copy);
+      if (!t) return;
+      var s = t.textContent.replace(/^\s*\$\s?/gm, "").replace(/\s+#.*$/gm, "").trim();
+      var done = function () {
+        b.dataset.state = "copied";
+        b.textContent = "copied";
+        setTimeout(function () { b.dataset.state = ""; b.textContent = "copy"; }, 1500);
+      };
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(s).then(done).catch(function () { b.textContent = "select+copy"; });
+      } else {
+        var ta = document.createElement("textarea");
+        ta.value = s;
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand("copy"); done(); } catch (e) { b.textContent = "select+copy"; }
+        document.body.removeChild(ta);
+      }
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the EdgeSync docs site. Used by both wrangler.jsonc (Cloudflare's
+# Linux build container) and local `wrangler deploy` from macOS.
+#
+# Strategy:
+# - If `hugo` is on PATH, use it (developer machines, CI with hugo preinstalled).
+# - Otherwise download the Linux extended build into the repo root and use that
+#   (Cloudflare Workers build container, which has no Hugo by default).
+set -euo pipefail
+
+HUGO_VERSION="0.160.0"
+
+if command -v hugo >/dev/null 2>&1; then
+    HUGO=hugo
+else
+    if [ ! -x ./hugo ]; then
+        echo "Downloading Hugo extended ${HUGO_VERSION} (linux-amd64)..."
+        curl -sSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" | tar xz hugo
+    fi
+    HUGO=./hugo
+fi
+
+bash scripts/gen-llms-txt.sh
+
+"${HUGO}" -s docs/site --minify

--- a/scripts/gen-llms-txt.sh
+++ b/scripts/gen-llms-txt.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SITE_DIR="docs/site"
+STATIC_DIR="$SITE_DIR/static"
+
+mkdir -p "$STATIC_DIR"
+
+# llms.txt: curated summary
+cat > "$STATIC_DIR/llms.txt" << 'HEADER'
+# EdgeSync
+
+> NATS-native sync engine for Fossil SCM repositories.
+> Leaf agents exchange blobs over NATS messaging instead of HTTP.
+> Optional bridge translates NATS to HTTP /xfer for legacy interop.
+
+## Key Concepts
+- Leaf Agent — daemon that reads/writes a .fossil repo and syncs over NATS
+- Bridge — translates NATS messages to HTTP /xfer cards for unmodified Fossil servers
+- NATS Mesh — peer/hub/leaf topology with embedded NATS server in each agent
+- Iroh — optional P2P QUIC transport for NAT traversal between leaves
+- Notify — bidirectional messaging for human-in-the-loop AI workflows
+
+## Quick Start
+1. go install github.com/danmestas/EdgeSync/cmd/edgesync@latest
+2. edgesync sync start --repo my.fossil --serve-http :9000
+3. Add a peer: --iroh --iroh-peer <ticket>
+4. Send a notification: edgesync notify send --project my-proj --body "hello"
+
+## Modules
+- cmd/edgesync — unified CLI (sync, bridge, notify, doctor, libfossil commands)
+- leaf/ — leaf agent module (sync daemon, NATS mesh, optional iroh)
+- bridge/ — NATS-to-HTTP bridge module
+- dst/ — deterministic simulation tests
+- External: github.com/danmestas/libfossil (pure-Go Fossil library)
+
+## Documentation
+Full docs: https://github.com/danmestas/EdgeSync/tree/main/docs/site
+HEADER
+
+# llms-full.txt: all content concatenated, frontmatter stripped
+echo "# EdgeSync Documentation (Full)" > "$STATIC_DIR/llms-full.txt"
+echo "" >> "$STATIC_DIR/llms-full.txt"
+echo "Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$STATIC_DIR/llms-full.txt"
+echo "" >> "$STATIC_DIR/llms-full.txt"
+
+find "$SITE_DIR/content" -name "*.md" -type f | sort | while read -r file; do
+    echo "---" >> "$STATIC_DIR/llms-full.txt"
+    echo "# Source: $file" >> "$STATIC_DIR/llms-full.txt"
+    echo "" >> "$STATIC_DIR/llms-full.txt"
+    awk 'NR==1 && /^---$/ { in_fm=1; next }
+     in_fm && /^---$/ { in_fm=0; next }
+     !in_fm' "$file" >> "$STATIC_DIR/llms-full.txt"
+    echo "" >> "$STATIC_DIR/llms-full.txt"
+done
+
+echo "Generated llms.txt and llms-full.txt in $STATIC_DIR/"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Read the latest git tag and write it into docs/site/hugo.yaml's
+# params.version so the landing page picks it up at build time. Run by
+# the Cloudflare build before Hugo invokes; safe to run locally too —
+# it only edits the working tree, never commits.
+#
+# Falls back to whatever value is already in hugo.yaml if no tags are
+# reachable (e.g., very early dev with no releases yet).
+set -euo pipefail
+
+HUGO_YAML="docs/site/hugo.yaml"
+
+# Cloudflare Workers Builds does a shallow clone with no tags; pull just
+# the tag refs cheaply so 'git describe' below has something to look at.
+git fetch --tags --depth=1 >/dev/null 2>&1 || true
+
+if TAG=$(git describe --tags --abbrev=0 2>/dev/null); then
+    VERSION="${TAG#v}"
+else
+    echo "sync-version: no git tags reachable, leaving hugo.yaml untouched" >&2
+    exit 0
+fi
+
+# Replace the version line. Use a temp file to stay portable across
+# GNU sed (Linux/CF) and BSD sed (macOS).
+awk -v v="${VERSION}" '
+    /^  version: "/ { print "  version: \"" v "\""; next }
+    { print }
+' "${HUGO_YAML}" > "${HUGO_YAML}.tmp"
+mv "${HUGO_YAML}.tmp" "${HUGO_YAML}"
+
+echo "sync-version: hugo.yaml params.version set to ${VERSION}"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,7 +5,7 @@
   "observability": { "enabled": true },
   "assets": { "directory": "./docs/site/public" },
   "build": {
-    "command": "bash scripts/build-docs.sh"
+    "command": "bash scripts/sync-version.sh && bash scripts/build-docs.sh"
   },
   "compatibility_flags": ["nodejs_compat"]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,7 +5,7 @@
   "observability": { "enabled": true },
   "assets": { "directory": "./docs/site/public" },
   "build": {
-    "command": "curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.160.0/hugo_extended_0.160.0_linux-amd64.tar.gz | tar xz hugo && bash scripts/gen-llms-txt.sh && cd docs/site && ../../hugo --minify"
+    "command": "bash scripts/build-docs.sh"
   },
   "compatibility_flags": ["nodejs_compat"]
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "edgesync-docs",
+  "compatibility_date": "2026-04-25",
+  "observability": { "enabled": true },
+  "assets": { "directory": "./docs/site/public" },
+  "build": {
+    "command": "curl -sSL https://github.com/gohugoio/hugo/releases/download/v0.160.0/hugo_extended_0.160.0_linux-amd64.tar.gz | tar xz hugo && bash scripts/gen-llms-txt.sh && cd docs/site && ../../hugo --minify"
+  },
+  "compatibility_flags": ["nodejs_compat"]
+}


### PR DESCRIPTION
## Summary

Adds an EdgeSync docs site mirroring the [libfossil](https://libfossil-docs.daniel-mestas.workers.dev) and dagnats pattern: a single static landing page with an inline SVG architecture diagram, plus a Hugo+hextra docs section. Deployed via Cloudflare Workers — `wrangler.jsonc` declares a build hook that downloads Hugo, generates `llms.txt` + `llms-full.txt`, then runs `hugo --minify`.

The Cloudflare project is **`edgesync-docs`**, expected to land at `https://edgesync-docs.daniel-mestas.workers.dev` once `wrangler deploy` runs from this branch (or main, after merge).

## What's included

- **Landing page** (`docs/site/layouts/index.html`) — 7 sections: install, overview, why, architecture (with custom SVG of the apps→leaf agent→mesh topology), comparison table vs upstream Fossil and git-based stacks, limits, get-going. Same warm palette + Geist Mono font as the sibling sites.
- **Docs content** (`docs/site/content/docs/`)
  - `quickstart.md` — install, create repo, start agent, peer over iroh, send a notification
  - `concepts.md` — leaf agent, bridge, NATS mesh roles, iroh, notify
  - `architecture.md` — module layout, sync wire protocol, embedded NATS, observability, DST (with same SVG as landing for theme-aware version)
  - `deployment.md` — VPS topology, Docker Compose, Cloudflare Tunnel, Tailscale, mobile pairing, OTel via Doppler
  - `notify.md` — data model, CLI reference, NATS subjects, pairing flow
- **Hugo config** (`docs/site/hugo.yaml`) — hextra theme via `github.com/imfing/hextra` Go module, flexsearch, edit-on-GitHub links, dark mode
- **Cloudflare config** (`wrangler.jsonc`) — build hook downloads Hugo v0.160.0, runs `gen-llms-txt.sh`, builds `--minify`. Assets directory is `./docs/site/public`.
- **`scripts/gen-llms-txt.sh`** — generates AI-friendly `llms.txt` (curated summary) and `llms-full.txt` (concatenated docs) at build time
- **`.gitignore`** — adds `docs/site/public/`, `docs/site/resources/`, `.hugo_build.lock`, generated llms files, `node_modules/`

## Test plan

- [x] `hugo --minify` builds locally — 15 pages, 11 static files, 112ms
- [x] Landing page rendered with EdgeSync content (verified `index.html` contents)
- [x] All 6 docs pages built (`architecture`, `concepts`, `deployment`, `notify`, `quickstart`, `_index`)
- [x] `gen-llms-txt.sh` runs cleanly from repo root
- [ ] `wrangler deploy` from repo root publishes to `edgesync-docs.daniel-mestas.workers.dev` (pending after merge)
- [ ] Visit live URL and confirm landing page + docs nav work

## Notes

- License row deliberately omitted from the spec table since EdgeSync has no `LICENSE` file yet (open-sourcing planned ~2026-05-03).
- The hextra theme is pulled via Hugo modules (Go module system), so no submodule or npm install — Cloudflare's build container handles it via `hugo mod get`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)