### PR TITLE
docs: changelog entry for v0.0.7 + skip CI on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'wrangler.jsonc'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'wrangler.jsonc'
+      - 'LICENSE'
 
 env:
   GOWORK: "off"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,17 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'wrangler.jsonc'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'wrangler.jsonc'
+      - 'LICENSE'
 
 jobs:
   unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ EdgeSync uses multi-module versioning: the root module and the `leaf` and
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-04-30
+
+### Changed
+
+- Bumped `libfossil` dependency to v0.4.5. Pulls in fixes for hub xfer
+  handler panic on cancelled partial transfers ([libfossil#14], v0.4.4)
+  and `sync.Clone` convergence against a hub being concurrently written
+  to ([libfossil#17], v0.4.5). Wire-format compatible; no EdgeSync source
+  changes.
+
+[libfossil#14]: https://github.com/danmestas/libfossil/issues/14
+[libfossil#17]: https://github.com/danmestas/libfossil/issues/17
+
 ## [0.0.6] - 2026-04-26
 
 Latest pre-1.0 release. EdgeSync is alpha — see the README "Status" section


### PR DESCRIPTION
Two small things bundled (caught in flight when the original CHANGELOG-only PR fired the full CI matrix):

1. **Backfill `[0.0.7]` CHANGELOG entry** that release PR #87 missed. Matches the v0.0.6 entry shape.
2. **Add `paths-ignore` to `ci.yml` + `test.yml`** so docs-only PRs skip Go vet/build/tests. Patterns: `**.md`, `docs/**`, `wrangler.jsonc`, `LICENSE`.

Workflow file changes themselves are NOT in the ignore list, so editing `.github/workflows/*` still runs CI (this PR will run it once more for that reason).

Caveat: if `Tests` ever becomes a required status check in branch protection, skipped jobs block merge — would need a no-op fallback job. Not the case today; revisit if/when branch protection tightens.