### PR TITLE
chore: bump leaf v0.0.8 → v0.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.2
-	github.com/danmestas/EdgeSync/leaf v0.0.8
+	github.com/danmestas/EdgeSync/leaf v0.0.9
 	github.com/danmestas/libfossil v0.5.0
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary

Bumps the root module's leaf pin from `v0.0.8` to `v0.0.9`. `leaf/v0.0.9` is already tagged and pushed.

`leaf/v0.0.9` ships:
- **fix(leaf/agent)** Agent.Commit chains onto trunk tip by default (#125, PR #133). Without this, `agent.Commit` produces orphan manifests every call, fragmenting the timeline.

After this merges, the next root tag (`v0.0.11`) cuts the full release with hub additions (#134 OpenRepo + *Repo, #135 SetUserCaps + NobodyCaps) — that's enough for bones to drop libfossil from go.mod entirely.

## Test plan

- [x] `make test` green (local replace means build still uses ./leaf — go.sum unchanged)
- [ ] CI green