### PR TITLE
fix(leaf): demote per-target sync errors when another target succeeded

### DIFF
--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -558,33 +558,18 @@ func (a *Agent) pollLoop(ctx context.Context) {
 			continue
 		}
 
-		// Iterate all sync targets uniformly.
+		// Run all sync targets, collect outcomes, then emit logs at
+		// the appropriate level. Per-target failures get demoted from
+		// ERROR to DEBUG when at least one other target succeeded —
+		// sync as a whole succeeded (e.g. round-0 NATS races where
+		// the HTTP target carries the real result), so isolated
+		// transport noise is not a user-actionable error.
+		outcomes := make([]syncOutcome, 0, len(a.syncTargets))
 		for _, target := range a.syncTargets {
 			result, err := a.repo.Sync(ctx, target.transport, a.buildSyncOpts())
-			if err != nil {
-				a.logf("sync error [%s]: %v", target.label, err)
-				slog.ErrorContext(ctx, "sync error", "target", target.label, "error", err)
-				continue
-			}
-			a.logf("sync done [%s]: ↑%d ↓%d rounds=%d", target.label, result.FilesSent, result.FilesRecvd, result.Rounds)
-			slog.DebugContext(ctx, "sync details",
-				"target", target.label,
-				"rounds", result.Rounds,
-				"files_sent", result.FilesSent,
-				"files_recv", result.FilesRecvd,
-				"bytes_sent", result.BytesSent,
-				"bytes_recv", result.BytesRecvd,
-				"uv_sent", result.UVFilesSent,
-				"uv_recv", result.UVFilesRecvd,
-				"errors", len(result.Errors),
-			)
-			for _, e := range result.Errors {
-				a.logf("sync warning [%s]: %s", target.label, e)
-			}
-			if a.config.PostSyncHook != nil {
-				a.config.PostSyncHook(result)
-			}
+			outcomes = append(outcomes, syncOutcome{target: target, result: result, err: err})
 		}
+		a.emitSyncOutcomes(ctx, outcomes)
 
 		// Update peer registry once per poll cycle.
 		if err := a.updatePeerRegistryAfterSync(); err != nil {

--- a/leaf/agent/sync_outcomes.go
+++ b/leaf/agent/sync_outcomes.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// syncOutcome carries the result of a single per-target sync attempt
+// inside one poll cycle. Either result or err is set (never both).
+type syncOutcome struct {
+	target syncTarget
+	result *libfossil.SyncResult
+	err    error
+}
+
+// emitSyncOutcomes logs the per-target outcomes from one poll cycle
+// and invokes PostSyncHook on every successful outcome.
+//
+// Failed outcomes log at ERROR when no target in this cycle succeeded
+// (sync as a whole failed; operator action likely needed). When at
+// least one target succeeded, failed outcomes log at DEBUG instead —
+// sync as a whole succeeded, isolated transport-level noise (e.g.
+// the round-0 NATS subject-interest race) shouldn't trip alerting.
+//
+// The legacy `a.logf("sync error [%s]: %v", ...)` callback fires
+// regardless of slog level so harness-supplied loggers stay
+// informed without slog depending on them.
+func (a *Agent) emitSyncOutcomes(ctx context.Context, outcomes []syncOutcome) {
+	anySuccess := false
+	for _, o := range outcomes {
+		if o.err == nil {
+			anySuccess = true
+			break
+		}
+	}
+	failedLevel := slog.LevelError
+	if anySuccess {
+		failedLevel = slog.LevelDebug
+	}
+
+	for _, o := range outcomes {
+		if o.err != nil {
+			a.logf("sync error [%s]: %v", o.target.label, o.err)
+			slog.LogAttrs(ctx, failedLevel, "sync error",
+				slog.String("target", o.target.label),
+				slog.Any("error", o.err),
+			)
+			continue
+		}
+		a.logf("sync done [%s]: ↑%d ↓%d rounds=%d",
+			o.target.label, o.result.FilesSent, o.result.FilesRecvd, o.result.Rounds)
+		slog.DebugContext(ctx, "sync details",
+			"target", o.target.label,
+			"rounds", o.result.Rounds,
+			"files_sent", o.result.FilesSent,
+			"files_recv", o.result.FilesRecvd,
+			"bytes_sent", o.result.BytesSent,
+			"bytes_recv", o.result.BytesRecvd,
+			"uv_sent", o.result.UVFilesSent,
+			"uv_recv", o.result.UVFilesRecvd,
+			"errors", len(o.result.Errors),
+		)
+		for _, e := range o.result.Errors {
+			a.logf("sync warning [%s]: %s", o.target.label, e)
+		}
+		if a.config.PostSyncHook != nil {
+			a.config.PostSyncHook(o.result)
+		}
+	}
+}

--- a/leaf/agent/sync_outcomes_test.go
+++ b/leaf/agent/sync_outcomes_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	libfossil "github.com/danmestas/libfossil"
+	"github.com/nats-io/nats.go"
+)
+
+// TestEmitSyncOutcomes_DemotesWhenAnotherTargetSucceeds pins the
+// fix for danmestas/EdgeSync#96 / danmestas/bones#118: when the
+// per-target sync loop has at least one successful target, failures
+// from sibling targets must NOT log at ERROR level. Sync as a whole
+// succeeded; isolated transport failures (e.g. round-0 NATS
+// "no responders" race) are at most warnings, not errors.
+func TestEmitSyncOutcomes_DemotesWhenAnotherTargetSucceeds(t *testing.T) {
+	buf := captureSlog(t)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, err: nats.ErrNoResponders},
+		{target: syncTarget{label: "http"}, result: &libfossil.SyncResult{Rounds: 1}},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if strings.Contains(out, `level=ERROR msg="sync error"`) {
+		t.Errorf("expected no ERROR-level sync error when another target succeeded, got:\n%s", out)
+	}
+	if !strings.Contains(out, "target=nats") {
+		t.Errorf("expected the nats failure to still be logged (at lower level), got:\n%s", out)
+	}
+}
+
+// TestEmitSyncOutcomes_PromotesWhenAllFail pins the inverse: if no
+// target succeeded, the failures retain ERROR level so operators
+// (and alerting) still see a real problem.
+func TestEmitSyncOutcomes_PromotesWhenAllFail(t *testing.T) {
+	buf := captureSlog(t)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, err: nats.ErrNoResponders},
+		{target: syncTarget{label: "http"}, err: errors.New("connection refused")},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if !strings.Contains(out, `level=ERROR msg="sync error" target=nats`) {
+		t.Errorf("expected ERROR-level nats sync error when no target succeeded, got:\n%s", out)
+	}
+	if !strings.Contains(out, `level=ERROR msg="sync error" target=http`) {
+		t.Errorf("expected ERROR-level http sync error when no target succeeded, got:\n%s", out)
+	}
+}
+
+// TestEmitSyncOutcomes_AllSuccessNoErrors pins that a fully-clean
+// poll cycle emits no error or warning records at all.
+func TestEmitSyncOutcomes_AllSuccessNoErrors(t *testing.T) {
+	buf := captureSlog(t)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, result: &libfossil.SyncResult{Rounds: 1}},
+		{target: syncTarget{label: "http"}, result: &libfossil.SyncResult{Rounds: 1}},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if strings.Contains(out, `msg="sync error"`) {
+		t.Errorf("expected no sync error records on fully-successful cycle, got:\n%s", out)
+	}
+}
+
+// captureSlog redirects slog.Default() to a bytes.Buffer at Debug
+// level for the duration of the test, restoring the prior default
+// in t.Cleanup. Returns the buffer for assertion.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}


### PR DESCRIPTION
## Summary
- `Agent.pollLoop`'s per-target sync loop refactored to collect outcomes first, then emit logs at the appropriate level
- Failed-target log records demote to `DEBUG` when at least one other target in the same poll cycle succeeded — sync as a whole succeeded, isolated transport failures (e.g. round-0 NATS subject-interest race) are not user-actionable errors
- `ERROR` level still applies when no target succeeded — operators / alerting still see real failures
- Successful-outcome logging unchanged; `PostSyncHook` still fires per success; harness-supplied `logf` callback fires for every outcome regardless of slog level
- New `emitSyncOutcomes` + `syncOutcome` extracted into `leaf/agent/sync_outcomes.go` for clarity and testability

## Motivation
Downstream `bones swarm commit` was emitting an `ERROR target=nats error="…no responders available"` line on every successful commit, even though the HTTP sync target succeeded in the same loop. Filed as #96; this is the upstream fix. bones is shipping a `slog.Handler` workaround that can be deleted once this lands and bones bumps the `leaf` dep.

## Test plan
- [x] `TestEmitSyncOutcomes_DemotesWhenAnotherTargetSucceeds` — nats fails, http succeeds → no ERROR record, nats failure still logged at lower level
- [x] `TestEmitSyncOutcomes_PromotesWhenAllFail` — both fail → both at ERROR
- [x] `TestEmitSyncOutcomes_AllSuccessNoErrors` — both succeed → no error records
- [x] All existing leaf tests pass (`cd leaf && go test -short -count=1 ./...`)
- [x] `go vet` clean for root, leaf, bridge

Closes #96