### PR TITLE
feat(cli/repo): EdgeSync-owned repo subcommand library (#105)

### DIFF
--- a/cli/repo/repo.go
+++ b/cli/repo/repo.go
@@ -1,0 +1,58 @@
+// Package repo exposes a kong-compatible command tree for fossil repository
+// operations (ci, co, timeline, diff, cat, config, merge, …) that consumers
+// can embed in their CLI struct without importing libfossil.
+//
+// # Usage
+//
+// Replace this in your CLI:
+//
+//	import libfossilcli "github.com/danmestas/libfossil/cli"
+//
+//	type CLI struct {
+//		libfossilcli.Globals
+//		Repo libfossilcli.RepoCmd `cmd:"" group:"repo" help:"Fossil repository operations"`
+//	}
+//
+// with this:
+//
+//	import repocli "github.com/danmestas/EdgeSync/cli/repo"
+//
+//	type CLI struct {
+//		repocli.Globals
+//		Repo repocli.Cmd `cmd:"" group:"repo" help:"Fossil repository operations"`
+//	}
+//
+// The flag surface, subcommand set, and behavior are identical — every
+// subcommand libfossil/cli.RepoCmd exposes today is reachable through
+// repocli.Cmd with the same UX.
+//
+// # Trade-off: type aliases
+//
+// Cmd and Globals are type aliases for their libfossil/cli counterparts.
+// Re-declaring them as wrapper structs would require mirroring ~38
+// subcommands' worth of kong flags by hand, brittle to libfossil flag
+// additions/renames. Aliases give consumers source-level isolation
+// (no "github.com/danmestas/libfossil/cli" import needed in consumer code)
+// while reusing libfossil's tested CLI implementation.
+//
+// Because aliases resolve to the same type, the libfossil/cli package is
+// reachable transitively through Go's type identity, but consumer source
+// code never names it. This is the minimum-viable shim that achieves the
+// architectural goal: drop the libfossil import from downstream consumers
+// once they've migrated to the new agent and hub APIs.
+package repo
+
+import (
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+// Globals holds flags shared by all repo subcommands (-R repo path, -v
+// verbose). Re-export of libfossil/cli.Globals so consumers can write
+// `repocli.Globals` instead of importing libfossil/cli.
+type Globals = libfossilcli.Globals
+
+// Cmd is the embeddable command tree for fossil repo operations. Re-export
+// of libfossil/cli.RepoCmd. Embed it in your CLI struct with the kong tag
+// `cmd:""` and your binary picks up the full fossil repo subcommand set
+// (ci, co, timeline, diff, cat, config, merge, …).
+type Cmd = libfossilcli.RepoCmd

--- a/cli/repo/repo_test.go
+++ b/cli/repo/repo_test.go
@@ -1,0 +1,58 @@
+package repo_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
+)
+
+// TestCmdParsesKnownSubcommands proves the re-exported Cmd carries every
+// fossil repo subcommand kong sees today. We pick a handful of stable
+// subcommands and confirm kong resolves them without erroring on schema.
+func TestCmdParsesKnownSubcommands(t *testing.T) {
+	type CLI struct {
+		repocli.Globals
+		Repo repocli.Cmd `cmd:""`
+	}
+
+	parser, err := kong.New(&CLI{}, kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	subs := []string{"timeline", "ls", "cat", "ci", "co", "diff", "config", "merge"}
+	help := captureHelp(t, parser)
+	for _, s := range subs {
+		if !strings.Contains(help, "repo "+s) {
+			t.Errorf("--help output missing 'repo %s' subcommand:\n%s", s, help)
+		}
+	}
+}
+
+// TestGlobalsHaveRepoFlag verifies the Globals re-export still exposes the
+// -R / --repo flag downstream consumers depend on.
+func TestGlobalsHaveRepoFlag(t *testing.T) {
+	type CLI struct {
+		repocli.Globals
+	}
+
+	parser, err := kong.New(&CLI{}, kong.Exit(func(int) {}))
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	help := captureHelp(t, parser)
+	if !strings.Contains(help, "--repo") {
+		t.Errorf("--help output missing --repo flag:\n%s", help)
+	}
+}
+
+func captureHelp(t *testing.T, p *kong.Kong) string {
+	t.Helper()
+	var sb strings.Builder
+	p.Stdout = &sb
+	p.Stderr = &sb
+	_, _ = p.Parse([]string{"--help"})
+	return sb.String()
+}

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	edgecli "github.com/danmestas/EdgeSync/cli"
-	"github.com/danmestas/libfossil/cli"
+	repocli "github.com/danmestas/EdgeSync/cli/repo"
 )
 
 type CLI struct {
-	cli.Globals
+	repocli.Globals
 
-	Repo   cli.RepoCmd       `cmd:"" help:"Repository operations"`
+	Repo   repocli.Cmd       `cmd:"" help:"Repository operations"`
 	Sync   edgecli.SyncCmd   `cmd:"" help:"Leaf agent sync"`
 	Bridge edgecli.BridgeCmd `cmd:"" help:"NATS-to-Fossil bridge"`
 	Notify edgecli.NotifyCmd `cmd:"" help:"Bidirectional notification messaging"`


### PR DESCRIPTION
## Summary

- New package `github.com/danmestas/EdgeSync/cli/repo` exposing `Cmd` and `Globals` so consumers can embed the full fossil repo subcommand surface without importing `github.com/danmestas/libfossil/cli`.
- `cmd/edgesync/cli.go` migrates to the new package as the first consumer. Flag surface, subcommand set, and behavior identical from the end-user perspective.

Closes #105.

### Decision worth flagging: type aliases over wrapper structs

`Cmd` and `Globals` are type aliases (`type Cmd = libfossilcli.RepoCmd`). The strict reading of "no libfossil types in exported signatures" would require ~38 wrapper structs mirroring every kong flag — fragile to libfossil flag additions/renames, ~600 LOC of boilerplate.

Aliases give the load-bearing win: consumer source code doesn't need `import libfossilcli`, which is the architectural goal in the brief — once bones migrates to the new agent / hub / cli surfaces, it can drop libfossil from its `go.mod`.

The trade-off: via Go's type identity, `repocli.Cmd` *is* `libfossilcli.RepoCmd`, so libfossil/cli is reachable transitively. The package doc spells this out. If we later need full type isolation (e.g. for binary-size or vendoring reasons), we can swap aliases for wrappers without breaking the public API shape.

## Test plan

- [x] `go test -count=1 -v ./cli/repo/...` — 2 tests, parses subcommands + globals through kong
- [x] `make test` — full suite green (covers the migrated `cmd/edgesync/cli.go`)
- [x] `edgesync repo --help` shows the same subcommands as before the migration
- [ ] CI green