### PR TITLE
cli: extract command tree into reusable package

### DIFF
--- a/cli/bridge_serve.go
+++ b/cli/bridge_serve.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -7,9 +7,14 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/danmestas/libfossil/cli"
 	"github.com/danmestas/EdgeSync/bridge/bridge"
+	libfossilcli "github.com/danmestas/libfossil/cli"
 )
+
+// BridgeCmd is the top-level command group for the NATS-to-Fossil bridge.
+type BridgeCmd struct {
+	Serve BridgeServeCmd `cmd:"" help:"Start NATS-to-Fossil bridge"`
+}
 
 type BridgeServeCmd struct {
 	NATSUrl   string `help:"NATS server URL" default:"nats://localhost:4222"`
@@ -17,7 +22,7 @@ type BridgeServeCmd struct {
 	Project   string `required:"" help:"Project code for NATS subject"`
 }
 
-func (c *BridgeServeCmd) Run(g *cli.Globals) error {
+func (c *BridgeServeCmd) Run(g *libfossilcli.Globals) error {
 	b, err := bridge.New(bridge.Config{
 		NATSUrl:     c.NATSUrl,
 		FossilURL:   c.FossilURL,

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -11,14 +11,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/danmestas/libfossil/cli"
+	libfossilcli "github.com/danmestas/libfossil/cli"
 )
 
 type DoctorCmd struct {
 	NATSUrl string `help:"NATS server URL to check connectivity" default:"nats://localhost:4222"`
 }
 
-func (c *DoctorCmd) Run(g *cli.Globals) error {
+func (c *DoctorCmd) Run(g *libfossilcli.Globals) error {
 	passed, warned, failed := 0, 0, 0
 
 	check := func(name string, fn func() (string, error)) {

--- a/cli/notify.go
+++ b/cli/notify.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"context"
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	libfossil "github.com/danmestas/libfossil"
-	"github.com/danmestas/libfossil/cli"
 	"github.com/danmestas/EdgeSync/leaf/agent/notify"
+	libfossil "github.com/danmestas/libfossil"
+	libfossilcli "github.com/danmestas/libfossil/cli"
 	"github.com/nats-io/nats.go"
 )
 
@@ -29,13 +29,13 @@ type NotifyCmd struct {
 }
 
 // notifyRepoPath returns the path to notify.fossil next to the -R repo.
-func notifyRepoPath(g *cli.Globals) string {
+func notifyRepoPath(g *libfossilcli.Globals) string {
 	dir := filepath.Dir(g.Repo)
 	return filepath.Join(dir, "notify.fossil")
 }
 
 // openNotifyRepo opens the notify.fossil repo with a clear error if missing.
-func openNotifyRepo(g *cli.Globals) (*libfossil.Repo, error) {
+func openNotifyRepo(g *libfossilcli.Globals) (*libfossil.Repo, error) {
 	path := notifyRepoPath(g)
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, fmt.Errorf("notify repo not found at %s (run: edgesync notify init -R <repo>)", path)
@@ -83,7 +83,7 @@ func parseActions(s string) []notify.Action {
 
 type NotifyInitCmd struct{}
 
-func (c *NotifyInitCmd) Run(g *cli.Globals) error {
+func (c *NotifyInitCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -108,7 +108,7 @@ type NotifySendCmd struct {
 	Body     string `arg:"" help:"Message body"`
 }
 
-func (c *NotifySendCmd) Run(g *cli.Globals) error {
+func (c *NotifySendCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -163,7 +163,7 @@ type NotifyAskCmd struct {
 	Body     string        `arg:"" help:"Message body"`
 }
 
-func (c *NotifyAskCmd) Run(g *cli.Globals) error {
+func (c *NotifyAskCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -239,7 +239,7 @@ type NotifyWatchCmd struct {
 	NATS    string `help:"NATS server URL (required for real-time delivery)" env:"EDGESYNC_NATS"`
 }
 
-func (c *NotifyWatchCmd) Run(g *cli.Globals) error {
+func (c *NotifyWatchCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -289,7 +289,7 @@ type NotifyThreadsCmd struct {
 	Project string `help:"Project code" required:""`
 }
 
-func (c *NotifyThreadsCmd) Run(g *cli.Globals) error {
+func (c *NotifyThreadsCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -324,7 +324,7 @@ type NotifyLogCmd struct {
 	Thread  string `arg:"" help:"Thread short ID"`
 }
 
-func (c *NotifyLogCmd) Run(g *cli.Globals) error {
+func (c *NotifyLogCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -354,7 +354,7 @@ func (c *NotifyLogCmd) Run(g *cli.Globals) error {
 
 type NotifyStatusCmd struct{}
 
-func (c *NotifyStatusCmd) Run(g *cli.Globals) error {
+func (c *NotifyStatusCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -379,7 +379,7 @@ type NotifyPairCmd struct {
 	Endpoint string `help:"Hub iroh endpoint ID for the QR payload" env:"EDGESYNC_IROH_ENDPOINT"`
 }
 
-func (c *NotifyPairCmd) Run(g *cli.Globals) error {
+func (c *NotifyPairCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -417,7 +417,7 @@ type NotifyUnpairCmd struct {
 	Name string `arg:"" help:"Device name to unpair"`
 }
 
-func (c *NotifyUnpairCmd) Run(g *cli.Globals) error {
+func (c *NotifyUnpairCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}
@@ -439,7 +439,7 @@ func (c *NotifyUnpairCmd) Run(g *cli.Globals) error {
 
 type NotifyDevicesCmd struct{}
 
-func (c *NotifyDevicesCmd) Run(g *cli.Globals) error {
+func (c *NotifyDevicesCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}

--- a/cli/sync_now.go
+++ b/cli/sync_now.go
@@ -1,17 +1,17 @@
-package main
+package cli
 
 import (
 	"fmt"
 	"syscall"
 
-	"github.com/danmestas/libfossil/cli"
+	libfossilcli "github.com/danmestas/libfossil/cli"
 )
 
 type SyncNowCmd struct {
 	PID int `arg:"" help:"PID of running agent to signal"`
 }
 
-func (c *SyncNowCmd) Run(g *cli.Globals) error {
+func (c *SyncNowCmd) Run(g *libfossilcli.Globals) error {
 	if c.PID <= 0 {
 		return fmt.Errorf("invalid PID: %d", c.PID)
 	}

--- a/cli/sync_start.go
+++ b/cli/sync_start.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -8,9 +8,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/danmestas/libfossil/cli"
 	"github.com/danmestas/EdgeSync/leaf/agent"
+	libfossilcli "github.com/danmestas/libfossil/cli"
 )
+
+// SyncCmd is the top-level command group for leaf agent sync.
+type SyncCmd struct {
+	Start SyncStartCmd `cmd:"" help:"Start leaf agent daemon"`
+	Now   SyncNowCmd   `cmd:"" help:"Trigger immediate sync"`
+}
 
 type SyncStartCmd struct {
 	NATSUrl      string        `help:"NATS server URL" default:"nats://localhost:4222"`
@@ -21,7 +27,7 @@ type SyncStartCmd struct {
 	Notify       bool          `help:"Enable notify messaging (requires notify.fossil next to repo)" default:"false"`
 }
 
-func (c *SyncStartCmd) Run(g *cli.Globals) error {
+func (c *SyncStartCmd) Run(g *libfossilcli.Globals) error {
 	if g.Repo == "" {
 		return fmt.Errorf("repository required (use -R <path>)")
 	}

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -1,24 +1,16 @@
 package main
 
 import (
+	edgecli "github.com/danmestas/EdgeSync/cli"
 	"github.com/danmestas/libfossil/cli"
 )
 
 type CLI struct {
 	cli.Globals
 
-	Repo   cli.RepoCmd `cmd:"" help:"Repository operations"`
-	Sync   SyncCmd     `cmd:"" help:"Leaf agent sync"`
-	Bridge BridgeCmd   `cmd:"" help:"NATS-to-Fossil bridge"`
-	Notify NotifyCmd   `cmd:"" help:"Bidirectional notification messaging"`
-	Doctor DoctorCmd   `cmd:"" help:"Check development environment health"`
-}
-
-type SyncCmd struct {
-	Start SyncStartCmd `cmd:"" help:"Start leaf agent daemon"`
-	Now   SyncNowCmd   `cmd:"" help:"Trigger immediate sync"`
-}
-
-type BridgeCmd struct {
-	Serve BridgeServeCmd `cmd:"" help:"Start NATS-to-Fossil bridge"`
+	Repo   cli.RepoCmd       `cmd:"" help:"Repository operations"`
+	Sync   edgecli.SyncCmd   `cmd:"" help:"Leaf agent sync"`
+	Bridge edgecli.BridgeCmd `cmd:"" help:"NATS-to-Fossil bridge"`
+	Notify edgecli.NotifyCmd `cmd:"" help:"Bidirectional notification messaging"`
+	Doctor edgecli.DoctorCmd `cmd:"" help:"Check development environment health"`
 }

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
-github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
 github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=


### PR DESCRIPTION
## Summary
- Move sync, bridge, notify, and doctor commands from `cmd/edgesync/` to a new top-level `cli/` package.
- `cmd/edgesync/cli.go` now imports from `EdgeSync/cli` (aliased `edgecli`) and assembles the binary's command surface.
- Mirrors `libfossil/cli`'s pattern — the `cli/` package exports embeddable Kong command structs that downstream consumers (agent-infra → eventually `bones`) can integrate alongside `libfossil/cli.RepoCmd` into their own unified CLI.
- No behavior change: `cmd/edgesync` builds the same binary with the same flags.

## Test plan
- [x] `go vet ./...` clean
- [x] `make test` clean — bridge, leaf agent, notify, telemetry, sim suites all pass
- [x] `cmd/edgesync` end-to-end notify CLI tests (`TestNotifyCLI*`) pass unchanged
- [x] `go mod tidy` produced only a 2-line go.sum cleanup (unrelated to renames)

## Why now

agent-infra is preparing to consolidate its three CLIs (`agent-init`, `agent-tasks`, `orchestrator-validate-plan`) into a single Kong-based binary that embeds `libfossil/cli` and EdgeSync's command tree. Today EdgeSync's commands live in `package main` and aren't importable. This PR exposes them.