### PR TITLE
feat(ci): receive libfossil dispatches, dispatch to bones, group changelog

### DIFF
--- a/.github/workflows/bump-upstream.yml
+++ b/.github/workflows/bump-upstream.yml
@@ -1,0 +1,152 @@
+name: Bump upstream
+on:
+  repository_dispatch:
+    types: [upstream-bump]
+  workflow_dispatch:
+    inputs:
+      repo:        { required: true,  type: string }
+      module_path: { required: true,  type: string }
+      version:     { required: true,  type: string }
+      release_url: { required: false, type: string }
+      tag_sha:     { required: false, type: string }
+      actor:       { required: false, type: string }
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_REPO: libfossil
+      EXPECTED_MODULE: github.com/danmestas/libfossil
+    steps:
+      - name: Resolve inputs
+        id: in
+        env:
+          PAYLOAD_REPO: ${{ github.event.client_payload.repo }}
+          PAYLOAD_MODULE: ${{ github.event.client_payload.module_path }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_RELEASE_URL: ${{ github.event.client_payload.release_url }}
+          PAYLOAD_TAG_SHA: ${{ github.event.client_payload.tag_sha }}
+          PAYLOAD_ACTOR: ${{ github.event.client_payload.actor }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_MODULE: ${{ inputs.module_path }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_URL: ${{ inputs.release_url }}
+          INPUT_TAG_SHA: ${{ inputs.tag_sha }}
+          INPUT_ACTOR: ${{ inputs.actor }}
+        run: |
+          REPO="${PAYLOAD_REPO:-$INPUT_REPO}"
+          MODULE_PATH="${PAYLOAD_MODULE:-$INPUT_MODULE}"
+          VERSION="${PAYLOAD_VERSION:-$INPUT_VERSION}"
+          RELEASE_URL="${PAYLOAD_RELEASE_URL:-$INPUT_RELEASE_URL}"
+          TAG_SHA="${PAYLOAD_TAG_SHA:-$INPUT_TAG_SHA}"
+          ACTOR="${PAYLOAD_ACTOR:-${INPUT_ACTOR:-${{ github.actor }}}}"
+
+          if [[ "$REPO" != "$EXPECTED_REPO" ]]; then
+            echo "::notice::Ignoring dispatch for repo=$REPO (expected $EXPECTED_REPO)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$MODULE_PATH" != "$EXPECTED_MODULE" ]]; then
+            echo "::error::module_path mismatch: got '$MODULE_PATH', expected '$EXPECTED_MODULE'"
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+            echo "::error::bad version: '$VERSION'"
+            exit 1
+          fi
+
+          {
+            echo "repo=$REPO"
+            echo "module=$MODULE_PATH"
+            echo "version=$VERSION"
+            echo "release_url=$RELEASE_URL"
+            echo "tag_sha=$TAG_SHA"
+            echo "actor=$ACTOR"
+            echo "branch=chore/bump-${REPO}-${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Idempotency check
+        if: steps.in.outputs.skip != 'true'
+        id: idem
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.in.outputs.branch }}
+        run: |
+          if gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number -q '.[0].number' | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::PR already open for $BRANCH; skipping"
+          fi
+
+      - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
+        name: Bump module
+        id: bump
+        env:
+          BRANCH: ${{ steps.in.outputs.branch }}
+          MODULE: ${{ steps.in.outputs.module }}
+          VERSION: ${{ steps.in.outputs.version }}
+        run: |
+          git switch -c "$BRANCH"
+          for i in 1 2 3; do
+            if go get "${MODULE}@${VERSION}"; then
+              break
+            fi
+            if [ "$i" -lt 3 ]; then
+              echo "::notice::go get failed (attempt $i/3) — likely GOPROXY propagation race; retrying in 15s..."
+              sleep 15
+            else
+              echo "::error::go get failed after 3 attempts"
+              exit 1
+            fi
+          done
+          go mod tidy
+          if git diff --quiet go.mod go.sum; then
+            echo "::notice::No-op bump — version already pinned"
+            echo "noop=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true' && steps.bump.outputs.noop != 'true'
+        name: Verify build
+        run: go build ./...
+
+      - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true' && steps.bump.outputs.noop != 'true'
+        name: Commit + push + open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.in.outputs.branch }}
+          REPO: ${{ steps.in.outputs.repo }}
+          VERSION: ${{ steps.in.outputs.version }}
+          MODULE: ${{ steps.in.outputs.module }}
+          RELEASE_URL: ${{ steps.in.outputs.release_url }}
+          TAG_SHA: ${{ steps.in.outputs.tag_sha }}
+          ACTOR: ${{ steps.in.outputs.actor }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add go.mod go.sum
+          git commit -m "chore: bump ${REPO} → ${VERSION}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: bump ${REPO} → ${VERSION}" \
+            --body "Auto-bump from upstream release.
+
+          - Module: \`${MODULE}\`
+          - Version: \`${VERSION}\`
+          - Upstream release: ${RELEASE_URL}
+          - Tag SHA: \`${TAG_SHA}\`
+          - Triggered by: @${ACTOR}
+
+          CI must pass before merge. Review go.sum diff for transitive surprises."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_PAT_TOKEN: ${{ secrets.HOMEBREW_PAT_TOKEN }}
+
+      - name: Dispatch downstream bump
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_PAT }}
+          DOWNSTREAM: bones
+          MODULE_PATH: github.com/danmestas/EdgeSync
+        run: |
+          gh api -X POST "repos/danmestas/${DOWNSTREAM}/dispatches" \
+            -f event_type=upstream-bump \
+            -f client_payload[repo]=${{ github.event.repository.name }} \
+            -f client_payload[module_path]=${MODULE_PATH} \
+            -f client_payload[version]=${{ github.ref_name }} \
+            -f client_payload[release_url]=${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }} \
+            -f client_payload[tag_sha]=${{ github.sha }} \
+            -f client_payload[actor]=${{ github.actor }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,15 +55,26 @@ snapshot:
 changelog:
   sort: asc
   use: github
+  groups:
+    - title: 'Features'
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: 'Bug fixes'
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: 'Other'
+      order: 999
   filters:
     exclude:
       - '^docs:'
       - '^chore:'
       - '^test:'
+      - '^ci:'
       - 'merge conflict'
-      - Merge pull request
-      - Merge remote-tracking branch
-      - Merge branch
+      - 'Merge PR'
+      - 'Merge pull request'
+      - 'Merge remote-tracking branch'
+      - 'Merge branch'
 
 release:
   github:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/bump-upstream.yml` — receiver listening for
  `repository_dispatch` events from libfossil's release workflow.
  Validates payload, retries `go get` up to 3 times for GOPROXY race,
  opens a chore PR via `github-actions[bot]`. Mirrors the production-
  tested shape from bones #90.
- Modify `.github/workflows/release.yml` — append `Dispatch downstream bump`
  step that fires `repository_dispatch` to `danmestas/bones` after
  goreleaser publishes a release. Uses `DISPATCH_PAT` secret (fine-grained,
  scoped to bones contents:write).
- Modify `.goreleaser.yml` — add `groups:` to changelog config so release
  notes are split into Features / Bug fixes / Other sections.

This closes the edgesync→bones link. Combined with PR #6 (adding
libfossil's release.yml), the full cascade goes live.

## Test plan
- [x] YAML validates (`yaml.safe_load`)
- [x] `goreleaser check` accepts the config (or trust GitHub-side validation)
- [ ] After merge: receiver smoke test via manual `gh api` fire
- [ ] After merge: full sender test by tagging `v0.0.8-rc1` and verifying bones receives a PR; close PR; delete rc tag

## Deploy notes
After merge, smoke-test the receiver:

```bash
gh api -X POST repos/danmestas/EdgeSync/dispatches \
  -f event_type=upstream-bump \
  -f client_payload[repo]=libfossil \
  -f client_payload[module_path]=github.com/danmestas/libfossil \
  -f client_payload[version]=v0.4.5 \
  -f client_payload[release_url]=https://github.com/danmestas/libfossil/releases/tag/v0.4.5 \
  -f client_payload[tag_sha]=$(gh api repos/danmestas/libfossil/git/refs/tags/v0.4.5 -q .object.sha) \
  -f client_payload[actor]=danmestas
```

Expected: noop (already pinned). Then test sender by tagging `v0.0.8-rc1`
and watching bones open a bump PR. Cleanup:

```bash
gh pr close --repo danmestas/bones $(gh pr list --repo danmestas/bones --head 'chore/bump-EdgeSync-v0.0.8-rc1' --json number -q '.[0].number') --delete-branch
git tag -d v0.0.8-rc1
git push origin --delete v0.0.8-rc1
gh release delete v0.0.8-rc1 --yes
```

Spec: see libfossil docs/superpowers/specs/2026-04-30-cross-repo-release-automation-design.md