### PR TITLE
fix(leaf): classify ErrNoResponders and ctx.Canceled as benign sync errors

### DIFF
--- a/leaf/agent/sync_outcomes.go
+++ b/leaf/agent/sync_outcomes.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	libfossil "github.com/danmestas/libfossil"
+	"github.com/nats-io/nats.go"
 )
 
 // syncOutcome carries the result of a single per-target sync attempt
@@ -21,8 +23,15 @@ type syncOutcome struct {
 // Failed outcomes log at ERROR when no target in this cycle succeeded
 // (sync as a whole failed; operator action likely needed). When at
 // least one target succeeded, failed outcomes log at DEBUG instead —
-// sync as a whole succeeded, isolated transport-level noise (e.g.
-// the round-0 NATS subject-interest race) shouldn't trip alerting.
+// sync as a whole succeeded, isolated transport-level noise shouldn't
+// trip alerting.
+//
+// Independently, errors classified as benign by isBenignSyncError
+// (today: nats.ErrNoResponders, context.Canceled) log at DEBUG
+// regardless of whether other targets succeeded. ErrNoResponders is
+// the round-0 subject-interest race, expected at every cold-start;
+// context.Canceled is the agent-shutdown teardown artifact. Neither
+// is user-actionable.
 //
 // The legacy `a.logf("sync error [%s]: %v", ...)` callback fires
 // regardless of slog level so harness-supplied loggers stay
@@ -35,15 +44,15 @@ func (a *Agent) emitSyncOutcomes(ctx context.Context, outcomes []syncOutcome) {
 			break
 		}
 	}
-	failedLevel := slog.LevelError
-	if anySuccess {
-		failedLevel = slog.LevelDebug
-	}
 
 	for _, o := range outcomes {
 		if o.err != nil {
 			a.logf("sync error [%s]: %v", o.target.label, o.err)
-			slog.LogAttrs(ctx, failedLevel, "sync error",
+			level := slog.LevelError
+			if anySuccess || isBenignSyncError(o.err) {
+				level = slog.LevelDebug
+			}
+			slog.LogAttrs(ctx, level, "sync error",
 				slog.String("target", o.target.label),
 				slog.Any("error", o.err),
 			)
@@ -69,4 +78,30 @@ func (a *Agent) emitSyncOutcomes(ctx context.Context, outcomes []syncOutcome) {
 			a.config.PostSyncHook(o.result)
 		}
 	}
+}
+
+// isBenignSyncError reports whether a sync error is known to be
+// non-actionable and should always log at DEBUG, even if it is the
+// only error in the cycle. Today's classifications:
+//
+//   - nats.ErrNoResponders: round-0 NATS request fired before the
+//     hub's serve-nats subscriber finished propagating its
+//     subject-interest through the leaf-node mesh. Expected on every
+//     cold-start; the next round resolves.
+//   - context.Canceled: agent shutdown interrupted an in-flight sync.
+//     The operator chose to stop; the in-flight result is moot.
+//
+// Both classifications are matched via errors.Is so wrapped errors
+// from libfossil's transport layer are caught.
+func isBenignSyncError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, nats.ErrNoResponders) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	return false
 }

--- a/leaf/agent/sync_outcomes_test.go
+++ b/leaf/agent/sync_outcomes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -37,15 +38,16 @@ func TestEmitSyncOutcomes_DemotesWhenAnotherTargetSucceeds(t *testing.T) {
 	}
 }
 
-// TestEmitSyncOutcomes_PromotesWhenAllFail pins the inverse: if no
-// target succeeded, the failures retain ERROR level so operators
-// (and alerting) still see a real problem.
+// TestEmitSyncOutcomes_PromotesWhenAllFail pins the inverse of the
+// "another target succeeded" rule: if no target succeeded AND the
+// failures aren't benign-classified, ERROR level is retained so
+// operators (and alerting) still see a real problem.
 func TestEmitSyncOutcomes_PromotesWhenAllFail(t *testing.T) {
 	buf := captureSlog(t)
 
 	a := &Agent{config: Config{}}
 	outcomes := []syncOutcome{
-		{target: syncTarget{label: "nats"}, err: nats.ErrNoResponders},
+		{target: syncTarget{label: "nats"}, err: errors.New("authentication failed")},
 		{target: syncTarget{label: "http"}, err: errors.New("connection refused")},
 	}
 	a.emitSyncOutcomes(context.Background(), outcomes)
@@ -56,6 +58,69 @@ func TestEmitSyncOutcomes_PromotesWhenAllFail(t *testing.T) {
 	}
 	if !strings.Contains(out, `level=ERROR msg="sync error" target=http`) {
 		t.Errorf("expected ERROR-level http sync error when no target succeeded, got:\n%s", out)
+	}
+}
+
+// TestEmitSyncOutcomes_DemotesNoRespondersWhenSoleTarget pins that
+// a single-syncTarget agent (the bones swarm leaf shape — only
+// "nats" is registered; HTTP push is bones' separate concern) does
+// not emit ERROR for the round-0 nats.ErrNoResponders race. The
+// "demote when another target succeeded" rule cannot help when
+// there are no other targets; benign-classification handles it.
+func TestEmitSyncOutcomes_DemotesNoRespondersWhenSoleTarget(t *testing.T) {
+	buf := captureSlog(t)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, err: nats.ErrNoResponders},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if strings.Contains(out, `level=ERROR msg="sync error"`) {
+		t.Errorf("expected no ERROR for sole-target ErrNoResponders, got:\n%s", out)
+	}
+	if !strings.Contains(out, "target=nats") {
+		t.Errorf("expected the nats failure logged at lower level, got:\n%s", out)
+	}
+}
+
+// TestEmitSyncOutcomes_DemotesContextCanceled pins the same shape
+// for context.Canceled — when the agent is being shut down and an
+// in-flight sync's ctx is canceled, the resulting "sync error" is
+// a teardown artifact, not user-actionable.
+func TestEmitSyncOutcomes_DemotesContextCanceled(t *testing.T) {
+	buf := captureSlog(t)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, err: context.Canceled},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if strings.Contains(out, `level=ERROR msg="sync error"`) {
+		t.Errorf("expected no ERROR for context.Canceled, got:\n%s", out)
+	}
+}
+
+// TestEmitSyncOutcomes_DemotesWrappedNoResponders ensures wrapped
+// sentinels (libfossil's "sync: exchange round 0: <wrapped>" shape)
+// are still recognized as benign via errors.Is.
+func TestEmitSyncOutcomes_DemotesWrappedNoResponders(t *testing.T) {
+	buf := captureSlog(t)
+
+	wrapped := fmt.Errorf("libfossil: sync: exchange round 0: %w", nats.ErrNoResponders)
+
+	a := &Agent{config: Config{}}
+	outcomes := []syncOutcome{
+		{target: syncTarget{label: "nats"}, err: wrapped},
+	}
+	a.emitSyncOutcomes(context.Background(), outcomes)
+
+	out := buf.String()
+	if strings.Contains(out, `level=ERROR msg="sync error"`) {
+		t.Errorf("expected no ERROR for wrapped ErrNoResponders, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `isBenignSyncError(err)` to `leaf/agent/sync_outcomes.go`. Today's classifications: `nats.ErrNoResponders` (round-0 NATS subject-interest race, expected at every cold-start) and `context.Canceled` (agent-shutdown teardown artifact).
- `emitSyncOutcomes` now demotes failed-target log records to `DEBUG` when `anySuccess || isBenignSyncError(err)`. Composes with the existing #97 demotion: multi-syncTarget agents still benefit from "another succeeded" demotion; single-syncTarget agents get the benign-classification.
- Updates `TestEmitSyncOutcomes_PromotesWhenAllFail` to use a non-benign NATS error (`"authentication failed"`) so the all-fail-promote-to-ERROR contract still pins.

## Why a follow-up to #97
The v0.0.4 fix only fired when at least one sibling syncTarget succeeded. Agents that register only NATS as a syncTarget (e.g. the bones swarm leaf — bones runs HTTP push as a separate code path, not as an EdgeSync target) didn't get the demotion. Round-0 races on those agents kept logging ERROR. Filed as #98.

## Test plan
- [x] New `TestEmitSyncOutcomes_DemotesNoRespondersWhenSoleTarget` — single-target agent with `nats.ErrNoResponders` → DEBUG (the bones swarm shape)
- [x] New `TestEmitSyncOutcomes_DemotesContextCanceled` — `context.Canceled` → DEBUG
- [x] New `TestEmitSyncOutcomes_DemotesWrappedNoResponders` — wrapped sentinels via `errors.Is` → DEBUG
- [x] Updated `TestEmitSyncOutcomes_PromotesWhenAllFail` — non-benign errors still ERROR when no target succeeded
- [x] Existing `TestEmitSyncOutcomes_DemotesWhenAnotherTargetSucceeds`, `TestEmitSyncOutcomes_AllSuccessNoErrors` still pass
- [x] All existing leaf tests pass
- [x] `go vet` clean for root, leaf, bridge

Closes #98