### PR TITLE
docs(architecture): add hub-package.md ADR (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ See `docs/architecture/` for condensed architectural decision records (ARDs):
 - `repo-operations.md` — CLI, tags, FTS, verify/rebuild, auth, shun/purge
 - `testing-strategy.md` — test tiers, DST, sim, interop, BUGGIFY
 - `notify-messaging.md` — bidirectional messaging: data model, dual delivery, CLI, planned phases
+- `hub-package.md` — in-process hub: fossil repo + embedded NATS + HTTP serving, libfossil-hidden API
 
 ## Architecture
 

--- a/docs/architecture/agent-deployment.md
+++ b/docs/architecture/agent-deployment.md
@@ -34,6 +34,10 @@ The leaf agent is a Go daemon in its own module (`leaf/`) that opens a Fossil re
 | `hub` | Yes | No | Dedicated server, cluster node |
 | `leaf` | No | Yes (always solicits outward) | WASM browser, lightweight client |
 
+## Hub Package
+
+The hub package (`hub/`, in the root module) is an in-process host for an EdgeSync hub: fossil repo bootstrap, embedded NATS server with JetStream, auto-port allocation, and the libfossil HTTP server. Consumers (notably bones) use it to host a hub without rolling their own libfossil + nats-server bootstrap; everything is libfossil-free at the public API boundary. Leaf agents on the same host (or another host) sync to it via `Hub.HTTPAddr()` (HTTP-xfer) or `Hub.LeafUpstream()` (NATS leaf node). See [hub-package.md](./hub-package.md).
+
 ## Bridge Architecture
 
 The bridge is a NATS-to-HTTP translator in its own module (`bridge/`). It subscribes to `<prefix>.<project-code>.sync`, decodes xfer messages, proxies them to a Fossil HTTP server via `sync.HTTPTransport`, and replies. One project per instance.

--- a/docs/architecture/hub-package.md
+++ b/docs/architecture/hub-package.md
@@ -1,0 +1,95 @@
+# Hub Package
+
+## Purpose
+
+In-process host for an EdgeSync hub: a fossil hub repo, an embedded NATS server with JetStream, auto-port allocation, and an HTTP server exposing the fossil timeline UI / xfer endpoint. Lets consumers (notably the bones project) host a hub without rolling their own libfossil + nats-server bootstrap.
+
+Before this package, every adopter that needed a hub fossil — a central shared repo that leaves push to and that serves the timeline — had to write the same ~900-line wrapper around `libfossil.Create`/`Open`, `natsserver.NewServer`, JetStream config, port allocation, PID files, and shutdown supervision.
+
+## Public API
+
+All types are libfossil-free and nats-server-free. Consumers import only `github.com/danmestas/EdgeSync/hub`.
+
+```go
+type Config struct {
+    RepoPath       string // hub.fossil path; created if absent
+    BootstrapUser  string // default "hub"
+    NATSStoreDir   string // default <repo dir>/nats-store
+    FossilHTTPPort int    // 0 = auto-pick
+    NATSClientPort int    // 0 = auto-pick
+    NATSLeafPort   int    // 0 = auto-pick
+}
+
+type Hub struct{ /* opaque */ }
+
+func NewHub(ctx context.Context, cfg Config) (*Hub, error)
+func (h *Hub) ServeHTTP(ctx context.Context) error
+func (h *Hub) Stop() error
+
+func (h *Hub) NATSURL() string       // "nats://127.0.0.1:NNNN"
+func (h *Hub) LeafUpstream() string  // "nats-leaf://127.0.0.1:LLLL"
+func (h *Hub) HTTPAddr() string      // "127.0.0.1:HHHH"
+
+type User struct{ Login, Caps string }
+
+func (h *Hub) AddUser(User) error
+func (h *Hub) GetUser(login string) (User, error)
+func (h *Hub) HasUser(login string) bool
+func (h *Hub) ListUsers() ([]User, error)
+func (h *Hub) RemoveUser(login string) error
+
+type RevID string
+type FileToCommit struct{ Name string; Content []byte }
+type CommitOpts struct{ Files []FileToCommit; Message, Author string }
+
+func (h *Hub) Commit(ctx context.Context, opts CommitOpts) (RevID, error)
+func (h *Hub) Read(ctx context.Context, path string) ([]byte, error)
+func (h *Hub) ReadAt(ctx context.Context, rev RevID, path string) ([]byte, error)
+```
+
+## Lifecycle
+
+`NewHub` does the bootstrap-or-open: opens an existing `RepoPath` if present, calls `libfossil.Create` if absent. It then binds the HTTP listener (so `HTTPAddr()` is immediately usable for downstream consumers wiring leaves to the hub) and starts the embedded NATS server, waiting for `ReadyForConnections`. After `NewHub` returns successfully, all three address accessors return live, reachable URLs.
+
+`ServeHTTP` is a blocking goroutine — typical pattern is `go h.ServeHTTP(ctx)`. It runs the fossil HTTP server (`h.repo.XferHandler()`) against the listener bound by `NewHub` until ctx is cancelled or `Stop` is called. `Stop` is idempotent.
+
+```go
+ctx, cancel := context.WithCancel(context.Background())
+defer cancel()
+
+h, err := hub.NewHub(ctx, hub.Config{RepoPath: "/data/hub.fossil"})
+if err != nil { return err }
+defer h.Stop()
+
+go h.ServeHTTP(ctx)
+// Hub now serving at h.HTTPAddr(), NATS at h.NATSURL(), leaf upstream h.LeafUpstream()
+```
+
+## SQLite Tuning
+
+`busy_timeout = 30000` is applied at hub bootstrap so concurrent operations retry on `SQLITE_BUSY` rather than failing fast.
+
+The hub deliberately does **not** cap `MaxOpenConns`. An earlier iteration set `SetMaxOpenConns(1)` (matching what bones did before this package existed), but libfossil's clone path has internal goroutines that all need a DB connection — capping the pool deadlocked every concurrent clone (issue #120). `busy_timeout` alone is the right primitive for concurrent-write safety.
+
+## Layout: in-root vs. separate module
+
+The `hub/` directory lives inside the EdgeSync **root module** rather than as a separate `go.mod` sibling of `leaf/`/`bridge/`. This was a deliberate choice to ship the package without a chicken-and-egg release: the package can evolve in lockstep with the leaf agent, and root tags pick it up.
+
+If a downstream consumer needs to depend on `hub` independently of EdgeSync's full transitive deps, the package can be promoted to its own module without changing its public API. That migration is tracked in issue #118; triggers worth waiting for include consumers wanting to embed hub but skip the rest of EdgeSync's deps, or hub picking up dependencies the rest of EdgeSync doesn't want.
+
+## Out of Scope
+
+- **Multi-hub federation / cross-host hub replication.** Out of band.
+- **Hub-side authentication beyond fossil user management.** Caller passes raw `Caps` strings; everything else is fossil's user table.
+- **Embedded `fossil` binary support.** In-process libfossil only.
+- **Public OTel / metrics surface.** If `leaf/telemetry` is wired in, hub hooks in; otherwise no-op. No new telemetry interface added at this stage.
+
+## Integration with the Leaf Agent
+
+A leaf agent boots with `NATSUpstream: hub.NATSURL()` (or pulls the leaf-node URL via `hub.LeafUpstream()` for the leaf-node path). Sync goes over the HTTP-xfer transport — leaves construct an HTTP transport against `hub.HTTPAddr()` and call `Agent.SyncTo(...)`. End-to-end coverage of this path is locked by `sim/hub_leaf_test.go::TestHubLeafE2E` (see [testing-strategy.md](./testing-strategy.md)).
+
+## Cross-references
+
+- [agent-deployment.md](./agent-deployment.md) — leaf agent lifecycle and the NATS mesh roles that consume `hub.LeafUpstream()`.
+- [sync-protocol.md](./sync-protocol.md) — the xfer wire format the hub serves at `/`.
+- [core-library.md](./core-library.md) — libfossil's opaque-handle API the hub wraps internally.


### PR DESCRIPTION
## Summary

- New `docs/architecture/hub-package.md`: condensed ADR for the hub package shipped in PR #109 and updated in PR #122 (deadlock fix).
- Listed at the top of `CLAUDE.md` alongside the other ADRs.
- Cross-referenced from `agent-deployment.md` (with a short Hub Package section between Leaf Agent and Bridge — they're the three deployment-shape components).

Closes #114.

### What the ADR captures

- Public API surface: `Config`, `NewHub`, `ServeHTTP`, `Stop`, address accessors, user mgmt, commits/reads. All libfossil-free.
- **Lifecycle ordering** — HTTP listener bound during `NewHub` so `HTTPAddr()` is immediately usable; NATS waits for `ReadyForConnections` before `NewHub` returns.
- **SQLite tuning** — busy_timeout=30s yes; `MaxOpenConns(1)` deliberately no, with #120 as the cautionary tale.
- **Layout decision** — in-root vs. separate `go.mod`. Picked in-root for ship-in-lockstep; #118 tracks the migration to a separate module if a consumer needs it.
- **Out of scope** — multi-hub federation, auth-beyond-fossil-users, embedded fossil binary, public OTel surface.
- **Cross-references** — agent-deployment, sync-protocol, core-library.

Length and density match the existing ADRs (~100 lines, between `wasm-targets.md`'s 43 and `notify-messaging.md`'s 394).

## Test plan

- [x] Markdown renders cleanly (no broken links to ADR siblings)
- [x] All cross-references point at files that exist
- [ ] CI green (docs-only PR; only Workers Builds will run)