### PR TITLE
fix(leaf,hub): drop SetMaxOpenConns(1) to unblock concurrent clones (#120)

### DIFF
--- a/hub/clone_concurrency_test.go
+++ b/hub/clone_concurrency_test.go
@@ -1,0 +1,104 @@
+package hub
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// TestHub_ConcurrentClones reproduces issue #120: the leaf v0.0.7
+// `applySQLiteTuning` call sets MaxOpenConns(1), which deadlocks
+// libfossil's clone path because the clone has internal goroutines
+// that all need the DB connection.
+//
+// Bones reported the deadlock from `examples/hub-leaf-e2e/` with N
+// concurrent clones against a shared hub repo. Reproduced here with
+// 3 concurrent clones; the deadlock is deterministic so 3 is enough.
+//
+// This test must complete in < 30s. Without the fix it hangs forever
+// (all clone goroutines wait on the single shared conn).
+func TestHub_ConcurrentClones(t *testing.T) {
+	h := newTestHub(t)
+
+	// Seed the hub repo with one commit so there's something to clone.
+	if _, err := h.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("v1")}},
+		Message: "seed",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+
+	// Add a user the clone clients can authenticate as. Default caps for
+	// "anonymous" are too narrow for clone in some builds; explicit user
+	// avoids that variability.
+	if err := h.AddUser(User{Login: "client", Caps: "asghbcofkimnqru"}); err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+
+	// Run hub HTTP serving in a goroutine.
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	t.Cleanup(cancelServe)
+	go func() { _ = h.ServeHTTP(serveCtx) }()
+
+	// Wait briefly for the listener to be live.
+	time.Sleep(50 * time.Millisecond)
+
+	hubURL := "http://" + h.HTTPAddr() + "/"
+	dir := t.TempDir()
+
+	const N = 3
+	done := make(chan error, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func() {
+			defer wg.Done()
+			cloneCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			path := filepath.Join(dir, "leaf-"+itoa(i)+".fossil")
+			r, _, err := libfossil.Clone(cloneCtx, path, libfossil.NewHTTPTransport(hubURL), libfossil.CloneOpts{
+				User:     "client",
+				Password: "",
+			})
+			if r != nil {
+				_ = r.Close()
+			}
+			done <- err
+		}()
+	}
+
+	// Whole test must complete within 25s; without the fix all N clones hang.
+	hardDeadline := time.After(25 * time.Second)
+	completed := 0
+	for completed < N {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("clone error: %v", err)
+			}
+			completed++
+		case <-hardDeadline:
+			t.Fatalf("deadlock: only %d/%d clones completed within 25s", completed, N)
+		}
+	}
+	wg.Wait()
+}
+
+func itoa(i int) string {
+	switch i {
+	case 0:
+		return "0"
+	case 1:
+		return "1"
+	case 2:
+		return "2"
+	case 3:
+		return "3"
+	}
+	return "n"
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -218,9 +218,12 @@ func portOrAuto(p int) int {
 	return p
 }
 
-// applySQLiteTuning matches the leaf agent's tuning: single-conn cap so
-// libfossil's per-connection PRAGMAs stick, plus a 30s busy timeout.
+// applySQLiteTuning sets a 30s SQLite busy_timeout so concurrent operations
+// retry on SQLITE_BUSY rather than failing fast.
+//
+// Mirrors leaf/agent's tuning. Notably does NOT cap MaxOpenConns: hub
+// repos serve concurrent clones, and capping the pool deadlocks libfossil's
+// clone path (issue #120).
 func applySQLiteTuning(r *libfossil.Repo) {
-	r.DB().SqlDB().SetMaxOpenConns(1)
 	_, _ = r.DB().Exec(`PRAGMA busy_timeout = 30000`)
 }

--- a/leaf/agent/code_artifact.go
+++ b/leaf/agent/code_artifact.go
@@ -248,10 +248,17 @@ func ridToUUID(r *libfossil.Repo, rid int64) (string, error) {
 	return uuid, nil
 }
 
-// applySQLiteTuning applies the per-connection SQLite settings the agent
-// needs for safe concurrent writes against its repo. libfossil PRAGMAs are
-// per-connection, so we cap MaxOpenConns at 1 to make them stick.
+// applySQLiteTuning applies SQLite settings the agent needs for safe
+// concurrent operation against its repo. The busy_timeout PRAGMA tells
+// SQLite to retry on SQLITE_BUSY for up to 30s before giving up, which
+// is what production callers want under contention.
+//
+// We do NOT cap MaxOpenConns at 1 here, even though libfossil PRAGMAs
+// are per-connection. Capping the pool to 1 deadlocks libfossil's clone
+// path, which has internal goroutines that all need a DB connection
+// (issue #120). If PRAGMA stickiness across pooled connections matters
+// later, route it through the modernc driver's per-connection init
+// hook rather than a pool cap.
 func applySQLiteTuning(r *libfossil.Repo) {
-	r.DB().SqlDB().SetMaxOpenConns(1)
 	_, _ = r.DB().Exec(`PRAGMA busy_timeout = 30000`)
 }


### PR DESCRIPTION
## Summary

- Removes `SetMaxOpenConns(1)` from `applySQLiteTuning` in both `leaf/agent` (added by #108) and `hub/` (propagated in #109). Keeps the `busy_timeout = 30000` PRAGMA.
- Adds `hub/clone_concurrency_test.go` — 3 parallel `libfossil.Clone` calls against a shared hub. Reproduces the deadlock without the fix (hangs to 25s timeout); passes in ~80ms with the fix.

Closes #120.

### Why the cap was wrong

The brief for #108 inherited the `SetMaxOpenConns(1)` pattern from bones. The justification was "libfossil PRAGMAs are per-connection, so the single-conn cap is what makes them stick." That logic only holds if the only consumer of the conn is a serial writer.

libfossil's clone path has internal goroutine concurrency — multiple goroutines within a single clone session need to query the DB. With `MaxOpenConns(1)`, one goroutine grabs the conn, another waits for it, and they deadlock when the first is waiting on a result the second is responsible for producing. Bones surfaced this as a deterministic hang in `examples/hub-leaf-e2e/`.

`busy_timeout` is the right primitive for concurrent-write safety — SQLite retries `SQLITE_BUSY` internally up to the timeout. We keep it; it's harmless on its own.

### Follow-up if needed

If a concrete case ever surfaces where a PRAGMA *must* stick across all pooled connections, route it through the modernc driver's per-connection init hook (DSN init query) rather than a pool cap. Not needed today — `busy_timeout` is the only PRAGMA we set, and SQLite applies it lazily on each connection's first use, which is fine.

## Test plan

- [x] `go test -count=1 -timeout 35s -run TestHub_ConcurrentClones -v ./hub/...` — fails (deadlocks) without fix, passes with fix
- [x] `go test -race -count=1 ./hub/...` and `cd leaf && go test -race -count=1 ./agent/...` — green
- [x] `make test` — full suite green
- [ ] CI green
- [ ] After merge: tag `leaf/v0.0.8` + bump root go.mod + tag `v0.0.10` so bones can pick up the fix