### PR TITLE
chore: bump leaf v0.0.7 → v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.2
-	github.com/danmestas/EdgeSync/leaf v0.0.7
+	github.com/danmestas/EdgeSync/leaf v0.0.8
 	github.com/danmestas/libfossil v0.5.0
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary

Bumps the root module's leaf pin from `v0.0.7` to `v0.0.8`. `leaf/v0.0.8` is already tagged and pushed.

`leaf/v0.0.8` ships:
- **fix(leaf,hub):** drop `SetMaxOpenConns(1)` from `applySQLiteTuning` (#120, PR #122). Resolves the concurrent-clone deadlock bones reported in `examples/hub-leaf-e2e/`.
- **chore:** built against libfossil v0.5.0 (PR #121).

The agent code-artifact API and notify Service surfaces from `v0.0.7` are unchanged. Downstream consumers should skip `v0.0.7` and pin to `v0.0.8`.

After this merges, root tag `v0.0.10` cuts the full release that ships the deadlock fix to bones via the GoReleaser pipeline + downstream-bump dispatch.

## Test plan

- [x] `make test` green
- [ ] CI green