### PR TITLE
polish: CHANGELOG + CONTRIBUTING (libfossil-level hygiene)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+EdgeSync uses multi-module versioning: the root module and the `leaf` and
+`bridge` submodules each carry their own tags (e.g. `v0.0.6`, `leaf/v0.0.3`,
+`bridge/v0.0.2`). This file tracks the root module unless otherwise noted.
+
+## [Unreleased]
+
+## [0.0.6] - 2026-04-26
+
+Latest pre-1.0 release. EdgeSync is alpha — see the README "Status" section
+for what's stable vs. in-flight.
+
+### Changed
+
+- Bumped `libfossil` dependency to v0.4.3.
+
+## [0.0.1] - 2026-04-23
+
+Initial open-source release of `EdgeSync`, a peer-to-peer replication and
+sync substrate built on `libfossil` for durable state and embedded NATS
+for real-time coordination. Provides the `leaf` daemon used by `bones`
+and other downstream consumers.
+
+### Added
+
+- `leaf` daemon with embedded NATS server.
+- `bridge` component for cross-cluster sync.
+- `iroh-sidecar` for libp2p-based replication.
+- Notify system with shared `natshdr.Carrier` for header propagation.
+- WASI and browser WASM build targets.
+- Deterministic simulation harness (`sim/`) for replay-based testing.
+- Module rename to `github.com/danmestas/EdgeSync`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to EdgeSync
+
+Thanks for your interest in `EdgeSync`, a peer-to-peer replication and sync
+substrate built on `libfossil` (durable state) and NATS (real-time
+coordination). This document covers everything you need to get a working
+checkout, run the tests, and submit changes.
+
+## Development setup
+
+Requires Go 1.26 or newer.
+
+```
+git clone https://github.com/danmestas/EdgeSync
+cd EdgeSync
+make setup     # installs hooks, builds binaries, runs tests
+```
+
+`make setup` is the one-shot bootstrap. The repository has a multi-module
+structure (root + `leaf` + `bridge` + `iroh-sidecar`); `setup` builds all
+of them. A `go.work.example` file is checked in — copy to `go.work` to
+resolve all submodules locally.
+
+## Running tests
+
+```
+make test         # full suite across all modules
+make vet          # go vet
+make sim          # deterministic simulation harness
+make sim-full     # extended simulation runs
+```
+
+`make test` is the canonical pre-PR gate — the same checks run in CI.
+
+## Building variants
+
+```
+make build        # all four binaries (edgesync, leaf, bridge, iroh-sidecar)
+make wasm         # WASI + browser WASM targets
+make wasm-wasi    # WASI only
+make wasm-browser # browser only
+```
+
+## Code layout
+
+- `cmd/`, `cli/` — CLI entry points (`edgesync`).
+- `leaf/` — leaf daemon Go submodule (separate `go.mod`, separately tagged).
+- `bridge/` — cross-cluster sync submodule.
+- `iroh-sidecar/` — libp2p sidecar for replication.
+- `deploy/` — deployment manifests and tooling.
+- `scripts/` — operational and test-helper scripts.
+- `sim/` — deterministic simulation harness.
+- `testdata/` — fixture data for tests.
+
+## Submitting changes
+
+1. Open a feature branch off `main`. Direct commits to `main` are not accepted.
+2. Run `make test` locally before pushing.
+3. Open a PR; CI will re-run the full suite.
+4. Submodules (`leaf`, `bridge`) are tagged independently — coordinate
+   release versions with the root module if a change spans both.
+
+## Reporting issues
+
+Open an issue at https://github.com/danmestas/EdgeSync/issues with
+reproduction steps, expected vs. actual behavior, and which submodule
+(`edgesync`, `leaf`, `bridge`, `iroh-sidecar`) is affected.


### PR DESCRIPTION
## Summary

Matches the `bones` polish template. Adds `CHANGELOG.md` (Keep-a-Changelog) and `CONTRIBUTING.md` (modeled on libfossil's structure), adapted for EdgeSync's multi-module layout.

## What's in here

- **`CHANGELOG.md`** — Root-module versions only (`[0.0.1]` initial → `[0.0.6]` latest). Header notes that `leaf/` and `bridge/` submodules carry their own tags.
- **`CONTRIBUTING.md`** — Dev setup (`make setup`), test/sim commands, the four-binary build (`edgesync` + `leaf` + `bridge` + `iroh-sidecar`), WASM targets, and submodule release coordination guidance.

## Caveats

- Intermediate `[0.0.2]` through `[0.0.5]` aren't broken out individually — the project's still alpha and the diffs are small. Easy to add detail later if desired.
- `[0.0.6]` shown as 2026-04-26 based on `bridge/v0.0.2` and `leaf/v0.0.3` co-merge date; if the root-module v0.0.6 tag has a different date I missed, let me know.

## What's NOT in here

- No README badges (deferred across the polish program).
- No CODE_OF_CONDUCT / SECURITY / issue templates.
- No README rewrite.

## Test plan

- [x] CHANGELOG validates as Keep-a-Changelog
- [x] All `make` targets in CONTRIBUTING exist in the Makefile
- [x] Multi-module structure correctly described