### PR TITLE
feat(hub): add OpenRepo + *hub.Repo type for server-less ops (#131)

### DIFF
--- a/hub/commit.go
+++ b/hub/commit.go
@@ -1,12 +1,6 @@
 package hub
 
-import (
-	"context"
-	"errors"
-	"fmt"
-
-	libfossil "github.com/danmestas/libfossil"
-)
+import "context"
 
 // RevID is an opaque commit handle.
 type RevID string
@@ -17,7 +11,7 @@ type FileToCommit struct {
 	Content []byte
 }
 
-// CommitOpts configures Hub.Commit.
+// CommitOpts configures Hub.Commit / Repo.Commit.
 type CommitOpts struct {
 	Files   []FileToCommit
 	Message string
@@ -26,34 +20,16 @@ type CommitOpts struct {
 
 // Commit commits a set of files to the hub repo.
 func (h *Hub) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
-	if opts.Author == "" {
-		return "", errors.New("hub: Commit: Author is required")
-	}
-	files := make([]libfossil.FileToCommit, len(opts.Files))
-	for i, f := range opts.Files {
-		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
-	}
-	_, uuid, err := h.repo.Commit(libfossil.CommitOpts{
-		Files:   files,
-		Comment: opts.Message,
-		User:    opts.Author,
-	})
-	if err != nil {
-		return "", fmt.Errorf("hub: commit: %w", err)
-	}
-	return RevID(uuid), nil
+	return h.repo.Commit(ctx, opts)
 }
 
 // Read returns the contents of path at the current trunk tip.
 func (h *Hub) Read(ctx context.Context, path string) ([]byte, error) {
-	return h.repo.ReadFileAt("trunk", path)
+	return h.repo.Read(ctx, path)
 }
 
 // ReadAt returns the contents of path at rev. rev may be a branch name
 // (e.g. "trunk"), a tag, or a RevID returned from Commit.
 func (h *Hub) ReadAt(ctx context.Context, rev RevID, path string) ([]byte, error) {
-	if rev == "" {
-		return nil, errors.New("hub: ReadAt: rev is required (use Read for current tip)")
-	}
-	return h.repo.ReadFileAt(string(rev), path)
+	return h.repo.ReadAt(ctx, rev, path)
 }

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -53,7 +53,7 @@ type Config struct {
 // Hub hosts an EdgeSync hub in-process. Construct one via NewHub, then call
 // ServeHTTP in a goroutine. Use Stop to tear everything down.
 type Hub struct {
-	repo       *libfossil.Repo
+	repo       *Repo
 	server     *natsserver.Server
 	httpListener net.Listener
 	httpServer *http.Server
@@ -79,11 +79,12 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		cfg.NATSStoreDir = filepath.Join(filepath.Dir(cfg.RepoPath), "nats-store")
 	}
 
-	repo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser)
+	libfossilRepo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser)
 	if err != nil {
 		return nil, err
 	}
-	applySQLiteTuning(repo)
+	applySQLiteTuning(libfossilRepo)
+	repo := newRepoFromHandle(libfossilRepo)
 
 	httpAddr := fmt.Sprintf("127.0.0.1:%d", cfg.FossilHTTPPort)
 	httpLn, err := net.Listen("tcp", httpAddr)
@@ -120,7 +121,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 // Stop is called.
 func (h *Hub) ServeHTTP(ctx context.Context) error {
 	mux := http.NewServeMux()
-	mux.Handle("/", h.repo.XferHandler())
+	mux.Handle("/", h.repo.handle.XferHandler())
 
 	srv := &http.Server{Handler: mux}
 	h.httpServer = srv
@@ -158,7 +159,7 @@ func (h *Hub) Stop() error {
 		}
 		if h.repo != nil {
 			if err := h.repo.Close(); err != nil && firstErr == nil {
-				firstErr = fmt.Errorf("hub: close repo: %w", err)
+				firstErr = err
 			}
 		}
 	})
@@ -175,6 +176,13 @@ func (h *Hub) LeafUpstream() string { return h.leafUpstream }
 
 // HTTPAddr returns the host:port the fossil HTTP server is bound to.
 func (h *Hub) HTTPAddr() string { return h.httpAddr }
+
+// Repo returns the underlying fossil-repo handle the hub serves from. Use
+// this to share the handle with another component in the same process —
+// e.g. a coexisting CLI command path that needs user/commit/read access
+// without re-opening the file. Don't call Close on the returned *Repo
+// while the Hub is still serving; use Hub.Stop for teardown.
+func (h *Hub) Repo() *Repo { return h.repo }
 
 func openOrCreateRepo(path, bootstrapUser string) (*libfossil.Repo, error) {
 	if r, err := libfossil.Open(path); err == nil {

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -1,0 +1,148 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// Repo is a hub fossil repo opened for direct operations — user mgmt,
+// commits, reads. No embedded NATS server, no HTTP listener; it's the
+// right handle for one-off CLI invocations like `<binary> hub user list`
+// where spinning up the full hub daemon would be wasteful.
+//
+// For the daemon use case (running hub serving leaves), construct a
+// *Hub via NewHub. A *Hub holds a *Repo internally; access it via
+// Hub.Repo if you need to share the handle with another component
+// in the same process. Don't call Close on a *Repo returned by
+// Hub.Repo while the Hub is still serving — Hub.Stop is the right
+// teardown for that case.
+type Repo struct {
+	handle  *libfossil.Repo
+	closeMu sync.Mutex
+	closed  bool
+}
+
+// OpenRepo opens an existing hub repo at path. Returns an error if the
+// path doesn't exist or isn't a valid fossil repo. The caller owns the
+// returned *Repo and must Close it when done.
+func OpenRepo(path string) (*Repo, error) {
+	if path == "" {
+		return nil, errors.New("hub: OpenRepo: path is required")
+	}
+	h, err := libfossil.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("hub: open repo at %s: %w", path, err)
+	}
+	applySQLiteTuning(h)
+	return &Repo{handle: h}, nil
+}
+
+// newRepoFromHandle wraps an already-opened libfossil handle as a *Repo.
+// Used internally by NewHub so the Hub and direct Repo callers share
+// method bodies.
+func newRepoFromHandle(h *libfossil.Repo) *Repo {
+	return &Repo{handle: h}
+}
+
+// Close releases the underlying libfossil handle. Idempotent — second
+// and subsequent calls return nil.
+func (r *Repo) Close() error {
+	r.closeMu.Lock()
+	defer r.closeMu.Unlock()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if err := r.handle.Close(); err != nil {
+		return fmt.Errorf("hub: close repo: %w", err)
+	}
+	return nil
+}
+
+// AddUser creates a fossil user. Errors if Login is empty or the user
+// already exists.
+func (r *Repo) AddUser(u User) error {
+	if u.Login == "" {
+		return errors.New("hub: AddUser: Login is required")
+	}
+	if err := r.handle.CreateUser(libfossil.UserOpts{Login: u.Login, Caps: u.Caps}); err != nil {
+		return fmt.Errorf("hub: add user %q: %w", u.Login, err)
+	}
+	return nil
+}
+
+// GetUser returns the user with the given login. Errors if no such user
+// exists.
+func (r *Repo) GetUser(login string) (User, error) {
+	u, err := r.handle.GetUser(login)
+	if err != nil {
+		return User{}, fmt.Errorf("hub: get user %q: %w", login, err)
+	}
+	return User{Login: u.Login, Caps: u.Caps}, nil
+}
+
+// HasUser reports whether a user with the given login exists.
+func (r *Repo) HasUser(login string) bool {
+	_, err := r.handle.GetUser(login)
+	return err == nil
+}
+
+// ListUsers returns all users on the hub repo.
+func (r *Repo) ListUsers() ([]User, error) {
+	users, err := r.handle.ListUsers()
+	if err != nil {
+		return nil, fmt.Errorf("hub: list users: %w", err)
+	}
+	out := make([]User, len(users))
+	for i, u := range users {
+		out[i] = User{Login: u.Login, Caps: u.Caps}
+	}
+	return out, nil
+}
+
+// RemoveUser deletes the user with the given login.
+func (r *Repo) RemoveUser(login string) error {
+	if err := r.handle.DeleteUser(login); err != nil {
+		return fmt.Errorf("hub: remove user %q: %w", login, err)
+	}
+	return nil
+}
+
+// Commit commits a set of files to the hub repo with the given message
+// and author. Returns the new manifest UUID as an opaque RevID.
+func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
+	if opts.Author == "" {
+		return "", errors.New("hub: Commit: Author is required")
+	}
+	files := make([]libfossil.FileToCommit, len(opts.Files))
+	for i, f := range opts.Files {
+		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
+	}
+	_, uuid, err := r.handle.Commit(libfossil.CommitOpts{
+		Files:   files,
+		Comment: opts.Message,
+		User:    opts.Author,
+	})
+	if err != nil {
+		return "", fmt.Errorf("hub: commit: %w", err)
+	}
+	return RevID(uuid), nil
+}
+
+// Read returns the contents of path at the current trunk tip.
+func (r *Repo) Read(ctx context.Context, path string) ([]byte, error) {
+	return r.handle.ReadFileAt("trunk", path)
+}
+
+// ReadAt returns the contents of path at rev. rev may be a branch name
+// (e.g. "trunk"), a tag, or a RevID returned from Commit.
+func (r *Repo) ReadAt(ctx context.Context, rev RevID, path string) ([]byte, error) {
+	if rev == "" {
+		return nil, errors.New("hub: ReadAt: rev is required (use Read for current tip)")
+	}
+	return r.handle.ReadFileAt(string(rev), path)
+}

--- a/hub/repo_test.go
+++ b/hub/repo_test.go
@@ -1,0 +1,167 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenRepo_RoundTrip exercises every *Repo method via OpenRepo on a
+// path that NewHub previously bootstrapped — proving CLI-style and
+// daemon-style code paths produce equivalent observable state.
+func TestOpenRepo_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	// Phase 1: bootstrap via NewHub, seed some state.
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	if _, err := h.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("seed")}},
+		Message: "seed",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("Hub.Commit: %v", err)
+	}
+	if err := h.AddUser(User{Login: "alice", Caps: "admin"}); err != nil {
+		t.Fatalf("Hub.AddUser: %v", err)
+	}
+	_ = h.Stop()
+
+	// Phase 2: re-open via OpenRepo — same state should be visible.
+	r, err := OpenRepo(repoPath)
+	if err != nil {
+		t.Fatalf("OpenRepo: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, err := r.Read(context.Background(), "seed.txt")
+	if err != nil {
+		t.Fatalf("Repo.Read: %v", err)
+	}
+	if !bytes.Equal(got, []byte("seed")) {
+		t.Errorf("Repo.Read seed.txt = %q, want %q", got, "seed")
+	}
+
+	if !r.HasUser("alice") {
+		t.Error("Repo.HasUser(alice) = false after NewHub seeded")
+	}
+
+	user, err := r.GetUser("alice")
+	if err != nil {
+		t.Fatalf("Repo.GetUser: %v", err)
+	}
+	if user.Login != "alice" || user.Caps != "admin" {
+		t.Errorf("Repo.GetUser = %+v, want {alice admin}", user)
+	}
+
+	users, err := r.ListUsers()
+	if err != nil {
+		t.Fatalf("Repo.ListUsers: %v", err)
+	}
+	if len(users) == 0 {
+		t.Error("Repo.ListUsers returned empty")
+	}
+
+	// New commit + new user via the *Repo path.
+	rev, err := r.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "from-repo.txt", Content: []byte("v")}},
+		Message: "from repo",
+		Author:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("Repo.Commit: %v", err)
+	}
+	if rev == "" {
+		t.Fatal("Repo.Commit returned empty RevID")
+	}
+	gotRev, err := r.ReadAt(context.Background(), rev, "from-repo.txt")
+	if err != nil {
+		t.Fatalf("Repo.ReadAt: %v", err)
+	}
+	if !bytes.Equal(gotRev, []byte("v")) {
+		t.Errorf("Repo.ReadAt = %q, want %q", gotRev, "v")
+	}
+
+	if err := r.AddUser(User{Login: "bob", Caps: "ro"}); err != nil {
+		t.Fatalf("Repo.AddUser: %v", err)
+	}
+	if err := r.RemoveUser("bob"); err != nil {
+		t.Fatalf("Repo.RemoveUser: %v", err)
+	}
+	if r.HasUser("bob") {
+		t.Error("HasUser(bob) = true after RemoveUser")
+	}
+}
+
+func TestOpenRepo_RejectsEmptyPath(t *testing.T) {
+	if _, err := OpenRepo(""); err == nil {
+		t.Fatal("OpenRepo with empty path should error")
+	}
+}
+
+func TestOpenRepo_RejectsMissingPath(t *testing.T) {
+	if _, err := OpenRepo(filepath.Join(t.TempDir(), "does-not-exist.fossil")); err == nil {
+		t.Fatal("OpenRepo with non-existent path should error")
+	}
+}
+
+func TestRepo_Close_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	// Bootstrap a fossil at this path so OpenRepo can succeed.
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	_ = h.Stop()
+
+	r, err := OpenRepo(repoPath)
+	if err != nil {
+		t.Fatalf("OpenRepo: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("second Close: %v (want nil)", err)
+	}
+}
+
+// TestHub_Repo_AccessorReturnsLiveHandle proves Hub.Repo() returns a *Repo
+// whose lifecycle is bound to the Hub. Operations against it observe the
+// same state as Hub.* methods.
+func TestHub_Repo_AccessorReturnsLiveHandle(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	if err := h.AddUser(User{Login: "alice"}); err != nil {
+		t.Fatalf("Hub.AddUser: %v", err)
+	}
+
+	r := h.Repo()
+	if r == nil {
+		t.Fatal("Hub.Repo returned nil")
+	}
+	if !r.HasUser("alice") {
+		t.Error("Repo.HasUser(alice) = false after Hub.AddUser")
+	}
+
+	// Adding via *Repo is observable via *Hub.
+	if err := r.AddUser(User{Login: "bob"}); err != nil {
+		t.Fatalf("Repo.AddUser: %v", err)
+	}
+	if !h.HasUser("bob") {
+		t.Error("Hub.HasUser(bob) = false after Repo.AddUser")
+	}
+}

--- a/hub/users.go
+++ b/hub/users.go
@@ -1,12 +1,5 @@
 package hub
 
-import (
-	"errors"
-	"fmt"
-
-	libfossil "github.com/danmestas/libfossil"
-)
-
 // User describes a fossil user on the hub repo.
 type User struct {
 	Login string
@@ -15,49 +8,17 @@ type User struct {
 
 // AddUser creates a fossil user. Returns an error if Login is empty or the
 // user already exists.
-func (h *Hub) AddUser(u User) error {
-	if u.Login == "" {
-		return errors.New("hub: AddUser: Login is required")
-	}
-	if err := h.repo.CreateUser(libfossil.UserOpts{Login: u.Login, Caps: u.Caps}); err != nil {
-		return fmt.Errorf("hub: add user %q: %w", u.Login, err)
-	}
-	return nil
-}
+func (h *Hub) AddUser(u User) error { return h.repo.AddUser(u) }
 
 // GetUser returns the user with the given login. Returns an error if no
 // such user exists.
-func (h *Hub) GetUser(login string) (User, error) {
-	u, err := h.repo.GetUser(login)
-	if err != nil {
-		return User{}, fmt.Errorf("hub: get user %q: %w", login, err)
-	}
-	return User{Login: u.Login, Caps: u.Caps}, nil
-}
+func (h *Hub) GetUser(login string) (User, error) { return h.repo.GetUser(login) }
 
 // HasUser reports whether a user with the given login exists.
-func (h *Hub) HasUser(login string) bool {
-	_, err := h.repo.GetUser(login)
-	return err == nil
-}
+func (h *Hub) HasUser(login string) bool { return h.repo.HasUser(login) }
 
 // ListUsers returns all users on the hub.
-func (h *Hub) ListUsers() ([]User, error) {
-	users, err := h.repo.ListUsers()
-	if err != nil {
-		return nil, fmt.Errorf("hub: list users: %w", err)
-	}
-	out := make([]User, len(users))
-	for i, u := range users {
-		out[i] = User{Login: u.Login, Caps: u.Caps}
-	}
-	return out, nil
-}
+func (h *Hub) ListUsers() ([]User, error) { return h.repo.ListUsers() }
 
 // RemoveUser deletes the user with the given login.
-func (h *Hub) RemoveUser(login string) error {
-	if err := h.repo.DeleteUser(login); err != nil {
-		return fmt.Errorf("hub: remove user %q: %w", login, err)
-	}
-	return nil
-}
+func (h *Hub) RemoveUser(login string) error { return h.repo.RemoveUser(login) }


### PR DESCRIPTION
## Summary

- Adds `hub.OpenRepo(path) (*Repo, error)` — server-less handle for one-off CLI invocations and short-lived helpers.
- New `*hub.Repo` type carries every user/commit/read method `*hub.Hub` used to define on itself; `*hub.Hub` now holds a `*Repo` internally and delegates. Method bodies live once.
- `Hub.Repo() *Repo` accessor returns the live handle out of a running hub.
- 4 new tests cover OpenRepo round-trip, edge cases (empty/missing path), idempotent Close, and Hub↔Repo state coherence via `Hub.Repo()`.

Closes #131. Unblocks bones's CLI / lease / plan-finalize sites that currently drop to `libfossil.Open` because `NewHub` was monolithic.

### Lifecycle contract worth noting

The `*Repo` returned by `Hub.Repo()` shares the libfossil handle with the running Hub. Don't call `Close` on it while the Hub is still serving — `Hub.Stop` is the right teardown. `Repo.Close` is idempotent (returns nil on subsequent calls), so accidental double-close from teardown ordering is safe.

### Why no embedding

Considered embedding `*Repo` in `Hub` for free method promotion, but that would also promote `Repo.Close` onto `Hub` — a footgun where `hub.Close()` would close the libfossil handle without tearing down NATS. Manual delegation costs ~12 lines and avoids the trap.

## Test plan

- [x] `go test -count=1 -race ./hub/...` — all green (existing 11 + 4 new)
- [x] `make test` — full suite green including the e2e
- [ ] CI green