### PR TITLE
feat(leaf/agent): libfossil-hidden code-artifact API (#103)

### DIFF
--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -89,6 +89,7 @@ func New(cfg Config) (*Agent, error) {
 	if err != nil {
 		return nil, fmt.Errorf("agent: open repo: %w", err)
 	}
+	applySQLiteTuning(r)
 
 	projectCode, err := r.Config("project-code")
 	if err != nil {
@@ -178,7 +179,13 @@ func (a *Agent) logf(format string, args ...any) {
 	}
 }
 
-// Repo returns the agent's Fossil repository (for invariant checking in simulation).
+// Repo returns the underlying libfossil handle for the agent's repository.
+//
+// Production code should prefer the libfossil-hidden code-artifact methods
+// (Commit, Sync, SyncTo, Read, Files, Diff, Tip, ExtractTo, Config) which
+// don't leak libfossil types into the consumer's import graph. Repo() stays
+// available for sim/test harnesses and for advanced callers that need
+// libfossil features the agent surface doesn't yet cover.
 func (a *Agent) Repo() *libfossil.Repo {
 	return a.repo
 }
@@ -492,7 +499,11 @@ func (a *Agent) Stop() error {
 // NotifyService returns the notify messaging service, or nil if notify is not enabled.
 func (a *Agent) NotifyService() *notify.Service { return a.notifySvc }
 
-// NotifyRepo returns the notify repository, or nil if notify is not enabled.
+// NotifyRepo returns the underlying libfossil handle for the notify
+// repository, or nil if notify is not enabled.
+//
+// Production code should prefer notify.Service methods. NotifyRepo() stays
+// available for sim/test harnesses and advanced callers.
 func (a *Agent) NotifyRepo() *libfossil.Repo { return a.notifyRepo }
 
 // IrohEndpointID returns the local iroh endpoint ID, or "" if iroh is not enabled

--- a/leaf/agent/code_artifact.go
+++ b/leaf/agent/code_artifact.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// RevID is an opaque commit handle. Treat as opaque; do not parse.
+type RevID string
+
+// FileToCommit names a file and its content for inclusion in a commit.
+type FileToCommit struct {
+	Name    string
+	Content []byte
+}
+
+// CommitOpts configures Agent.Commit.
+type CommitOpts struct {
+	Files   []FileToCommit
+	Message string
+	Author  string // fossil user; required
+}
+
+// SyncOpts configures Agent.SyncTo.
+type SyncOpts struct {
+	Push        bool
+	Pull        bool
+	User        string
+	Password    string
+	ProjectCode string // optional; auto-derived from agent's repo if empty
+}
+
+// SyncResult summarizes a sync session.
+type SyncResult struct {
+	Pushed   int
+	Pulled   int
+	Forked   bool
+	BranchID string // local fork tip's UUID; empty if no fork
+}
+
+// Commit commits a set of files to the agent's repo with the given message
+// and author. Returns the new manifest UUID as an opaque RevID.
+func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
+	if opts.Author == "" {
+		return "", errors.New("agent: Commit: Author is required")
+	}
+	files := make([]libfossil.FileToCommit, len(opts.Files))
+	for i, f := range opts.Files {
+		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
+	}
+	_, uuid, err := a.repo.Commit(libfossil.CommitOpts{
+		Files:   files,
+		Comment: opts.Message,
+		User:    opts.Author,
+	})
+	if err != nil {
+		return "", fmt.Errorf("agent: commit: %w", err)
+	}
+	return RevID(uuid), nil
+}
+
+// Sync runs one sync round against the agent's configured upstream/transport.
+// Returns nil result if no transport is configured.
+func (a *Agent) Sync(ctx context.Context) (*SyncResult, error) {
+	if a.transport == nil {
+		return nil, errors.New("agent: Sync: no transport configured")
+	}
+	res, err := a.repo.Sync(ctx, a.transport, a.buildSyncOpts())
+	if err != nil {
+		return nil, fmt.Errorf("agent: sync: %w", err)
+	}
+	return a.toSyncResult(res), nil
+}
+
+// SyncTo runs one sync round against an explicit hub URL. The transport is
+// constructed internally; callers do not see libfossil.Transport.
+func (a *Agent) SyncTo(ctx context.Context, hubURL string, opts SyncOpts) (*SyncResult, error) {
+	if hubURL == "" {
+		return nil, errors.New("agent: SyncTo: hubURL is required")
+	}
+	transport := libfossil.NewHTTPTransport(hubURL)
+	projectCode := opts.ProjectCode
+	if projectCode == "" {
+		projectCode = a.projectCode
+	}
+	res, err := a.repo.Sync(ctx, transport, libfossil.SyncOpts{
+		Push:        opts.Push,
+		Pull:        opts.Pull,
+		ProjectCode: projectCode,
+		User:        opts.User,
+		Password:    opts.Password,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent: syncTo %s: %w", hubURL, err)
+	}
+	return a.toSyncResult(res), nil
+}
+
+// Read returns the contents of path at the current trunk tip.
+func (a *Agent) Read(ctx context.Context, path string) ([]byte, error) {
+	return a.repo.ReadFileAt("trunk", path)
+}
+
+// Files lists the file names at the current trunk tip. An empty repo (no
+// checkins on trunk) returns (nil, nil).
+func (a *Agent) Files(ctx context.Context) ([]string, error) {
+	rid, err := a.repo.BranchTip("trunk")
+	if err != nil {
+		return nil, fmt.Errorf("agent: files: %w", err)
+	}
+	if rid == 0 {
+		return nil, nil
+	}
+	entries, err := a.repo.ListFiles(rid)
+	if err != nil {
+		return nil, fmt.Errorf("agent: files: %w", err)
+	}
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name
+	}
+	return names, nil
+}
+
+// Diff returns the unified diff between revA and revB, concatenated across
+// all changed files. Either rev may be a branch name, tag, or RevID.
+func (a *Agent) Diff(ctx context.Context, revA, revB RevID) ([]byte, error) {
+	ridA, err := a.repo.ResolveVersion(string(revA))
+	if err != nil {
+		return nil, fmt.Errorf("agent: diff: resolve %q: %w", revA, err)
+	}
+	ridB, err := a.repo.ResolveVersion(string(revB))
+	if err != nil {
+		return nil, fmt.Errorf("agent: diff: resolve %q: %w", revB, err)
+	}
+	filesA, err := a.repo.ListFiles(ridA)
+	if err != nil {
+		return nil, fmt.Errorf("agent: diff: list files at %q: %w", revA, err)
+	}
+	filesB, err := a.repo.ListFiles(ridB)
+	if err != nil {
+		return nil, fmt.Errorf("agent: diff: list files at %q: %w", revB, err)
+	}
+	uuidByName := make(map[string]string, len(filesA)+len(filesB))
+	for _, f := range filesA {
+		uuidByName[f.Name] = f.UUID
+	}
+	names := make([]string, 0, len(uuidByName)+len(filesB))
+	seen := make(map[string]bool, len(uuidByName)+len(filesB))
+	for _, f := range filesA {
+		if !seen[f.Name] {
+			names = append(names, f.Name)
+			seen[f.Name] = true
+		}
+	}
+	for _, f := range filesB {
+		if changed := uuidByName[f.Name] != f.UUID; changed && !seen[f.Name] {
+			names = append(names, f.Name)
+			seen[f.Name] = true
+		}
+	}
+	var out strings.Builder
+	for _, name := range names {
+		entries, derr := a.repo.Diff(ridA, ridB, name)
+		if derr != nil {
+			return nil, fmt.Errorf("agent: diff %q: %w", name, derr)
+		}
+		for _, e := range entries {
+			out.WriteString(e.Unified)
+		}
+	}
+	return []byte(out.String()), nil
+}
+
+// Tip returns the manifest UUID at the tip of the named branch. An unknown
+// or empty branch (no checkins) returns "" with nil error; an error
+// indicates a substrate fault, not an empty branch.
+func (a *Agent) Tip(ctx context.Context, branch string) (RevID, error) {
+	rid, err := a.repo.BranchTip(branch)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "no rows in result set") {
+			return "", nil
+		}
+		return "", fmt.Errorf("agent: tip %q: %w", branch, err)
+	}
+	if rid == 0 {
+		return "", nil
+	}
+	uuid, err := ridToUUID(a.repo, rid)
+	if err != nil {
+		return "", fmt.Errorf("agent: tip %q: %w", branch, err)
+	}
+	return RevID(uuid), nil
+}
+
+// ExtractTo populates dir with the files at rev. dir must already exist.
+// rev may be a branch name, tag, or RevID returned from Commit. Empty rev
+// is a no-op.
+func (a *Agent) ExtractTo(ctx context.Context, dir string, rev RevID) error {
+	if rev == "" {
+		return nil
+	}
+	rid, err := a.repo.ResolveVersion(string(rev))
+	if err != nil {
+		return fmt.Errorf("agent: extractTo %q: resolve %q: %w", dir, rev, err)
+	}
+	co, err := a.repo.CreateCheckout(dir, libfossil.CheckoutCreateOpts{})
+	if err != nil {
+		return fmt.Errorf("agent: extractTo %q: create checkout: %w", dir, err)
+	}
+	defer co.Close()
+	if err := co.Extract(rid, libfossil.ExtractOpts{}); err != nil {
+		return fmt.Errorf("agent: extractTo %q: extract: %w", dir, err)
+	}
+	return nil
+}
+
+// Config reads a fossil config value (e.g. "project-code").
+func (a *Agent) Config(key string) (string, error) {
+	return a.repo.Config(key)
+}
+
+func (a *Agent) toSyncResult(r *libfossil.SyncResult) *SyncResult {
+	out := &SyncResult{}
+	if r != nil {
+		out.Pushed = r.FilesSent
+		out.Pulled = r.FilesRecvd
+	}
+	if forks, err := a.repo.DetectForks(); err == nil && len(forks) > 0 {
+		out.Forked = true
+		if uuid, uerr := ridToUUID(a.repo, forks[0].LocalTip); uerr == nil {
+			out.BranchID = uuid
+		}
+	}
+	return out
+}
+
+func ridToUUID(r *libfossil.Repo, rid int64) (string, error) {
+	var uuid string
+	if err := r.DB().QueryRow(`SELECT uuid FROM blob WHERE rid = ?`, rid).Scan(&uuid); err != nil {
+		return "", fmt.Errorf("rid→uuid: %w", err)
+	}
+	return uuid, nil
+}
+
+// applySQLiteTuning applies the per-connection SQLite settings the agent
+// needs for safe concurrent writes against its repo. libfossil PRAGMAs are
+// per-connection, so we cap MaxOpenConns at 1 to make them stick.
+func applySQLiteTuning(r *libfossil.Repo) {
+	r.DB().SqlDB().SetMaxOpenConns(1)
+	_, _ = r.DB().Exec(`PRAGMA busy_timeout = 30000`)
+}

--- a/leaf/agent/code_artifact_test.go
+++ b/leaf/agent/code_artifact_test.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// newAgentForCommitTests opens a fresh repo and builds an Agent without
+// touching networking. The state-machine fields are unused for code-artifact
+// tests; only repo + projectCode are needed.
+func newAgentForCommitTests(t *testing.T) *Agent {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.fossil")
+	r, err := libfossil.Create(path, libfossil.CreateOpts{User: "testuser"})
+	if err != nil {
+		t.Fatalf("libfossil.Create: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	applySQLiteTuning(r)
+
+	projCode, err := r.Config("project-code")
+	if err != nil {
+		t.Fatalf("read project-code: %v", err)
+	}
+	return &Agent{repo: r, projectCode: projCode}
+}
+
+func TestAgent_Commit_RoundtripsThroughReadAndFiles(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	rev, err := a.Commit(ctx, CommitOpts{
+		Files: []FileToCommit{
+			{Name: "hello.txt", Content: []byte("hello\n")},
+			{Name: "sub/world.txt", Content: []byte("world\n")},
+		},
+		Message: "initial",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if rev == "" {
+		t.Fatal("Commit returned empty RevID")
+	}
+
+	got, err := a.Read(ctx, "hello.txt")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello\n")) {
+		t.Errorf("Read hello.txt = %q, want %q", got, "hello\n")
+	}
+
+	files, err := a.Files(ctx)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if !slices.Contains(files, "hello.txt") || !slices.Contains(files, "sub/world.txt") {
+		t.Errorf("Files = %v, want hello.txt + sub/world.txt", files)
+	}
+}
+
+func TestAgent_Commit_RejectsEmptyAuthor(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	_, err := a.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "x", Content: []byte("y")}},
+		Message: "no author",
+	})
+	if err == nil {
+		t.Fatal("Commit with empty Author returned nil")
+	}
+}
+
+func TestAgent_Tip_ReturnsCommitUUID(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	rev, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f", Content: []byte("v1")}},
+		Message: "c1",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	tip, err := a.Tip(ctx, "trunk")
+	if err != nil {
+		t.Fatalf("Tip: %v", err)
+	}
+	if tip != rev {
+		t.Errorf("Tip = %q, want %q", tip, rev)
+	}
+}
+
+func TestAgent_Tip_EmptyBranchReturnsEmptyNoError(t *testing.T) {
+	a := newAgentForCommitTests(t)
+
+	tip, err := a.Tip(context.Background(), "no-such-branch")
+	if err != nil {
+		t.Fatalf("Tip: %v (want nil)", err)
+	}
+	if tip != "" {
+		t.Errorf("Tip = %q, want empty", tip)
+	}
+}
+
+func TestAgent_Diff_BetweenTwoRevs(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	revA, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("alpha\n")}},
+		Message: "v1",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Commit v1: %v", err)
+	}
+	revB, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("beta\n")}},
+		Message: "v2",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Commit v2: %v", err)
+	}
+
+	diff, err := a.Diff(ctx, revA, revB)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !bytes.Contains(diff, []byte("alpha")) || !bytes.Contains(diff, []byte("beta")) {
+		t.Errorf("Diff missing alpha/beta markers: %s", diff)
+	}
+}
+
+func TestAgent_ExtractTo_PopulatesDir(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	rev, err := a.Commit(ctx, CommitOpts{
+		Files: []FileToCommit{
+			{Name: "a.txt", Content: []byte("AAA")},
+			{Name: "b/c.txt", Content: []byte("CCC")},
+		},
+		Message: "initial",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := a.ExtractTo(ctx, dir, rev); err != nil {
+		t.Fatalf("ExtractTo: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, "*.txt"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Errorf("ExtractTo produced no top-level .txt files in %s", dir)
+	}
+}
+
+func TestAgent_ExtractTo_EmptyRevIsNoop(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	dir := t.TempDir()
+	if err := a.ExtractTo(context.Background(), dir, ""); err != nil {
+		t.Errorf("ExtractTo with empty rev should be no-op, got: %v", err)
+	}
+}
+
+func TestAgent_Config_ReadsProjectCode(t *testing.T) {
+	a := newAgentForCommitTests(t)
+
+	got, err := a.Config("project-code")
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if got == "" || got != a.projectCode {
+		t.Errorf("Config(project-code) = %q, want non-empty matching agent.projectCode (%q)", got, a.projectCode)
+	}
+}
+
+func TestAgent_Sync_NoTransportReturnsError(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	if _, err := a.Sync(context.Background()); err == nil {
+		t.Fatal("Sync with no transport should error")
+	}
+}
+
+func TestAgent_SyncTo_RejectsEmptyURL(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	if _, err := a.SyncTo(context.Background(), "", SyncOpts{Push: true}); err == nil {
+		t.Fatal("SyncTo with empty URL should error")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Commit`, `Sync`, `SyncTo`, `Read`, `Files`, `Diff`, `Tip`, `ExtractTo`, `Config` methods on `*Agent` that take/return only primitives or types defined in `leaf/agent`. No `*libfossil.*` in any new signature.
- New types: `RevID`, `FileToCommit`, `CommitOpts`, `SyncOpts`, `SyncResult`. `RevID` is the manifest UUID under the hood, exposed as opaque.
- `applySQLiteTuning` (SetMaxOpenConns(1) + `PRAGMA busy_timeout = 30000`) now runs on every agent boot. libfossil PRAGMAs are per-connection so the single-conn cap is what makes them stick.
- `Agent.Repo()` and `Agent.NotifyRepo()` stay; doc comments updated to recommend the new methods.

Closes #103.

### Notes for reviewer

- `Tip` covers the empty-branch case by translating `sql.ErrNoRows` (the libfossil propagation when a branch has no checkins) to `("", nil)` rather than an error. Useful so callers don't have to special-case fresh repos.
- `Diff` enumerates the union of files at both revs and calls libfossil's per-file `Diff` for each, since libfossil's `Diff` requires a non-empty `filePath`. Output is the concatenation of unified diffs across changed files, matching the brief's `[]byte` shape.
- `SyncResult.Forked`/`BranchID` are populated via `r.DetectForks()` — first fork's local-tip UUID. Empty `BranchID` means no fork (or the substrate query failed silently — DetectForks errors are swallowed, since fork detection is advisory).
- `RevID` is a string alias; the underlying value is the fossil manifest UUID. Treat as opaque on the consumer side.

## Test plan

- [x] `cd leaf && go test -count=1 -run TestAgent_ ./agent/` — 10 new tests green
- [x] `cd leaf && go test -race -count=1 ./agent/...` — full suite green under race
- [x] `make test` — pre-commit hook + CI-equivalent green
- [ ] CI green