### PR TITLE
deps: bump libfossil v0.1.0 → v0.4.3 across all modules

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -3,9 +3,9 @@ module github.com/danmestas/EdgeSync/bridge
 go 1.26.0
 
 require (
-	github.com/danmestas/libfossil v0.1.0
-	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/danmestas/EdgeSync/leaf v0.0.0
+	github.com/danmestas/libfossil v0.4.3
+	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0
 	go.opentelemetry.io/otel v1.43.0

--- a/bridge/go.sum
+++ b/bridge/go.sum
@@ -6,6 +6,8 @@ github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
 github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
 github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
+github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.15.0
-	github.com/danmestas/libfossil v0.1.0
-	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/danmestas/EdgeSync/bridge v0.0.0-00010101000000-000000000000
 	github.com/danmestas/EdgeSync/leaf v0.0.0
+	github.com/danmestas/libfossil v0.4.3
+	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
 github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
 github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
+github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/leaf/go.mod
+++ b/leaf/go.mod
@@ -3,7 +3,7 @@ module github.com/danmestas/EdgeSync/leaf
 go 1.26.0
 
 require (
-	github.com/danmestas/libfossil v0.1.0
+	github.com/danmestas/libfossil v0.4.3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/danmestas/libfossil/db/driver/ncruces v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6

--- a/leaf/go.sum
+++ b/leaf/go.sum
@@ -14,6 +14,8 @@ github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
 github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
 github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
+github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=


### PR DESCRIPTION
## Summary

Bumps `github.com/danmestas/libfossil` from `v0.1.0` to `v0.4.3` across the root, leaf, and bridge modules.

## Why

- v0.4.3 has a substantive xfer-protocol fix ([libfossil#12](https://github.com/danmestas/libfossil/pull/12) — always emit project-code on push/pull cards) that affects sync handshakes.
- v0.4.0 era (NewHTTPTransport / Clone API) is what the sibling [agent-infra](https://github.com/danmestas/agent-infra) repo is built against; agent-infra has been masking the version drift via a local `replace ../EdgeSync/leaf` directive, which is now no longer needed.
- v0.4.3 also exposes `ResolveVersion` + `ReadFileAt` (libfossil#11) which agent-infra and EdgeSync may use in the future.

## Test plan

- [x] `go build ./...` clean across root, leaf, bridge, sim
- [x] `make test` green: leaf/agent, leaf/agent/notify, leaf/telemetry, bridge/bridge, sim/* — all passing
- [x] No code changes needed — the libfossil public API stayed stable across v0.1 → v0.4.3
- [x] Cross-checked against agent-infra Phase 1 EdgeSync refactor (just landed): the new MeshClientURL/MeshLeafAddr accessors from PR #77 still build clean against the bumped libfossil

## Follow-up

Once this lands and a `leaf/v0.0.3` tag is cut, agent-infra can drop the `replace github.com/danmestas/EdgeSync/leaf => ../EdgeSync/leaf` directive in its go.mod and pin to `EdgeSync/leaf v0.0.3` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)