### PR TITLE
README: front-load value prop, add prereqs, badges, deep-dive links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # EdgeSync
 
-Replace Fossil's HTTP sync with NATS messaging or direct peer-to-peer sync. Leaf agents can act as both sync clients and servers — a stock `fossil clone`/`fossil sync` can talk to them directly.
+[![CI](https://github.com/danmestas/EdgeSync/actions/workflows/ci.yml/badge.svg)](https://github.com/danmestas/EdgeSync/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/danmestas/EdgeSync.svg)](https://pkg.go.dev/github.com/danmestas/EdgeSync)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/danmestas/EdgeSync)](https://goreportcard.com/report/github.com/danmestas/EdgeSync)
+
+Sync engine for distributed teams that want code-and-data replication without a central server. Each peer carries the full repository, syncs over [NATS](https://nats.io) messaging or QUIC tunnels (via [iroh](https://www.iroh.computer/)), and stays compatible with the [Fossil](https://fossil-scm.org/) version-control protocol — so a stock `fossil clone` or `fossil sync` still works against any leaf agent.
+
+## Why EdgeSync
+
+Centralized sync (Git over HTTPS, S3, Postgres replication) breaks down when peers are intermittently connected, NAT-stuck, or want eventual-consistency replication of structured state alongside code. EdgeSync solves three problems together:
+
+- **Real-time over messaging.** Use NATS subjects for low-latency change announcements; sync hops are sub-second on a healthy connection.
+- **No central server required.** Two leaf agents over iroh form a peer-to-peer mesh that traverses NAT without VPN.
+- **Fossil-compatible wire format.** Existing Fossil tooling continues to work; EdgeSync is a faster transport, not a replacement DAG.
+
+If your team is using Git + an HTTP server and that's working well, you don't need EdgeSync. If you're building offline-first agents, multi-tenant collaboration tools, or anything where peer-to-peer beats request-response, this is for you.
+
+## Status
+
+**Pre-1.0 (v0.0.x).** APIs are stable in spirit but may change in patch releases until 1.0. The leaf agent and sync engine run in a [reference production deployment](docs/site/content/docs/deployment.md) and pass deterministic-simulation, integration, and interop test suites against the real Fossil binary on every commit. Suitable for evaluation and self-hosted use; not yet under formal version policy.
 
 ## Architecture
 
@@ -28,18 +47,59 @@ graph LR
 3. **Leaf → Leaf (HTTP)** — Peer-to-peer via ServeHTTP. Stock `fossil clone`/`fossil sync` works.
 4. **Leaf → Leaf (iroh)** — Peer-to-peer over QUIC with NAT traversal. Each agent runs an embedded NATS server; leaf node connections tunnel over iroh. Enables presence and messaging without central infrastructure.
 
+## Prerequisites
+
+- **Go 1.26+** — required to build all binaries
+- **NATS server** — for sync modes 1, 2, 4 (skip if using mode 3 over plain HTTP). Install via `brew install nats-server` or [nats-io/nats-server releases](https://github.com/nats-io/nats-server/releases)
+- **Fossil binary** *(optional)* — needed only for interop tests and to create demo repos. Install from [fossil-scm.org/downloads](https://fossil-scm.org/home/uv/download.html)
+- **direnv** *(optional)* — if installed, the included `.envrc` sets `GOFLAGS=-buildvcs=false` automatically (see Dual VCS Note below)
+
 ## Quick Start
 
 ```bash
-# One command: install hooks + build + test
+# Clone, install hooks, build all binaries, run tests
+git clone https://github.com/danmestas/EdgeSync
+cd EdgeSync
 make setup
 
-# Run the leaf agent
-bin/leaf --repo my.fossil --nats nats://localhost:4222 --serve-http :8080
+# Create a demo Fossil repo (or use any existing .fossil file)
+fossil new demo.fossil
 
-# Run the edgesync CLI
-bin/edgesync repo info
+# Start NATS in another terminal
+nats-server &
+
+# Run the leaf agent
+bin/leaf --repo demo.fossil --nats nats://localhost:4222 --serve-http :8080
+
+# Inspect repository state
+bin/edgesync repo info -R demo.fossil
 ```
+
+A stock `fossil` client can now clone from the leaf agent over HTTP:
+
+```bash
+fossil clone http://localhost:8080 /tmp/from-leaf.fossil
+```
+
+## Use as a Go library
+
+EdgeSync is a multi-module repo. Each module is independently importable:
+
+```bash
+# Sync engine + repo internals (most common)
+go get github.com/danmestas/libfossil
+
+# Leaf agent (NATS + HTTP server, mesh, notify)
+go get github.com/danmestas/EdgeSync/leaf
+
+# Bridge (NATS ↔ Fossil HTTP /xfer translator)
+go get github.com/danmestas/EdgeSync/bridge
+
+# Embeddable Kong CLI commands
+go get github.com/danmestas/EdgeSync/cli
+```
+
+API documentation: [pkg.go.dev/github.com/danmestas/EdgeSync](https://pkg.go.dev/github.com/danmestas/EdgeSync). Each module has a `README.md` with the public API surface and example usage.
 
 ### Dual VCS Note
 
@@ -68,61 +128,55 @@ doppler run -- bin/leaf --repo my.fossil --nats nats://localhost:4222
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4318 bin/leaf --repo my.fossil --nats nats://localhost:4222
 ```
 
+## Deep Dive
+
+Architecture decisions and protocol details live in [`docs/architecture/`](docs/architecture/):
+
+- [`core-library.md`](docs/architecture/core-library.md) — libfossil package layout, blob format, xfer wire format, SQLite drivers
+- [`sync-protocol.md`](docs/architecture/sync-protocol.md) — xfer card protocol, client/server flow, clone, UV, config sync, private artifacts
+- [`agent-deployment.md`](docs/architecture/agent-deployment.md) — leaf agent, bridge, Docker, WASM targets, observability
+- [`checkout-merge.md`](docs/architecture/checkout-merge.md) — checkout/checkin, merge strategies, fork prevention, autosync, ci-lock
+- [`repo-operations.md`](docs/architecture/repo-operations.md) — CLI, tags, FTS, verify/rebuild, auth, shun/purge
+- [`testing-strategy.md`](docs/architecture/testing-strategy.md) — test tiers, DST, sim, interop, BUGGIFY
+- [`notify-messaging.md`](docs/architecture/notify-messaging.md) — bidirectional messaging: data model, dual delivery, CLI, planned phases
+- [`wasm-targets.md`](docs/architecture/wasm-targets.md) — WASI and browser builds
+
 ## Project Layout
 
 ```
 cmd/edgesync/          Unified CLI binary (50 subcommands)
-
-libfossil/             Core library — Go port of Fossil internals
-  annotate/            Line-level blame/annotate
-  bisect/              Binary search for regressions
-  blob/                Blob compression (Fossil's 4-byte prefix + zlib)
-  content/             Artifact storage and expansion (delta chains)
-  db/                  SQLite adapter (3 drivers via build tags)
-  deck/                Manifest/control-artifact parsing
-  delta/               Fossil delta codec (ported from delta.c)
-  hash/                SHA1/SHA3-256 content addressing
-  manifest/            Checkin, file listing, timeline
-  merge/               3-way merge with swappable strategies
-  path/                Checkout path resolution
-  repo/                Fossil repo DB operations (create, open, verify)
-  simio/               Simulation I/O abstractions (Clock, Rand, Env)
-  stash/               Working-tree stash save/restore
-  sync/                Sync engine: client (Sync, Clone), server (HandleSync,
-                         ServeHTTP), transport (HTTP, NATS, mock)
-  tag/                 Tag read/write on artifacts
-  testutil/            Shared test helpers
-  undo/                Undo/redo state tracking
-  xfer/                Xfer card protocol encoder/decoder
+cli/                   Embeddable Kong commands (importable as a Go module)
 
 leaf/                  Leaf agent module
   agent/               Agent logic, NATS transport, ServeNATS, ServeP2P stub
   cmd/leaf/            Standalone leaf daemon binary
+  cmd/wasm/            Browser-WASM build target
 
 bridge/                Bridge module
   bridge/              Bridge logic (NATS <-> HTTP /xfer translation)
   cmd/bridge/          Standalone bridge daemon binary
 
 dst/                   Deterministic simulation testing
-                         SimNetwork (bridge mode), PeerNetwork (leaf-to-leaf)
-sim/                   Integration simulation testing
-                         Real NATS + Fossil + fault proxy + serve tests
+sim/                   Integration simulation (real NATS + Fossil + fault proxy)
   cmd/soak/            Continuous soak test runner
 
 docs/                  Documentation
-  dev/specs/           Design specifications
-  dev/plans/           Implementation plans
+  architecture/        Design specs and protocol references
+  site/                Hugo site (deployed to docs.example.com)
 ```
+
+The core sync engine and repo internals live in the separate [`libfossil`](https://github.com/danmestas/libfossil) repo and are imported as a public Go module.
 
 ## Go Modules
 
 | Module | Path | Purpose |
 |--------|------|---------|
 | `github.com/danmestas/EdgeSync` | `.` | Root: CLI, sim/, soak runner |
-| `github.com/danmestas/libfossil` | `libfossil/` | Core library (public, v0.3.x) |
 | `github.com/danmestas/EdgeSync/leaf` | `leaf/` | Leaf agent |
 | `github.com/danmestas/EdgeSync/bridge` | `bridge/` | Bridge |
+| `github.com/danmestas/EdgeSync/cli` | `cli/` | Embeddable Kong commands |
 | `github.com/danmestas/EdgeSync/dst` | `dst/` | Deterministic sim tests |
+| `github.com/danmestas/libfossil` | external | Core library (separate repo) |
 
 ## SQLite Drivers
 
@@ -150,8 +204,14 @@ make drivers           # Test all 3 SQLite drivers
 - `github.com/alecthomas/kong` — CLI framework
 - `github.com/hexops/gotextdiff` — Unified diff output
 
+## License
+
+[Apache License 2.0](LICENSE)
+
 ## Reference
 
 - [Fossil sync protocol](https://fossil-scm.org/home/doc/tip/www/sync.wiki)
 - [Fossil delta format](https://fossil-scm.org/home/doc/tip/www/delta_format.wiki)
 - [Fossil password authentication](https://fossil-scm.org/home/doc/tip/www/password.wiki)
+- [NATS messaging](https://nats.io)
+- [iroh QUIC mesh](https://www.iroh.computer/)


### PR DESCRIPTION
## Summary

DX-audit pass on the README before flipping the repo public. Items 1-6 from the audit:

1. **New tagline + Why section** — explains the use case for non-Fossil-aware readers (real-time over messaging, peer-to-peer without VPN, Fossil-compatible). Honest "if you don't need this, don't use it" note.
2. **Status callout** — pre-1.0, reference production deployment, what's tested. Sets expectations.
3. **Prerequisites section** before Quick Start: Go 1.26+, NATS server, optional Fossil binary, optional direnv.
4. **Quick Start works cold** — create a demo Fossil repo, start NATS, run leaf, show \`fossil clone\` hitting it.
5. **"Use as a Go library" section** with \`go get\` per module + pkg.go.dev link.
6. **"Deep Dive" section** linking each \`docs/architecture/*.md\` by topic (was discovery-by-filesystem-grep before).

Plus:
- 4 status badges: CI, Go reference, license, Go report card
- License section pointing at LICENSE
- Project layout updated to reflect the cli/ module and that libfossil now lives in its own repo

## Test plan
- [x] Markdown renders cleanly (links, mermaid, code blocks)
- [x] All linked \`docs/architecture/*.md\` files exist
- [x] All \`go get\` paths resolve to actual Go modules in this repo
- [x] Badges point at real CI workflow + module path

The audit identified 4 follow-ups (CONTRIBUTING.md, SECURITY.md, issue templates, glossary). Those land separately.