### PR TITLE
chore: bump libfossil v0.4.3 → v0.4.5

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/danmestas/EdgeSync/leaf v0.0.3
-	github.com/danmestas/libfossil v0.4.3
+	github.com/danmestas/libfossil v0.4.5
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/bridge/go.sum
+++ b/bridge/go.sum
@@ -4,10 +4,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
-github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
-github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
-github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.5 h1:sDIcQCqp6cCOQgMaIGseRoopCD0mPYg2FRUrEV8P0HY=
+github.com/danmestas/libfossil v0.4.5/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.2
 	github.com/danmestas/EdgeSync/leaf v0.0.3
-	github.com/danmestas/libfossil v0.4.3
+	github.com/danmestas/libfossil v0.4.5
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
-github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.5 h1:sDIcQCqp6cCOQgMaIGseRoopCD0mPYg2FRUrEV8P0HY=
+github.com/danmestas/libfossil v0.4.5/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/leaf/go.mod
+++ b/leaf/go.mod
@@ -3,7 +3,7 @@ module github.com/danmestas/EdgeSync/leaf
 go 1.26.0
 
 require (
-	github.com/danmestas/libfossil v0.4.3
+	github.com/danmestas/libfossil v0.4.5
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/danmestas/libfossil/db/driver/ncruces v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6

--- a/leaf/go.sum
+++ b/leaf/go.sum
@@ -12,10 +12,8 @@ github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipw
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.1.0 h1:4YvP/Ope5ggWQK4xsW6Y2DXI6U9kow7SgArRzuALMfs=
-github.com/danmestas/libfossil v0.1.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
-github.com/danmestas/libfossil v0.4.3 h1:Oo/0T4KgovoYfvUtXVsTNnyprvWYtaN1u0dWwIZ+zYw=
-github.com/danmestas/libfossil v0.4.3/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.4.5 h1:sDIcQCqp6cCOQgMaIGseRoopCD0mPYg2FRUrEV8P0HY=
+github.com/danmestas/libfossil v0.4.5/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=


### PR DESCRIPTION
## Summary
Bumps `github.com/danmestas/libfossil` from v0.4.3 → v0.4.5 across all three EdgeSync modules (root, leaf, bridge). No source changes — both fixes are libfossil-internal.

Closes #86.

## What this pulls in

- **v0.4.4** ([libfossil#14](https://github.com/danmestas/libfossil/issues/14)) — hub xfer handler no longer panics with `content.MakePublic: rid must be positive` when a client cancels mid-transfer.
- **v0.4.5** ([libfossil#17](https://github.com/danmestas/libfossil/issues/17), [libfossil#18](https://github.com/danmestas/libfossil/pull/18)) — `sync.Clone` now converges against a hub being concurrently written to. Three compounding root causes addressed:
  1. Server: snapshot `max(rid)` at session start, scope batch query (`rid > cursor AND rid <= cap`)
  2. Client: emit `CloneSeqNoCard` on continuation rounds (the actual pagination cursor server-side)
  3. Cookie roundtrip via existing `CookieCard` carrier (`lf-clone-cap:<rid>`)

  Wire-format compatible with older peers; no protocol break.

## Why this matters for EdgeSync
EdgeSync's leaf-side sync and any hub it serves both go through libfossil's clone/sync. Concurrent-leaf topologies (the bones swarm dispatch pattern, and any similar) will hit the v0.4.5-fixed convergence bug at scale; production observed ~7% of clones (2/30) failing with the round-cap error in a single dispatch wave.

## Test plan
- [x] `go vet ./...` (root + leaf + bridge)
- [x] `go test ./... -short -count=1` in leaf — passed
- [x] `go test ./... -short -count=1` in bridge — passed
- [x] `go build -buildvcs=false ./cmd/edgesync/`
- [x] `go test -buildvcs=false ./cmd/edgesync/ -count=1 -timeout=60s` — passed