### PR TITLE
chore: bump leaf v0.0.3 → v0.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.2
-	github.com/danmestas/EdgeSync/leaf v0.0.3
+	github.com/danmestas/EdgeSync/leaf v0.0.7
 	github.com/danmestas/libfossil v0.4.6-rc3
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary

Bumps the root module's leaf pin from `v0.0.3` to `v0.0.7`. `leaf/v0.0.7` is already tagged and pushed (just before this PR).

`leaf/v0.0.7` carries:
- `feat(leaf/agent)` libfossil-hidden code-artifact API (#108) — the keystone of the bones libfossil-exit roadmap
- `feat(notify)` libfossil-hidden Service methods (#111)
- the `v0.0.5`/`v0.0.6` fixes for sync-error classification and the notify Subscriber race that already shipped on the leaf module independently

The local `replace github.com/danmestas/EdgeSync/leaf => ./leaf` directive means this bump doesn't change anything for in-repo builds (root keeps using `./leaf`). It only affects what version downstream consumers see when they import EdgeSync's root module without a replace.

After this merges, the next root tag (`v0.0.9`) captures hub/, cli/repo/, and the cmd/edgesync migration alongside the leaf bump — that's enough for bones to start migrating off libfossil while we wait for libfossil #23/#24 to land.

Supersedes the in-flight `chore/bump-leaf-v0.0.6` branch (which was pre-empted by the new APIs landing).

## Test plan

- [x] `make test` green (local replace means build still uses ./leaf — go.sum unchanged)
- [ ] CI green