### PR TITLE
feat(hub): top-level hub package for fossil hub + embedded NATS (#102)

### DIFF
--- a/hub/commit.go
+++ b/hub/commit.go
@@ -1,0 +1,59 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// RevID is an opaque commit handle.
+type RevID string
+
+// FileToCommit names a file and its content for inclusion in a commit.
+type FileToCommit struct {
+	Name    string
+	Content []byte
+}
+
+// CommitOpts configures Hub.Commit.
+type CommitOpts struct {
+	Files   []FileToCommit
+	Message string
+	Author  string // fossil user; required
+}
+
+// Commit commits a set of files to the hub repo.
+func (h *Hub) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
+	if opts.Author == "" {
+		return "", errors.New("hub: Commit: Author is required")
+	}
+	files := make([]libfossil.FileToCommit, len(opts.Files))
+	for i, f := range opts.Files {
+		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
+	}
+	_, uuid, err := h.repo.Commit(libfossil.CommitOpts{
+		Files:   files,
+		Comment: opts.Message,
+		User:    opts.Author,
+	})
+	if err != nil {
+		return "", fmt.Errorf("hub: commit: %w", err)
+	}
+	return RevID(uuid), nil
+}
+
+// Read returns the contents of path at the current trunk tip.
+func (h *Hub) Read(ctx context.Context, path string) ([]byte, error) {
+	return h.repo.ReadFileAt("trunk", path)
+}
+
+// ReadAt returns the contents of path at rev. rev may be a branch name
+// (e.g. "trunk"), a tag, or a RevID returned from Commit.
+func (h *Hub) ReadAt(ctx context.Context, rev RevID, path string) ([]byte, error) {
+	if rev == "" {
+		return nil, errors.New("hub: ReadAt: rev is required (use Read for current tip)")
+	}
+	return h.repo.ReadFileAt(string(rev), path)
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -1,0 +1,226 @@
+// Package hub hosts an EdgeSync hub in-process: a fossil hub repo, an
+// embedded NATS server with JetStream, and an HTTP server exposing the
+// fossil timeline UI / xfer endpoint. All libfossil and nats-server types
+// are wrapped internally — the public API exposes only stdlib types and
+// types defined here, so consumers can host a hub without importing
+// libfossil or nats-server.
+//
+// The package lives inside the EdgeSync root module rather than a separate
+// go.mod so that it can ship in lockstep with the leaf agent without a
+// chicken-and-egg release. It can be promoted to its own module later if
+// downstream consumers need to depend on it independently.
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	natsserver "github.com/nats-io/nats-server/v2/server"
+)
+
+// Config configures NewHub.
+type Config struct {
+	// RepoPath is the absolute path to hub.fossil. Created if absent.
+	RepoPath string
+
+	// BootstrapUser is the libfossil user created at hub bootstrap.
+	// Default: "hub".
+	BootstrapUser string
+
+	// NATSStoreDir is the JetStream storage directory. When empty, defaults
+	// to filepath.Dir(RepoPath) + "/nats-store".
+	NATSStoreDir string
+
+	// FossilHTTPPort is the port to serve fossil HTTP on. 0 = auto-pick.
+	FossilHTTPPort int
+
+	// NATSClientPort is the embedded NATS server's client port.
+	// 0 = auto-pick.
+	NATSClientPort int
+
+	// NATSLeafPort is the leafnode listener port for remote agents.
+	// 0 = auto-pick.
+	NATSLeafPort int
+}
+
+// Hub hosts an EdgeSync hub in-process. Construct one via NewHub, then call
+// ServeHTTP in a goroutine. Use Stop to tear everything down.
+type Hub struct {
+	repo       *libfossil.Repo
+	server     *natsserver.Server
+	httpListener net.Listener
+	httpServer *http.Server
+
+	httpAddr     string
+	natsURL      string
+	leafUpstream string
+
+	stopOnce sync.Once
+}
+
+// NewHub bootstraps the hub repo if absent, applies SQLite tunings, binds
+// the HTTP listener (so HTTPAddr is immediately available), and starts the
+// embedded NATS server. Does not yet serve HTTP — call ServeHTTP for that.
+func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
+	if cfg.RepoPath == "" {
+		return nil, errors.New("hub: Config.RepoPath is required")
+	}
+	if cfg.BootstrapUser == "" {
+		cfg.BootstrapUser = "hub"
+	}
+	if cfg.NATSStoreDir == "" {
+		cfg.NATSStoreDir = filepath.Join(filepath.Dir(cfg.RepoPath), "nats-store")
+	}
+
+	repo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser)
+	if err != nil {
+		return nil, err
+	}
+	applySQLiteTuning(repo)
+
+	httpAddr := fmt.Sprintf("127.0.0.1:%d", cfg.FossilHTTPPort)
+	httpLn, err := net.Listen("tcp", httpAddr)
+	if err != nil {
+		repo.Close()
+		return nil, fmt.Errorf("hub: bind HTTP listener on %s: %w", httpAddr, err)
+	}
+
+	natsServer, err := startNATS(cfg)
+	if err != nil {
+		httpLn.Close()
+		repo.Close()
+		return nil, err
+	}
+
+	leafAddr := ""
+	if varz, vErr := natsServer.Varz(&natsserver.VarzOptions{}); vErr == nil && varz.LeafNode.Port > 0 {
+		leafAddr = fmt.Sprintf("nats-leaf://127.0.0.1:%d", varz.LeafNode.Port)
+	}
+
+	h := &Hub{
+		repo:         repo,
+		server:       natsServer,
+		httpListener: httpLn,
+		httpAddr:     httpLn.Addr().String(),
+		natsURL:      natsServer.ClientURL(),
+		leafUpstream: leafAddr,
+	}
+	return h, nil
+}
+
+// ServeHTTP runs the fossil HTTP server (timeline UI + xfer endpoint)
+// against the listener bound by NewHub. Blocks until ctx is cancelled or
+// Stop is called.
+func (h *Hub) ServeHTTP(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.Handle("/", h.repo.XferHandler())
+
+	srv := &http.Server{Handler: mux}
+	h.httpServer = srv
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	if err := srv.Serve(h.httpListener); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("hub: serve HTTP: %w", err)
+	}
+	return nil
+}
+
+// Stop tears down the embedded NATS server and any HTTP listeners. Safe to
+// call multiple times.
+func (h *Hub) Stop() error {
+	var firstErr error
+	h.stopOnce.Do(func() {
+		if h.httpServer != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := h.httpServer.Shutdown(shutdownCtx); err != nil && err != http.ErrServerClosed {
+				firstErr = fmt.Errorf("hub: shutdown HTTP: %w", err)
+			}
+		} else if h.httpListener != nil {
+			h.httpListener.Close()
+		}
+		if h.server != nil {
+			h.server.Shutdown()
+			h.server.WaitForShutdown()
+		}
+		if h.repo != nil {
+			if err := h.repo.Close(); err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("hub: close repo: %w", err)
+			}
+		}
+	})
+	return firstErr
+}
+
+// NATSURL returns the embedded NATS server's client URL.
+func (h *Hub) NATSURL() string { return h.natsURL }
+
+// LeafUpstream returns the leafnode listener URL, suitable for passing to
+// remote agents as their NATS leaf upstream. Empty if no leaf port is
+// configured.
+func (h *Hub) LeafUpstream() string { return h.leafUpstream }
+
+// HTTPAddr returns the host:port the fossil HTTP server is bound to.
+func (h *Hub) HTTPAddr() string { return h.httpAddr }
+
+func openOrCreateRepo(path, bootstrapUser string) (*libfossil.Repo, error) {
+	if r, err := libfossil.Open(path); err == nil {
+		return r, nil
+	}
+	r, err := libfossil.Create(path, libfossil.CreateOpts{User: bootstrapUser})
+	if err != nil {
+		return nil, fmt.Errorf("hub: create repo at %s: %w", path, err)
+	}
+	return r, nil
+}
+
+func startNATS(cfg Config) (*natsserver.Server, error) {
+	opts := &natsserver.Options{
+		Host:      "127.0.0.1",
+		Port:      portOrAuto(cfg.NATSClientPort),
+		NoLog:     true,
+		NoSigs:    true,
+		JetStream: true,
+		StoreDir:  cfg.NATSStoreDir,
+	}
+	opts.LeafNode.Host = "127.0.0.1"
+	opts.LeafNode.Port = portOrAuto(cfg.NATSLeafPort)
+
+	srv, err := natsserver.NewServer(opts)
+	if err != nil {
+		return nil, fmt.Errorf("hub: create NATS server: %w", err)
+	}
+	srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		srv.Shutdown()
+		return nil, fmt.Errorf("hub: NATS server not ready within 5s")
+	}
+	return srv, nil
+}
+
+func portOrAuto(p int) int {
+	if p == 0 {
+		return -1 // nats-server convention for "auto-pick"
+	}
+	return p
+}
+
+// applySQLiteTuning matches the leaf agent's tuning: single-conn cap so
+// libfossil's per-connection PRAGMAs stick, plus a 30s busy timeout.
+func applySQLiteTuning(r *libfossil.Repo) {
+	r.DB().SqlDB().SetMaxOpenConns(1)
+	_, _ = r.DB().Exec(`PRAGMA busy_timeout = 30000`)
+}

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -1,0 +1,255 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+	"github.com/nats-io/nats.go"
+)
+
+func newTestHub(t *testing.T) *Hub {
+	t.Helper()
+	dir := t.TempDir()
+	h, err := NewHub(context.Background(), Config{
+		RepoPath: filepath.Join(dir, "hub.fossil"),
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+	return h
+}
+
+func TestNewHub_BootstrapAndAddresses(t *testing.T) {
+	h := newTestHub(t)
+
+	if h.HTTPAddr() == "" {
+		t.Error("HTTPAddr empty after NewHub")
+	}
+	if h.NATSURL() == "" {
+		t.Error("NATSURL empty after NewHub")
+	}
+	if h.LeafUpstream() == "" {
+		t.Error("LeafUpstream empty after NewHub")
+	}
+}
+
+func TestNewHub_AutoPortsAreDistinct(t *testing.T) {
+	h := newTestHub(t)
+
+	natsURL := h.NATSURL()         // nats://127.0.0.1:NNNN
+	leafURL := h.LeafUpstream()    // nats-leaf://127.0.0.1:LLLL
+	httpAddr := h.HTTPAddr()       // 127.0.0.1:HHHH
+
+	if natsURL == leafURL || natsURL == httpAddr || leafURL == httpAddr {
+		t.Errorf("expected three distinct addresses, got NATS=%s leaf=%s http=%s", natsURL, leafURL, httpAddr)
+	}
+}
+
+func TestHub_NATSURL_Connects(t *testing.T) {
+	h := newTestHub(t)
+
+	conn, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect(%s): %v", h.NATSURL(), err)
+	}
+	defer conn.Close()
+	if !conn.IsConnected() {
+		t.Error("nats connection not established")
+	}
+}
+
+func TestHub_OpenExistingRepo(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h1, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub (bootstrap): %v", err)
+	}
+	if _, err := h1.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "f", Content: []byte("v1")}},
+		Message: "first",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	_ = h1.Stop()
+
+	h2, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub (open): %v", err)
+	}
+	defer h2.Stop()
+
+	got, err := h2.Read(context.Background(), "f")
+	if err != nil {
+		t.Fatalf("Read after reopen: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Errorf("Read = %q, want %q", got, "v1")
+	}
+}
+
+func TestHub_CommitReadReadAtRoundtrip(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	rev, err := h.Commit(ctx, CommitOpts{
+		Files: []FileToCommit{
+			{Name: "a.txt", Content: []byte("alpha")},
+			{Name: "dir/b.txt", Content: []byte("beta")},
+		},
+		Message: "initial",
+		Author:  "hub",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	got, err := h.Read(ctx, "a.txt")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("alpha")) {
+		t.Errorf("Read a.txt = %q, want %q", got, "alpha")
+	}
+
+	gotRev, err := h.ReadAt(ctx, rev, "dir/b.txt")
+	if err != nil {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if !bytes.Equal(gotRev, []byte("beta")) {
+		t.Errorf("ReadAt dir/b.txt = %q, want %q", gotRev, "beta")
+	}
+
+	gotTrunk, err := h.ReadAt(ctx, "trunk", "a.txt")
+	if err != nil {
+		t.Fatalf("ReadAt trunk: %v", err)
+	}
+	if !bytes.Equal(gotTrunk, []byte("alpha")) {
+		t.Errorf("ReadAt trunk a.txt = %q, want %q", gotTrunk, "alpha")
+	}
+}
+
+func TestHub_Commit_RejectsEmptyAuthor(t *testing.T) {
+	h := newTestHub(t)
+	if _, err := h.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "x", Content: []byte("y")}},
+		Message: "no author",
+	}); err == nil {
+		t.Fatal("Commit with empty Author returned nil")
+	}
+}
+
+func TestHub_ReadAt_RejectsEmptyRev(t *testing.T) {
+	h := newTestHub(t)
+	if _, err := h.ReadAt(context.Background(), "", "any"); err == nil {
+		t.Fatal("ReadAt with empty rev returned nil")
+	}
+}
+
+func TestHub_UserMgmt_RoundTrip(t *testing.T) {
+	h := newTestHub(t)
+
+	if err := h.AddUser(User{Login: "alice", Caps: "admin"}); err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+	if !h.HasUser("alice") {
+		t.Error("HasUser(alice) = false after AddUser")
+	}
+	if h.HasUser("definitely-not-a-real-user-zzz") {
+		t.Error("HasUser(definitely-not-a-real-user-zzz) = true; want false")
+	}
+
+	got, err := h.GetUser("alice")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if got.Login != "alice" || got.Caps != "admin" {
+		t.Errorf("GetUser alice = %+v, want {alice admin}", got)
+	}
+
+	users, err := h.ListUsers()
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	hasAlice := slices.ContainsFunc(users, func(u User) bool { return u.Login == "alice" })
+	if !hasAlice {
+		t.Errorf("ListUsers = %+v, want one with Login=alice", users)
+	}
+
+	if err := h.RemoveUser("alice"); err != nil {
+		t.Fatalf("RemoveUser: %v", err)
+	}
+	if h.HasUser("alice") {
+		t.Error("HasUser(alice) = true after RemoveUser")
+	}
+}
+
+func TestHub_AddUser_RejectsEmptyLogin(t *testing.T) {
+	h := newTestHub(t)
+	if err := h.AddUser(User{}); err == nil {
+		t.Fatal("AddUser with empty Login returned nil")
+	}
+}
+
+func TestHub_ServeHTTP_RespondsAndShutsDownOnContextCancel(t *testing.T) {
+	h := newTestHub(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- h.ServeHTTP(ctx) }()
+
+	// Wait for server to come up.
+	deadline := time.Now().Add(2 * time.Second)
+	var resp *http.Response
+	var err error
+	for time.Now().Before(deadline) {
+		resp, err = http.Get("http://" + h.HTTPAddr() + "/")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("HTTP GET %s: %v", h.HTTPAddr(), err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == 0 {
+		t.Errorf("HTTP GET = status %d", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Errorf("ServeHTTP returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("ServeHTTP did not shut down within 2s of ctx cancel")
+	}
+}
+
+func TestHub_Stop_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	h, err := NewHub(context.Background(), Config{
+		RepoPath: filepath.Join(dir, "hub.fossil"),
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+
+	if err := h.Stop(); err != nil {
+		t.Errorf("first Stop: %v", err)
+	}
+	if err := h.Stop(); err != nil {
+		t.Errorf("second Stop: %v", err)
+	}
+}

--- a/hub/users.go
+++ b/hub/users.go
@@ -1,0 +1,63 @@
+package hub
+
+import (
+	"errors"
+	"fmt"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// User describes a fossil user on the hub repo.
+type User struct {
+	Login string
+	Caps  string
+}
+
+// AddUser creates a fossil user. Returns an error if Login is empty or the
+// user already exists.
+func (h *Hub) AddUser(u User) error {
+	if u.Login == "" {
+		return errors.New("hub: AddUser: Login is required")
+	}
+	if err := h.repo.CreateUser(libfossil.UserOpts{Login: u.Login, Caps: u.Caps}); err != nil {
+		return fmt.Errorf("hub: add user %q: %w", u.Login, err)
+	}
+	return nil
+}
+
+// GetUser returns the user with the given login. Returns an error if no
+// such user exists.
+func (h *Hub) GetUser(login string) (User, error) {
+	u, err := h.repo.GetUser(login)
+	if err != nil {
+		return User{}, fmt.Errorf("hub: get user %q: %w", login, err)
+	}
+	return User{Login: u.Login, Caps: u.Caps}, nil
+}
+
+// HasUser reports whether a user with the given login exists.
+func (h *Hub) HasUser(login string) bool {
+	_, err := h.repo.GetUser(login)
+	return err == nil
+}
+
+// ListUsers returns all users on the hub.
+func (h *Hub) ListUsers() ([]User, error) {
+	users, err := h.repo.ListUsers()
+	if err != nil {
+		return nil, fmt.Errorf("hub: list users: %w", err)
+	}
+	out := make([]User, len(users))
+	for i, u := range users {
+		out[i] = User{Login: u.Login, Caps: u.Caps}
+	}
+	return out, nil
+}
+
+// RemoveUser deletes the user with the given login.
+func (h *Hub) RemoveUser(login string) error {
+	if err := h.repo.DeleteUser(login); err != nil {
+		return fmt.Errorf("hub: remove user %q: %w", login, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds a top-level `hub/` package that hosts an EdgeSync hub in-process: fossil hub repo bootstrap, embedded NATS server with JetStream, auto-port allocation, libfossil HTTP serving (timeline UI / xfer endpoint), user management, and hub-side commits/reads.
- Public surface exposes only stdlib types and types defined in `hub/`. `grep -r "libfossil\." hub/` matches only inside non-test files where libfossil calls are made internally; no exported field, parameter, or return type references a libfossil or nats-server type.
- 11 tests cover lifecycle (bootstrap + open existing repo), auto-port allocation, NATS connectivity, user round-trip, commit/read/readAt round-trip, ServeHTTP context-cancel teardown, and idempotent Stop.

Closes #102.

### Decisions worth flagging

- **Module placement:** chose to put `hub/` inside the EdgeSync root module rather than as a separate go.mod sibling of `leaf/`/`bridge/`. Avoids the chicken-and-egg of publishing `hub@v0.0.x` before consumers can use it; ships in lockstep with the leaf agent. Can be extracted to its own module later if downstream consumers need independent dependency on it.
- **HTTP listener bound at NewHub:** the listener for fossil HTTP is bound during `NewHub` (before `ServeHTTP` starts) so `HTTPAddr()` is immediately usable for downstream consumers wiring leaves to the hub.
- **`Read` vs `ReadAt`:** kept both rather than overloading `Read` with optional rev — `Read` is current-tip, `ReadAt` requires explicit rev. Errors clearly when called with empty rev to nudge consumers toward the right method.
- **`HasUser` semantics:** uses `GetUser` under the hood; fossil has reserved/built-in users (e.g. `nobody`) that may return as present. Tests use a definitely-not-real login.

## Test plan

- [x] `go test -count=1 -race ./hub/...` — 11 tests green
- [x] `make test` — full suite green
- [x] `go vet ./...` clean
- [ ] CI green