### PR TITLE
feat(notify): libfossil-hidden Service methods (#104)

### DIFF
--- a/leaf/agent/notify/notify.go
+++ b/leaf/agent/notify/notify.go
@@ -58,7 +58,14 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// Repo returns the underlying Fossil repo.
+// Repo returns the underlying libfossil repo handle.
+//
+// New code should prefer the libfossil-hidden Service methods
+// (ListThreads, ReadThread, MessageCount, ListDevices, AddDevice,
+// RemoveDevice, CreatePairingToken, ValidateToken) which take/return
+// only stdlib types or types defined in this package. Repo() stays
+// available for sim/test harnesses and advanced consumers that need
+// libfossil features the Service surface doesn't yet cover.
 func (s *Service) Repo() *libfossil.Repo {
 	return s.repo
 }

--- a/leaf/agent/notify/service_methods.go
+++ b/leaf/agent/notify/service_methods.go
@@ -1,0 +1,57 @@
+package notify
+
+import (
+	"context"
+)
+
+// ListThreads returns the threads for project from the agent's notify repo.
+// Thin delegation to the libfossil-typed free function ListThreads.
+//
+// project is required because the notify repo can hold threads for multiple
+// projects; the free-function shape requires it. A Service that tracks a
+// default project would be a reasonable follow-up but is out of scope.
+func (s *Service) ListThreads(ctx context.Context, project string) ([]ThreadSummary, error) {
+	return ListThreads(s.repo, project)
+}
+
+// ReadThread returns the messages in (project, threadShort) ordered as
+// stored. Thin delegation to ReadThread.
+func (s *Service) ReadThread(ctx context.Context, project, threadShort string) ([]Message, error) {
+	return ReadThread(s.repo, project, threadShort)
+}
+
+// MessageCount returns the number of messages in (project, threadShort).
+func (s *Service) MessageCount(ctx context.Context, project, threadShort string) (int, error) {
+	msgs, err := ReadThread(s.repo, project, threadShort)
+	if err != nil {
+		return 0, err
+	}
+	return len(msgs), nil
+}
+
+// ListDevices returns the registered devices on the agent's notify repo.
+func (s *Service) ListDevices(ctx context.Context) ([]Device, error) {
+	return ListDevices(s.repo)
+}
+
+// AddDevice registers a device on the agent's notify repo.
+func (s *Service) AddDevice(ctx context.Context, dev Device) error {
+	return AddDevice(s.repo, dev)
+}
+
+// RemoveDevice removes a device by name from the agent's notify repo.
+func (s *Service) RemoveDevice(ctx context.Context, name string) error {
+	return RemoveDevice(s.repo, name)
+}
+
+// CreatePairingToken generates a pairing token for name and stores it in
+// the agent's notify repo.
+func (s *Service) CreatePairingToken(ctx context.Context, name string) (string, error) {
+	return CreatePairingToken(s.repo, name)
+}
+
+// ValidateToken validates a formatted pairing token against the agent's
+// notify repo and returns the matching pending token (or error if none).
+func (s *Service) ValidateToken(ctx context.Context, token string) (PendingToken, error) {
+	return ValidateToken(s.repo, token)
+}

--- a/leaf/agent/notify/service_methods_test.go
+++ b/leaf/agent/notify/service_methods_test.go
@@ -1,0 +1,142 @@
+package notify
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// newServiceForTests builds a Service backed by a fresh notify repo and
+// no NATS connection. Sufficient for exercising the libfossil-hidden
+// Service methods that delegate to the existing free functions.
+func newServiceForTests(t *testing.T) *Service {
+	t.Helper()
+	r := createTestRepo(t)
+	svc, err := NewService(ServiceConfig{Repo: r, From: "endpoint-test", FromName: "test"})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+	return svc
+}
+
+func TestService_ListThreads_Roundtrip(t *testing.T) {
+	svc := newServiceForTests(t)
+
+	msg := NewMessage(MessageOpts{
+		Project: "p1",
+		From:    "endpoint-test",
+		Body:    "hi",
+	})
+	msg.Timestamp = time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	if err := CommitMessage(svc.repo, msg); err != nil {
+		t.Fatalf("CommitMessage: %v", err)
+	}
+
+	threads, err := svc.ListThreads(context.Background(), "p1")
+	if err != nil {
+		t.Fatalf("ListThreads: %v", err)
+	}
+	if len(threads) != 1 || threads[0].ThreadShort != msg.ThreadShort() {
+		t.Errorf("ListThreads = %+v, want one thread with short=%q", threads, msg.ThreadShort())
+	}
+}
+
+func TestService_ReadThread_Roundtrip(t *testing.T) {
+	svc := newServiceForTests(t)
+
+	msg := NewMessage(MessageOpts{Project: "p1", From: "endpoint-test", Body: "first"})
+	msg.Timestamp = time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	if err := CommitMessage(svc.repo, msg); err != nil {
+		t.Fatalf("CommitMessage: %v", err)
+	}
+
+	got, err := svc.ReadThread(context.Background(), "p1", msg.ThreadShort())
+	if err != nil {
+		t.Fatalf("ReadThread: %v", err)
+	}
+	if len(got) != 1 || got[0].Body != "first" {
+		t.Errorf("ReadThread = %+v, want one msg with Body=first", got)
+	}
+}
+
+func TestService_MessageCount(t *testing.T) {
+	svc := newServiceForTests(t)
+
+	m1 := NewMessage(MessageOpts{Project: "p1", From: "endpoint-test", Body: "a"})
+	m1.Timestamp = time.Date(2026, 5, 4, 10, 0, 0, 0, time.UTC)
+	if err := CommitMessage(svc.repo, m1); err != nil {
+		t.Fatalf("CommitMessage m1: %v", err)
+	}
+	m2 := NewReply(m1, ReplyOpts{From: "endpoint-other", Body: "b"})
+	m2.Timestamp = m1.Timestamp.Add(time.Minute)
+	if err := CommitMessage(svc.repo, m2); err != nil {
+		t.Fatalf("CommitMessage m2: %v", err)
+	}
+
+	count, err := svc.MessageCount(context.Background(), "p1", m1.ThreadShort())
+	if err != nil {
+		t.Fatalf("MessageCount: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("MessageCount = %d, want 2", count)
+	}
+}
+
+func TestService_DeviceMgmt_RoundTrip(t *testing.T) {
+	svc := newServiceForTests(t)
+	ctx := context.Background()
+
+	dev := Device{Name: "phone", EndpointID: "endpoint-phone"}
+	if err := svc.AddDevice(ctx, dev); err != nil {
+		t.Fatalf("AddDevice: %v", err)
+	}
+
+	devs, err := svc.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if !slices.ContainsFunc(devs, func(d Device) bool { return d.Name == "phone" }) {
+		t.Errorf("ListDevices = %+v, want one named phone", devs)
+	}
+
+	if err := svc.RemoveDevice(ctx, "phone"); err != nil {
+		t.Fatalf("RemoveDevice: %v", err)
+	}
+	devs, err = svc.ListDevices(ctx)
+	if err != nil {
+		t.Fatalf("ListDevices after remove: %v", err)
+	}
+	if slices.ContainsFunc(devs, func(d Device) bool { return d.Name == "phone" }) {
+		t.Errorf("ListDevices still contains phone after RemoveDevice: %+v", devs)
+	}
+}
+
+func TestService_PairingToken_CreateAndValidate(t *testing.T) {
+	svc := newServiceForTests(t)
+	ctx := context.Background()
+
+	tok, err := svc.CreatePairingToken(ctx, "alice")
+	if err != nil {
+		t.Fatalf("CreatePairingToken: %v", err)
+	}
+	if tok == "" {
+		t.Fatal("CreatePairingToken returned empty token")
+	}
+
+	pt, err := svc.ValidateToken(ctx, tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if pt.DeviceName != "alice" {
+		t.Errorf("ValidateToken returned Name=%q, want alice", pt.DeviceName)
+	}
+}
+
+func TestService_ValidateToken_RejectsUnknown(t *testing.T) {
+	svc := newServiceForTests(t)
+	if _, err := svc.ValidateToken(context.Background(), "totally-bogus"); err == nil {
+		t.Fatal("ValidateToken with unknown token should error")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds methods on `*notify.Service` that wrap the existing libfossil-typed free functions (`ListThreads`, `ReadThread`, `ListDevices`, `AddDevice`, `RemoveDevice`, `CreatePairingToken`, `ValidateToken`) plus a new `MessageCount`, with no `*libfossil.*` in any signature.
- Free functions and `Service.Repo()` stay; doc on `Repo()` updated to recommend the new methods for new code.

Closes #104.

### Decision worth flagging: project parameter on thread methods

The brief listed `ListThreads(ctx) ([]ThreadSummary, error)` / `ReadThread(ctx, threadShort) ([]Message, error)` without a `project` parameter. The free-function counterparts take project, the notify repo holds threads for multiple projects, and `ServiceConfig` doesn't carry a default project today.

Implemented as `Service.ListThreads(ctx, project)`, `Service.ReadThread(ctx, project, threadShort)`, `Service.MessageCount(ctx, project, threadShort)` — pragmatic match to the underlying surface. Carrying a default project on `Service` would be a reasonable follow-up if downstream consumers want a one-arg shape; out of scope here.

`NewServiceFromPath` (the optional path-based constructor in the brief) is also a follow-up; the Service-method wrappers are the load-bearing change for the libfossil-exit goal.

## Test plan

- [x] `cd leaf && go test -race -count=1 ./agent/notify/` — 6 new tests + existing suite green
- [x] `make test` — full suite green
- [ ] CI green