### PR TITLE
ci(bump-upstream): walk every go.mod in the repo (#127)

### DIFF
--- a/.github/workflows/bump-upstream.yml
+++ b/.github/workflows/bump-upstream.yml
@@ -92,7 +92,7 @@ jobs:
           go-version-file: go.mod
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
-        name: Bump module
+        name: Bump module in every go.mod
         id: bump
         env:
           BRANCH: ${{ steps.in.outputs.branch }}
@@ -100,27 +100,57 @@ jobs:
           VERSION: ${{ steps.in.outputs.version }}
         run: |
           git switch -c "$BRANCH"
-          for i in 1 2 3; do
-            if go get "${MODULE}@${VERSION}"; then
-              break
+
+          # Walk every go.mod in the repo. Skip modules that don't depend on
+          # $MODULE (otherwise `go get` would add it as a new dep).
+          mapfile -t GOMODS < <(find . -name go.mod -not -path './.git/*' -not -path './node_modules/*' | sort)
+          echo "::notice::Found ${#GOMODS[@]} go.mod file(s): ${GOMODS[*]}"
+
+          any_changed=false
+          for gomod in "${GOMODS[@]}"; do
+            d=$(dirname "$gomod")
+            if ! grep -qE "^[[:space:]]*${MODULE}([[:space:]]|$)" "$gomod"; then
+              echo "::notice::${d}: ${MODULE} not a direct dep — skipping"
+              continue
             fi
-            if [ "$i" -lt 3 ]; then
-              echo "::notice::go get failed (attempt $i/3) — likely GOPROXY propagation race; retrying in 15s..."
-              sleep 15
+            pushd "$d" >/dev/null
+            for i in 1 2 3; do
+              if go get "${MODULE}@${VERSION}"; then
+                break
+              fi
+              if [ "$i" -lt 3 ]; then
+                echo "::notice::${d}: go get failed (attempt ${i}/3) — likely GOPROXY propagation race; retrying in 15s..."
+                sleep 15
+              else
+                echo "::error::${d}: go get failed after 3 attempts"
+                exit 1
+              fi
+            done
+            go mod tidy
+            if ! git diff --quiet go.mod go.sum; then
+              any_changed=true
+              echo "::notice::${d}: bumped"
             else
-              echo "::error::go get failed after 3 attempts"
-              exit 1
+              echo "::notice::${d}: already at ${VERSION}, no diff"
             fi
+            popd >/dev/null
           done
-          go mod tidy
-          if git diff --quiet go.mod go.sum; then
-            echo "::notice::No-op bump — version already pinned"
+
+          if [ "$any_changed" = "false" ]; then
+            echo "::notice::No-op bump — version already pinned in every module"
             echo "noop=true" >> "$GITHUB_OUTPUT"
           fi
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true' && steps.bump.outputs.noop != 'true'
-        name: Verify build
-        run: go build ./...
+        name: Verify build for every module
+        run: |
+          mapfile -t GOMODS < <(find . -name go.mod -not -path './.git/*' -not -path './node_modules/*' | sort)
+          for gomod in "${GOMODS[@]}"; do
+            d=$(dirname "$gomod")
+            echo "::group::go build ./... in ${d}"
+            (cd "$d" && go build ./...)
+            echo "::endgroup::"
+          done
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true' && steps.bump.outputs.noop != 'true'
         name: Commit + push + open PR
@@ -136,7 +166,12 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add go.mod go.sum
+          # Stage every changed go.mod and go.sum across the repo.
+          mapfile -t GOMODS < <(find . -name go.mod -not -path './.git/*' -not -path './node_modules/*' | sort)
+          for gomod in "${GOMODS[@]}"; do
+            d=$(dirname "$gomod")
+            git add "${d}/go.mod" "${d}/go.sum" 2>/dev/null || true
+          done
           git commit -m "chore: bump ${REPO} → ${VERSION}"
           git push -u origin "$BRANCH"
           gh pr create \
@@ -149,4 +184,4 @@ jobs:
           - Tag SHA: \`${TAG_SHA}\`
           - Triggered by: @${ACTOR}
 
-          CI must pass before merge. Review go.sum diff for transitive surprises."
+          Updated every \`go.mod\` in the repo that depends on \`${MODULE}\`. CI must pass before merge. Review \`go.sum\` diffs for transitive surprises."


### PR DESCRIPTION
## Summary

The `Bump module`, `Verify build`, and `Commit + push + open PR` steps in `.github/workflows/bump-upstream.yml` previously only operated on the root `go.mod`. After this change all three iterate every `go.mod` file in the repo:

- `Bump module in every go.mod` — find every `go.mod`, skip ones where the target module isn't a direct dep (avoids `go get` adding it as a new dep), run `go get @V` + `go mod tidy` in each. Aggregate no-op detection across all modules.
- `Verify build for every module` — `go build ./...` per module dir.
- `Commit + push + open PR` — `git add` every `go.mod` / `go.sum` pair.

Closes #127. Motivated by what happened when libfossil v0.5.0 dispatched (#121): only root bumped, `leaf/go.mod` and `bridge/go.mod` stayed on v0.4.5 until I patched the PR by hand.

### Why find-based vs. hard-coded list

`find . -name go.mod` automatically picks up future modules. When the hub package is promoted to its own module (#118) or any other new module is added under the repo, the workflow Just Works — no edits required. Hard-coding `for d in . leaf bridge` was the alternative; the find-based version is the same line count and self-maintaining.

The find call excludes `.git/` and `node_modules/` (the latter for paranoia — there's no Node deps today, but if a docs tool ever lands one, we shouldn't recurse into it).

### Verified locally

Dry-ran the find/grep logic against this repo's main:

```
Found 4 go.mod file(s):
  ./bridge/go.mod
  ./docs/site/go.mod
  ./go.mod
  ./leaf/go.mod
[check] ./bridge: depends on github.com/danmestas/libfossil
[skip] ./docs/site: github.com/danmestas/libfossil not a direct dep
[check] .: depends on github.com/danmestas/libfossil
[check] ./leaf: depends on github.com/danmestas/libfossil
```

Correctly identifies the three modules that depend on libfossil and skips the Hugo site under `docs/site/`.

### What I didn't do (and why)

- **Didn't trigger an actual workflow_dispatch run as a smoke test.** That would re-bump libfossil to v0.5.0 across the repo, opening a duplicate PR. The idempotency check on the `chore/bump-libfossil-v0.5.0` branch name prevents real damage, but the better validation is the next libfossil release (or any future bump). If you want an immediate live test, can dispatch with a synthetic version that's already tagged.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML syntax valid
- [x] Local dry-run of the find/grep logic produces the expected per-module classification
- [x] `make test` green (workflow change only; no Go code touched)
- [ ] CI green (only Workers Builds; this is a workflow file change)
- [ ] First real upstream bump after merge demonstrates all three modules update