### PR TITLE
go.mod: pin sub-module deps to real tags so EdgeSync/cli is consumable

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -3,7 +3,7 @@ module github.com/danmestas/EdgeSync/bridge
 go 1.26.0
 
 require (
-	github.com/danmestas/EdgeSync/leaf v0.0.0
+	github.com/danmestas/EdgeSync/leaf v0.0.3
 	github.com/danmestas/libfossil v0.4.3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.15.0
-	github.com/danmestas/EdgeSync/bridge v0.0.0-00010101000000-000000000000
-	github.com/danmestas/EdgeSync/leaf v0.0.0
+	github.com/danmestas/EdgeSync/bridge v0.0.2
+	github.com/danmestas/EdgeSync/leaf v0.0.3
 	github.com/danmestas/libfossil v0.4.3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary
- Root \`go.mod\`: replace \`bridge v0.0.0-00010101\` and \`leaf v0.0.0\` placeholders with the real tagged versions (\`bridge v0.0.2\`, \`leaf v0.0.3\`).
- \`bridge/go.mod\`: same fix for its \`leaf\` requirement.
- Local \`replace\` directives stay — intra-repo dev against unreleased changes still works.

## Why
With the placeholder versions, external consumers of \`EdgeSync/cli\` (the package extracted in #80) get:

\`\`\`
go: github.com/danmestas/EdgeSync/cli imports
    github.com/danmestas/EdgeSync/bridge/bridge:
    github.com/danmestas/EdgeSync/bridge@v0.0.0-00010101000000-000000000000:
    invalid version: unknown revision 000000000000
\`\`\`

Real version pins make \`go get github.com/danmestas/EdgeSync/cli@v0.0.5\` resolve cleanly. agent-infra is the immediate consumer (consolidating into a single \`bones\` binary).

## Test plan
- [x] \`make test\` clean — all suites pass with the new pins
- [x] \`go mod tidy\` no-op (tags resolve)
- [ ] After merge + tag v0.0.5, agent-infra side: \`go get EdgeSync/cli@v0.0.5\` builds cleanly