### PR TITLE
fix(leaf/notify): mutex-gate Watch teardown to prevent send-on-closed-channel panic

### DIFF
--- a/leaf/agent/notify/notify.go
+++ b/leaf/agent/notify/notify.go
@@ -121,12 +121,16 @@ type WatchOpts struct {
 
 // Watch returns a channel of messages, closed when ctx is cancelled.
 //
-// Teardown order is subscription-first, channel-close-second: when ctx
-// cancels the close goroutine Unsubscribes from NATS before close(ch),
-// so no late-arriving callback can race the close and panic on a
-// closed channel. Without this ordering, a message arriving between
-// ctx.Done and the channel-close window would trigger a send on a
-// closed channel.
+// Teardown is mutex-gated: every callback dispatch holds `mu` while
+// it does its select, and the close goroutine takes `mu` before
+// `close(ch)`. Neither Unsubscribe nor Drain synchronizes with NATS'
+// per-subscription dispatch goroutine — both can return while a
+// callback is mid-select. Without the mutex, a callback that already
+// committed to `case ch <- msg` would race the close and panic on a
+// closed channel (#100). The `closed` flag keeps callbacks scheduled
+// after teardown from re-entering the select once ch is closed; in
+// practice Unsubscribe stops most of them, the mutex and flag handle
+// the residual.
 func (s *Service) Watch(ctx context.Context, opts WatchOpts) <-chan Message {
 	ch := make(chan Message, 16)
 
@@ -142,7 +146,17 @@ func (s *Service) Watch(ctx context.Context, opts WatchOpts) <-chan Message {
 		subject += ".*"
 	}
 
+	var (
+		mu     sync.Mutex
+		closed bool
+	)
+
 	natsSub, subErr := s.sub.subscribeForWatch(subject, func(msg Message) {
+		mu.Lock()
+		defer mu.Unlock()
+		if closed {
+			return
+		}
 		select {
 		case ch <- msg:
 		case <-ctx.Done():
@@ -157,7 +171,10 @@ func (s *Service) Watch(ctx context.Context, opts WatchOpts) <-chan Message {
 	go func() {
 		<-ctx.Done()
 		_ = natsSub.Unsubscribe()
+		mu.Lock()
+		closed = true
 		close(ch)
+		mu.Unlock()
 	}()
 
 	return ch

--- a/leaf/agent/notify/watch_drain_test.go
+++ b/leaf/agent/notify/watch_drain_test.go
@@ -1,0 +1,68 @@
+package notify
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestServiceWatch_NoPanicOnCancelWithInFlightMessages stress-tests
+// the Watch teardown path for the race fixed by closing channels
+// only after the underlying NATS subscription has drained its
+// pending callbacks. Before the fix, an in-flight callback that
+// passed through `case <-ctx.Done()` and entered `case ch <- msg`
+// could race with `close(ch)` and panic with "send on closed
+// channel" (danmestas/EdgeSync#100).
+//
+// The race is timing-dependent so this is run under repeated
+// iteration with a tight cancel window. If it ever panics the
+// whole test process dies, which is exactly the regression we
+// are pinning out.
+func TestServiceWatch_NoPanicOnCancelWithInFlightMessages(t *testing.T) {
+	ts := newTestService(t)
+
+	const iterations = 25
+	const sendsPerIter = 8
+
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		ch := ts.svc.Watch(ctx, WatchOpts{Project: "stress"})
+
+		// Drain the channel concurrently so the buffered chan
+		// doesn't backpressure the callback into the ctx.Done
+		// branch. We want the race window — callback in
+		// `case ch <- msg:` while teardown closes ch.
+		drainDone := make(chan struct{})
+		go func() {
+			defer close(drainDone)
+			for range ch {
+			}
+		}()
+
+		// Fire several sends. Each commits to the repo and
+		// publishes via NATS; the watcher's callback receives
+		// each one.
+		var sendWG sync.WaitGroup
+		for j := 0; j < sendsPerIter; j++ {
+			sendWG.Add(1)
+			go func() {
+				defer sendWG.Done()
+				_, _ = ts.svc.Send(SendOpts{Project: "stress", Body: "x"})
+			}()
+		}
+
+		// Tight cancel window — sometimes before sends complete,
+		// sometimes during, sometimes after. The variance is the
+		// point: we want the race to fire across iterations.
+		time.Sleep(time.Duration(i%4) * time.Millisecond)
+		cancel()
+
+		// Wait for the channel to close and the consumer goroutine
+		// to exit. If a panic fires in the NATS callback it will
+		// crash the process; reaching this point means the iteration
+		// didn't panic.
+		<-drainDone
+		sendWG.Wait()
+	}
+}


### PR DESCRIPTION
## Summary
- `Service.Watch`'s NATS callback enters `select { case ch <- msg: case <-ctx.Done() }`. When ctx cancels concurrently with a callback dispatch by NATS' `waitForMsgs` goroutine, both cases can be ready and Go's select picks randomly. If it picks the send and `close(ch)` lands first, the send panics on a closed channel (#100)
- **Drain doesn't help.** Local stress-test reproduced the panic with `Drain` in place — neither `Unsubscribe` nor `Drain` synchronizes with NATS' per-subscription dispatch goroutine (both can return while a callback is mid-select)
- **The fix is mutex-gated.** Every callback dispatch holds `mu` while doing its select; a `closed` flag short-circuits new sends after teardown; the close goroutine takes the same `mu` before `close(ch)`, so the close cannot interleave with an in-flight send

## Test plan
- [x] New `TestServiceWatch_NoPanicOnCancelWithInFlightMessages` — 25 iterations × 8 concurrent sends + tight cancel windows
- [x] Reliably reproduced the panic before the fix (pre-commit hook caught it on first push attempt with a Drain-only fix)
- [x] Passes 20 iterations clean under \`-race\` after the fix
- [x] All existing leaf tests pass
- [x] \`go vet\` clean for root, leaf, bridge

## Original failure trace (downstream danmestas/bones#125 CI)
\`\`\`
panic: send on closed channel
goroutine 8008 [running]:
github.com/danmestas/EdgeSync/leaf/agent/notify.(*Service).Watch.func1(...)
    .../leaf/agent/notify/notify.go:146 +0xd0
github.com/danmestas/EdgeSync/leaf/agent/notify.(*Subscriber).subscribeReturn.func1(...)
    .../leaf/agent/notify/pubsub.go:147 +0x108
github.com/nats-io/nats.go.(*Conn).waitForMsgs(...)
\`\`\`

Closes #100