### PR TITLE
feat(hub): SetUserCaps + Config.NobodyCaps (#130)

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -48,6 +48,12 @@ type Config struct {
 	// NATSLeafPort is the leafnode listener port for remote agents.
 	// 0 = auto-pick.
 	NATSLeafPort int
+
+	// NobodyCaps grants the libfossil-pre-populated 'nobody' user these
+	// caps after hub bootstrap. Empty leaves nobody at libfossil's defaults
+	// (no caps; unauthenticated requests are rejected). Set to "gio" to
+	// allow unauthenticated clone/pull/push, the typical hub deployment.
+	NobodyCaps string
 }
 
 // Hub hosts an EdgeSync hub in-process. Construct one via NewHub, then call
@@ -85,6 +91,13 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 	}
 	applySQLiteTuning(libfossilRepo)
 	repo := newRepoFromHandle(libfossilRepo)
+
+	if cfg.NobodyCaps != "" {
+		if err := repo.SetUserCaps("nobody", cfg.NobodyCaps); err != nil {
+			repo.Close()
+			return nil, fmt.Errorf("hub: apply NobodyCaps: %w", err)
+		}
+	}
 
 	httpAddr := fmt.Sprintf("127.0.0.1:%d", cfg.FossilHTTPPort)
 	httpLn, err := net.Listen("tcp", httpAddr)

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -112,6 +112,18 @@ func (r *Repo) RemoveUser(login string) error {
 	return nil
 }
 
+// SetUserCaps replaces the caps string on an existing user. Errors if the
+// user doesn't exist or the underlying SetCaps fails.
+func (r *Repo) SetUserCaps(login, caps string) error {
+	if login == "" {
+		return errors.New("hub: SetUserCaps: login is required")
+	}
+	if err := r.handle.SetCaps(login, caps); err != nil {
+		return fmt.Errorf("hub: set caps for %q: %w", login, err)
+	}
+	return nil
+}
+
 // Commit commits a set of files to the hub repo with the given message
 // and author. Returns the new manifest UUID as an opaque RevID.
 func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {

--- a/hub/repo_test.go
+++ b/hub/repo_test.go
@@ -132,6 +132,136 @@ func TestRepo_Close_IsIdempotent(t *testing.T) {
 	}
 }
 
+// TestRepo_SetUserCaps_RoundTrip exercises SetUserCaps against an existing
+// user. The 'nobody' user is libfossil-pre-populated with empty caps;
+// SetUserCaps replaces them.
+func TestRepo_SetUserCaps_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	_ = h.Stop()
+
+	r, err := OpenRepo(repoPath)
+	if err != nil {
+		t.Fatalf("OpenRepo: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	if err := r.SetUserCaps("nobody", "gio"); err != nil {
+		t.Fatalf("SetUserCaps: %v", err)
+	}
+	got, err := r.GetUser("nobody")
+	if err != nil {
+		t.Fatalf("GetUser nobody: %v", err)
+	}
+	if got.Caps != "gio" {
+		t.Errorf("nobody.Caps = %q, want %q", got.Caps, "gio")
+	}
+}
+
+func TestRepo_SetUserCaps_RejectsEmptyLogin(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	_ = h.Stop()
+
+	r, err := OpenRepo(repoPath)
+	if err != nil {
+		t.Fatalf("OpenRepo: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	if err := r.SetUserCaps("", "gio"); err == nil {
+		t.Fatal("SetUserCaps with empty login should error")
+	}
+}
+
+// TestNewHub_NobodyCaps_AppliedAtBootstrap proves Config.NobodyCaps is
+// applied during NewHub so unauthenticated request setup is one-line.
+func TestNewHub_NobodyCaps_AppliedAtBootstrap(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(context.Background(), Config{
+		RepoPath:   repoPath,
+		NobodyCaps: "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	got, err := h.GetUser("nobody")
+	if err != nil {
+		t.Fatalf("Hub.GetUser nobody: %v", err)
+	}
+	if got.Caps != "gio" {
+		t.Errorf("nobody.Caps after bootstrap = %q, want %q", got.Caps, "gio")
+	}
+}
+
+// TestNewHub_NobodyCaps_Idempotent proves calling NewHub twice with the
+// same NobodyCaps on an existing repo leaves the same end state.
+func TestNewHub_NobodyCaps_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h1, err := NewHub(context.Background(), Config{RepoPath: repoPath, NobodyCaps: "gio"})
+	if err != nil {
+		t.Fatalf("NewHub phase 1: %v", err)
+	}
+	_ = h1.Stop()
+
+	h2, err := NewHub(context.Background(), Config{RepoPath: repoPath, NobodyCaps: "gio"})
+	if err != nil {
+		t.Fatalf("NewHub phase 2 (open): %v", err)
+	}
+	t.Cleanup(func() { _ = h2.Stop() })
+
+	got, err := h2.GetUser("nobody")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if got.Caps != "gio" {
+		t.Errorf("nobody.Caps after re-open = %q, want %q", got.Caps, "gio")
+	}
+}
+
+// TestNewHub_NobodyCaps_EmptyDoesNotOverwrite proves empty NobodyCaps
+// doesn't replace previously-set caps. Bootstrap with "gio", then re-open
+// with NobodyCaps unset — caps should still be "gio".
+func TestNewHub_NobodyCaps_EmptyDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h1, err := NewHub(context.Background(), Config{RepoPath: repoPath, NobodyCaps: "gio"})
+	if err != nil {
+		t.Fatalf("NewHub phase 1: %v", err)
+	}
+	_ = h1.Stop()
+
+	h2, err := NewHub(context.Background(), Config{RepoPath: repoPath /* NobodyCaps left empty */})
+	if err != nil {
+		t.Fatalf("NewHub phase 2: %v", err)
+	}
+	t.Cleanup(func() { _ = h2.Stop() })
+
+	got, err := h2.GetUser("nobody")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if got.Caps != "gio" {
+		t.Errorf("nobody.Caps after empty NobodyCaps = %q, want %q (no overwrite)", got.Caps, "gio")
+	}
+}
+
 // TestHub_Repo_AccessorReturnsLiveHandle proves Hub.Repo() returns a *Repo
 // whose lifecycle is bound to the Hub. Operations against it observe the
 // same state as Hub.* methods.

--- a/hub/users.go
+++ b/hub/users.go
@@ -22,3 +22,6 @@ func (h *Hub) ListUsers() ([]User, error) { return h.repo.ListUsers() }
 
 // RemoveUser deletes the user with the given login.
 func (h *Hub) RemoveUser(login string) error { return h.repo.RemoveUser(login) }
+
+// SetUserCaps replaces the caps string on an existing user.
+func (h *Hub) SetUserCaps(login, caps string) error { return h.repo.SetUserCaps(login, caps) }


### PR DESCRIPTION
## Summary

- Adds `Repo.SetUserCaps(login, caps) error` (with a `Hub` delegate) wrapping libfossil's `SetCaps`. Lets consumers grant or change caps on existing users without leaving the hub package.
- Adds `Config.NobodyCaps string` — applied at bootstrap, no-op when empty. Saves the typical bones case (`Hub` with unauthenticated `gio` for the pre-populated `nobody` user) from one manual `SetUserCaps` call after every `NewHub`.
- 5 tests: SetUserCaps round-trip, empty-login rejection, NobodyCaps applied, idempotent re-open, empty NobodyCaps doesn't overwrite previously-set caps.

Closes #130. Last bones libfossil-exit migration gap as of this commit — bones can now drop `libfossil.SetCaps`/direct `libfossil.Open` from its hub bootstrap path.

### Note on libfossil's `nobody` defaults

I'd assumed (from the issue body) that libfossil pre-populates `nobody` with empty caps. v0.5.0 actually pre-populates with `"cghijknorswy"` (a fairly broad cap set). That doesn't change the design — `NobodyCaps` is for callers who want to **explicitly set** the value, not for callers who need to know the libfossil default. Empty `NobodyCaps` is now documented as "leave nobody at whatever libfossil/the prior config left it"; tests cover both behaviors.

## Test plan

- [x] `go test -count=1 -race ./hub/...` — all green
- [x] `make test` — full suite green
- [ ] CI green