### PR TITLE
chore(agents): scaffold ## Agent skills + docs/agents/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,20 @@ cd ~/EdgeSync && git pull && cd deploy && sudo docker compose up -d --build
 - `mlink` — file mappings per checkin
 - `unversioned` — mutable UV files (name, mtime, hash, sz, encoding, content)
 
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues on `danmestas/EdgeSync` (use the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` — plus `bug`/`enhancement`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout. ADRs live in `docs/architecture/` (not `docs/adr/`); no `CONTEXT.md` — fall back to `CLAUDE.md` + `MEMORY.md`. See `docs/agents/domain.md`.
+
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,57 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+Single-context repo. ADRs (architectural decision records) live in `docs/architecture/` rather than `docs/adr/`:
+
+```
+/
+├── CLAUDE.md                      ← project instructions
+├── MEMORY.md                      ← cross-session project memory
+├── docs/
+│   ├── architecture/              ← condensed ADRs (read these first)
+│   │   ├── core-library.md
+│   │   ├── sync-protocol.md
+│   │   ├── agent-deployment.md
+│   │   ├── checkout-merge.md
+│   │   ├── repo-operations.md
+│   │   ├── testing-strategy.md
+│   │   ├── notify-messaging.md
+│   │   └── wasm-targets.md
+│   └── superpowers/specs/         ← design specs for in-flight features
+└── src/
+```
+
+There is no `CONTEXT.md` glossary yet. The closest equivalents are `CLAUDE.md` (architecture overview, conventions) and `MEMORY.md` (decisions, in-flight projects, user preferences). When a skill asks for `CONTEXT.md`, fall back to those.
+
+## Before exploring, read these
+
+- **`CLAUDE.md`** at the repo root — architecture, conventions, build/test commands.
+- **`MEMORY.md`** at the repo root — recent decisions and project state.
+- **`docs/architecture/*.md`** — read the ADR(s) covering the area you're about to work in.
+- **`docs/superpowers/specs/`** — design specs for in-flight features.
+
+If a relevant ADR doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating one upfront.
+
+## Use the project's vocabulary
+
+When naming domain concepts (in issue titles, refactor proposals, hypotheses, test names), use the terms defined in `CLAUDE.md` and the ADRs. Don't drift to synonyms.
+
+Examples of canonical terms:
+- "leaf agent" not "node" or "client daemon"
+- "bridge" not "gateway" or "proxy" (specifically: NATS↔HTTP/xfer translator)
+- "xfer cards" not "sync messages"
+- "libfossil" — the external Go module (`github.com/danmestas/libfossil`)
+- "notify" — the bidirectional messaging subsystem, distinct from "sync"
+- "DST" — deterministic simulation testing (in `dst/`)
+- "BUGGIFY" — the FoundationDB-style fault-injection pattern
+
+If the concept you need isn't established yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (flag it).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR in `docs/architecture/`, surface it explicitly rather than silently overriding:
+
+> _Contradicts `docs/architecture/sync-protocol.md` — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `danmestas/EdgeSync`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,20 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role     | Label in our tracker | Meaning                                  |
+| ------------------ | -------------------- | ---------------------------------------- |
+| `needs-triage`     | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`       | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`  | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`  | `ready-for-human`    | Requires human implementation            |
+| `wontfix`          | `wontfix`            | Will not be actioned                     |
+
+Category roles:
+
+| Canonical role | Label in our tracker |
+| -------------- | -------------------- |
+| `bug`          | `bug`                |
+| `enhancement`  | `enhancement`        |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.


### PR DESCRIPTION
## Summary

- Add an `## Agent skills` section to `CLAUDE.md` and three companion docs under `docs/agents/` so the engineering skills (`triage`, `to-issues`, `to-prd`, `diagnose`, `tdd`, `improve-codebase-architecture`) know how to consume this repo: issue tracker (GitHub via `gh`), triage label vocabulary (canonical names), and domain-doc layout (single-context; ADRs live in `docs/architecture/`).
- Repo-side: created the four missing triage labels on GitHub (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`); `bug`, `enhancement`, `wontfix` already existed.

No code changes — pure docs + manifest.

## Test plan

- [x] `make test` (CI hook) green at commit time
- [ ] Confirm CI green