### PR TITLE
feat(notify): add NewServiceFromPath constructor (#115)

### DIFF
--- a/leaf/agent/notify/notify.go
+++ b/leaf/agent/notify/notify.go
@@ -29,6 +29,7 @@ type Service struct {
 	config    ServiceConfig
 	threadMap map[string]string // thread-short -> full thread ID cache
 	mu        sync.Mutex
+	ownsRepo  bool // true when the Service was constructed via NewServiceFromPath
 }
 
 // NewService creates a new notify Service. Repo must be non-nil.
@@ -50,10 +51,59 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 	}, nil
 }
 
-// Close unsubscribes from NATS. Does NOT close the repo.
+// ServiceFromPathConfig holds configuration for NewServiceFromPath.
+type ServiceFromPathConfig struct {
+	RepoPath string     // notify.fossil path; created if absent
+	NATSConn *nats.Conn // May be nil for repo-only mode
+	From     string     // iroh endpoint ID
+	FromName string     // Human-readable name
+}
+
+// NewServiceFromPath creates a Service that opens (or creates) the notify
+// repo at the given path. Unlike NewService — which expects a pre-opened
+// repo and leaves ownership with the caller — this constructor owns the
+// repo lifecycle: Close() will close it.
+//
+// If the repo already exists at RepoPath, it's opened. If not, it's
+// created via InitNotifyRepo.
+func NewServiceFromPath(cfg ServiceFromPathConfig) (*Service, error) {
+	if cfg.RepoPath == "" {
+		return nil, fmt.Errorf("notify: ServiceFromPathConfig.RepoPath is required")
+	}
+	repo, err := libfossil.Open(cfg.RepoPath)
+	if err != nil {
+		repo, err = InitNotifyRepo(cfg.RepoPath)
+		if err != nil {
+			return nil, fmt.Errorf("notify: open or create notify repo at %s: %w", cfg.RepoPath, err)
+		}
+	}
+	s, err := NewService(ServiceConfig{
+		Repo:     repo,
+		NATSConn: cfg.NATSConn,
+		From:     cfg.From,
+		FromName: cfg.FromName,
+	})
+	if err != nil {
+		repo.Close()
+		return nil, err
+	}
+	s.ownsRepo = true
+	return s, nil
+}
+
+// Close unsubscribes from NATS. When the Service was constructed via
+// NewServiceFromPath, also closes the underlying repo. When constructed
+// via NewService, the repo is left open (caller retains ownership).
 func (s *Service) Close() error {
 	if s.sub != nil {
 		s.sub.Unsubscribe()
+	}
+	if s.ownsRepo && s.repo != nil {
+		err := s.repo.Close()
+		s.repo = nil
+		if err != nil {
+			return fmt.Errorf("notify: close repo: %w", err)
+		}
 	}
 	return nil
 }

--- a/leaf/agent/notify/service_from_path_test.go
+++ b/leaf/agent/notify/service_from_path_test.go
@@ -1,0 +1,133 @@
+package notify
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+func TestNewServiceFromPath_FreshPath_CreatesRepo(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "notify.fossil")
+
+	svc, err := NewServiceFromPath(ServiceFromPathConfig{
+		RepoPath: repoPath,
+		From:     "endpoint-test",
+		FromName: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewServiceFromPath: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	// Round-trip a message through the Service.
+	msg, err := svc.Send(SendOpts{Project: "p1", Body: "hello"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	got, err := svc.ReadThread(context.Background(), "p1", msg.ThreadShort())
+	if err != nil {
+		t.Fatalf("ReadThread: %v", err)
+	}
+	if len(got) != 1 || got[0].Body != "hello" {
+		t.Errorf("ReadThread = %+v, want one msg with Body=hello", got)
+	}
+}
+
+func TestNewServiceFromPath_ExistingPath_OpensRepo(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "notify.fossil")
+
+	// Phase 1: create + send via path-based constructor.
+	svc1, err := NewServiceFromPath(ServiceFromPathConfig{
+		RepoPath: repoPath,
+		From:     "endpoint-test",
+		FromName: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewServiceFromPath phase 1: %v", err)
+	}
+	msg, err := svc1.Send(SendOpts{Project: "p1", Body: "first"})
+	if err != nil {
+		t.Fatalf("Send phase 1: %v", err)
+	}
+	if err := svc1.Close(); err != nil {
+		t.Fatalf("Close phase 1: %v", err)
+	}
+
+	// Phase 2: re-open via the path constructor and confirm the message
+	// is still readable.
+	svc2, err := NewServiceFromPath(ServiceFromPathConfig{
+		RepoPath: repoPath,
+		From:     "endpoint-test",
+		FromName: "test",
+	})
+	if err != nil {
+		t.Fatalf("NewServiceFromPath phase 2: %v", err)
+	}
+	t.Cleanup(func() { _ = svc2.Close() })
+
+	got, err := svc2.ReadThread(context.Background(), "p1", msg.ThreadShort())
+	if err != nil {
+		t.Fatalf("ReadThread phase 2: %v", err)
+	}
+	if len(got) != 1 || got[0].Body != "first" {
+		t.Errorf("ReadThread after reopen = %+v, want one msg with Body=first", got)
+	}
+}
+
+func TestNewServiceFromPath_RejectsEmptyPath(t *testing.T) {
+	_, err := NewServiceFromPath(ServiceFromPathConfig{})
+	if err == nil {
+		t.Fatal("NewServiceFromPath with empty RepoPath should error")
+	}
+}
+
+// TestNewServiceFromPath_ClosesOwnedRepo verifies that Close() releases the
+// repo file when constructed via NewServiceFromPath. We confirm by re-
+// opening the same path with libfossil.Open after Close — that should
+// succeed without "database is locked" errors that the prior owner would
+// otherwise hold.
+func TestNewServiceFromPath_ClosesOwnedRepo(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "notify.fossil")
+
+	svc, err := NewServiceFromPath(ServiceFromPathConfig{
+		RepoPath: repoPath,
+		From:     "endpoint-test",
+	})
+	if err != nil {
+		t.Fatalf("NewServiceFromPath: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Should be able to open the repo independently after Service.Close.
+	r, err := libfossil.Open(repoPath)
+	if err != nil {
+		t.Fatalf("libfossil.Open after Service.Close: %v", err)
+	}
+	r.Close()
+}
+
+// TestNewService_DoesNotOwnRepo verifies the existing NewService contract
+// is unchanged: Close() does NOT close the repo.
+func TestNewService_DoesNotOwnRepo(t *testing.T) {
+	r := createTestRepo(t) // owned by test harness, registered cleanup
+	svc, err := NewService(ServiceConfig{Repo: r, From: "x"})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if err := svc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Repo should still be open — Config() should succeed against it.
+	if _, err := r.Config("project-code"); err != nil {
+		t.Errorf("repo unexpectedly closed by Service.Close: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `NewServiceFromPath` constructor on `notify.Service`. Open-or-create semantics (matches `hub.NewHub`) — opens an existing notify.fossil if present, otherwise calls `InitNotifyRepo`.
- Adds `ownsRepo` flag on `Service`. `Service.Close()` now closes the repo only when the Service was constructed via `NewServiceFromPath`. Existing `NewService` semantics are unchanged: caller retains ownership of the pre-opened repo.
- 5 tests cover: fresh-path creation + round-trip, existing-path re-open + reads back prior data, empty-path rejection, owned-repo close releases the file, `NewService` Close does **not** close the caller's repo.

Closes #115.

### Decision worth flagging: open-or-create

The brief described the constructor as "creates the repo if absent." Implemented as full open-or-create — if the repo already exists, the Service opens it instead of erroring. Same shape as `hub.NewHub`. This makes re-running a Service against the same path a no-op, which is what consumers expect for restart scenarios.

## Test plan

- [x] `cd leaf && go test -count=1 -race -run 'TestNewServiceFromPath|TestNewService_' ./agent/notify/` — 5 tests green
- [x] `make test` — full suite green
- [ ] CI green