### PR TITLE
release: GoReleaser config + tag-push workflow + edgesync --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.0'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_PAT_TOKEN: ${{ secrets.HOMEBREW_PAT_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,106 @@
+# GoReleaser config for edgesync.
+# https://goreleaser.com
+#
+# Cross-compiles edgesync for macOS and Linux on amd64/arm64, archives
+# as tarballs, generates checksums, publishes a GitHub release, and
+# updates the Homebrew formula in danmestas/homebrew-tap.
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: edgesync
+    main: ./cmd/edgesync
+    binary: edgesync
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+      - -buildvcs=false
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.CommitDate}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: edgesync
+    formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^chore:'
+      - '^test:'
+      - 'merge conflict'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+
+release:
+  github:
+    owner: danmestas
+    name: EdgeSync
+  draft: false
+  prerelease: auto
+  name_template: "{{.ProjectName}} v{{.Version}}"
+  footer: |
+    **Full Changelog**: https://github.com/danmestas/EdgeSync/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+    ## Install
+
+    ### Homebrew (macOS / Linux)
+    ```bash
+    brew install danmestas/tap/edgesync
+    ```
+
+    ### Go
+    ```bash
+    go install github.com/danmestas/EdgeSync/cmd/edgesync@{{ .Tag }}
+    ```
+
+    ### Direct download
+    Pick a binary from the assets above for your OS/arch.
+
+brews:
+  - name: edgesync
+    repository:
+      owner: danmestas
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_PAT_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/danmestas/EdgeSync
+    description: "Sync engine for distributed teams: NATS messaging or peer-to-peer Fossil sync."
+    license: Apache-2.0
+    install: |
+      bin.install "edgesync"
+    test: |
+      system "#{bin}/edgesync --version"

--- a/cmd/edgesync/main.go
+++ b/cmd/edgesync/main.go
@@ -1,11 +1,28 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/alecthomas/kong"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
+// Build-time variables, populated via -ldflags by GoReleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
+	// Handle --version / -V at the top level. Done before Kong.Parse so
+	// it doesn't collide with sub-flags like `repo extract --version`.
+	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "-V") {
+		fmt.Printf("edgesync %s (commit %s, built %s)\n", version, commit, date)
+		return
+	}
+
 	var c CLI
 	ctx := kong.Parse(&c,
 		kong.Name("edgesync"),


### PR DESCRIPTION
## Summary

Wires up the release pipeline for edgesync, mirroring the bones setup ([\`danmestas/bones#25\`](https://github.com/danmestas/bones/pull/25), [#26](https://github.com/danmestas/bones/pull/26)). On every \`v*\` tag push:

1. Cross-compile \`edgesync\` for darwin/linux × amd64/arm64.
2. Archive as \`.tar.gz\` with binary + LICENSE + README.
3. SHA-256 checksums.
4. Publish a GitHub release with auto-generated changelog.
5. Update the Homebrew formula at \`danmestas/homebrew-tap/Formula/edgesync.rb\`.

## Files

- \`.goreleaser.yml\`
- \`.github/workflows/release.yml\`
- \`cmd/edgesync/main.go\` — adds \`version\`/\`commit\`/\`date\` package vars and a top-level \`--version\` / \`-V\` short-circuit (avoids collision with \`repo extract --version\`)

## Required setup (post-merge)

The release workflow needs \`HOMEBREW_PAT_TOKEN\` set on this repo — a PAT with \`contents:write\` on \`danmestas/homebrew-tap\`. (Same token used for bones; you can copy the secret value from the bones repo settings.)

Add at: https://github.com/danmestas/EdgeSync/settings/secrets/actions

## Test plan
- [x] \`make test\` clean
- [x] \`go build -ldflags "-X main.version=v0.0.6 ..." ./cmd/edgesync/\` produces a binary that prints \`edgesync v0.0.6 (commit abc1234, built 2026-04-27)\` for both \`--version\` and \`-V\`
- [ ] After merge + secret + tag v0.0.6: workflow runs end-to-end, brew formula lands at \`danmestas/homebrew-tap/Formula/edgesync.rb\`, \`brew install danmestas/tap/edgesync\` works