### PR TITLE
feat: close three gaps blocking bones go.mod libfossil drop (#137)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Sim unit tests
         run: cd sim && go test . -run 'TestFaultProxy|TestGenerateSchedule|TestBuggify' -count=1
       - name: Sim serve tests
-        run: cd sim && go test . -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe|TestHubLeafE2E' -count=1 -timeout=120s
+        run: cd sim && go test . -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe|TestHubLeafE2E|TestAgentNew_|TestHubNATSFossilSync_' -count=1 -timeout=120s
       - name: Interop (short)
         run: cd sim && go test . -run 'TestInterop' -count=1 -short -timeout=60s
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 	for pid in $$pids; do wait $$pid || fail=1; done; \
 	if [ $$fail -ne 0 ]; then echo "FAIL: unit tests"; exit 1; fi
 	(cd sim && go test . -run 'TestFaultProxy|TestGenerateSchedule|TestBuggify' -count=1)
-	(cd sim && go test . -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe|TestHubLeafE2E' -count=1 -timeout=120s)
+	(cd sim && go test . -run 'TestServeHTTP|TestLeafToLeaf|TestAgentServe|TestHubLeafE2E|TestAgentNew_|TestHubNATSFossilSync_' -count=1 -timeout=120s)
 	(cd sim && go test . -run 'TestInterop' -count=1 -short -timeout=60s)
 	(cd sim && go test . -run 'TestSimulation' -sim.seed=1 -count=1 -timeout=120s)
 

--- a/hub/commit.go
+++ b/hub/commit.go
@@ -1,6 +1,9 @@
 package hub
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // RevID is an opaque commit handle.
 type RevID string
@@ -9,6 +12,12 @@ type RevID string
 type FileToCommit struct {
 	Name    string
 	Content []byte
+
+	// Perm is the libfossil-style file permission marker. The empty string
+	// means default (regular file); "x" marks the file executable so the
+	// resulting manifest's F-card carries the executable bit. Other libfossil
+	// perm markers (e.g. "l" for symlinks) are passed through verbatim.
+	Perm string
 }
 
 // CommitOpts configures Hub.Commit / Repo.Commit.
@@ -16,6 +25,12 @@ type CommitOpts struct {
 	Files   []FileToCommit
 	Message string
 	Author  string // fossil user; required
+
+	// Time is the commit timestamp. The zero value defaults to time.Now().UTC()
+	// at commit time; callers that need reproducible seeded commits (e.g. a
+	// production daemon bootstrapping a hub repo from on-disk content) should
+	// pass an explicit value.
+	Time time.Time
 }
 
 // Commit commits a set of files to the hub repo.

--- a/hub/commit_perm_time_test.go
+++ b/hub/commit_perm_time_test.go
@@ -1,0 +1,116 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+)
+
+func TestHub_FileToCommit_PermXMarksExecutable(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	rev, err := h.Commit(ctx, CommitOpts{
+		Files: []FileToCommit{
+			{Name: "script.sh", Content: []byte("#!/bin/sh\necho hi\n"), Perm: "x"},
+			{Name: "data.txt", Content: []byte("hi\n")},
+		},
+		Message: "perm round-trip",
+		Author:  "hub",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	r := h.Repo().handle
+	rid, err := r.ResolveVersion(string(rev))
+	if err != nil {
+		t.Fatalf("ResolveVersion(%s): %v", rev, err)
+	}
+
+	entries, err := r.ListFiles(rid)
+	if err != nil {
+		t.Fatalf("ListFiles: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, e := range entries {
+		got[e.Name] = e.Perm
+	}
+	if got["script.sh"] != "x" {
+		t.Errorf("script.sh perm = %q, want %q", got["script.sh"], "x")
+	}
+	if got["data.txt"] != "" {
+		t.Errorf("data.txt perm = %q, want empty (default)", got["data.txt"])
+	}
+}
+
+func TestHub_CommitOpts_TimeIsHonoured(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	want := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+
+	rev, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("x")}},
+		Message: "explicit time",
+		Author:  "hub",
+		Time:    want,
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	r := h.Repo().handle
+	rid, err := r.ResolveVersion(string(rev))
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	entries, err := r.Timeline(libfossil.LogOpts{Start: rid, Limit: 1})
+	if err != nil {
+		t.Fatalf("Timeline: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("Timeline returned no entries")
+	}
+	got := entries[0].Time.UTC()
+	if !got.Equal(want) {
+		t.Errorf("commit time = %s, want %s", got, want)
+	}
+}
+
+func TestHub_CommitOpts_ZeroTimeDefaultsToNow(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	before := time.Now().UTC().Add(-1 * time.Second)
+	rev, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("x")}},
+		Message: "default time",
+		Author:  "hub",
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	after := time.Now().UTC().Add(1 * time.Second)
+
+	r := h.Repo().handle
+	rid, err := r.ResolveVersion(string(rev))
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	entries, err := r.Timeline(libfossil.LogOpts{Start: rid, Limit: 1})
+	if err != nil {
+		t.Fatalf("Timeline: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("Timeline returned no entries")
+	}
+	got := entries[0].Time.UTC()
+	if got.Before(before) || got.After(after) {
+		t.Errorf("commit time = %s, want in [%s, %s]", got, before, after)
+	}
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -23,6 +23,7 @@ import (
 
 	libfossil "github.com/danmestas/libfossil"
 	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 )
 
 // Config configures NewHub.
@@ -54,15 +55,37 @@ type Config struct {
 	// (no caps; unauthenticated requests are rejected). Set to "gio" to
 	// allow unauthenticated clone/pull/push, the typical hub deployment.
 	NobodyCaps string
+
+	// DisableFossilSyncOverNATS turns off the hub's NATS subscriber for the
+	// fossil sync subject. By default, NewHub connects a local NATS client
+	// to the embedded server and subscribes to "fossil.<project-code>.sync"
+	// so peer leaf agents can push xfer requests to the hub over NATS
+	// (alongside the HTTP path). Set to true for read-only HTTP-only
+	// mirrors that don't accept NATS pushes.
+	//
+	// Inverted-name (Disable*) shape over the more obvious ServeFossilSyncOverNATS
+	// because Go bool zero-value is false; the production default is "enabled,"
+	// which maps cleanly to "DisableX defaults false."
+	DisableFossilSyncOverNATS bool
+
+	// FossilSyncSubjectPrefix overrides the NATS subject prefix used by the
+	// fossil sync subscriber. Empty defaults to "fossil" (matching the
+	// leaf-agent default). The full subscribed subject is
+	// "<prefix>.<project-code>.sync".
+	FossilSyncSubjectPrefix string
 }
 
 // Hub hosts an EdgeSync hub in-process. Construct one via NewHub, then call
 // ServeHTTP in a goroutine. Use Stop to tear everything down.
 type Hub struct {
-	repo       *Repo
-	server     *natsserver.Server
+	repo         *Repo
+	server       *natsserver.Server
 	httpListener net.Listener
-	httpServer *http.Server
+	httpServer   *http.Server
+
+	natsClient    *nats.Conn
+	natsSyncSub   *nats.Subscription
+	syncSubject   string
 
 	httpAddr     string
 	natsURL      string
@@ -126,7 +149,76 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		natsURL:      natsServer.ClientURL(),
 		leafUpstream: leafAddr,
 	}
+
+	if !cfg.DisableFossilSyncOverNATS {
+		if err := h.startFossilSyncSubscriber(cfg); err != nil {
+			natsServer.Shutdown()
+			natsServer.WaitForShutdown()
+			httpLn.Close()
+			repo.Close()
+			return nil, err
+		}
+	}
+
 	return h, nil
+}
+
+// startFossilSyncSubscriber connects a local NATS client to the embedded
+// server and subscribes to "<prefix>.<project-code>.sync", dispatching
+// incoming xfer payloads to the hub repo's HandleSync. Invoked by NewHub
+// when Config.DisableFossilSyncOverNATS is false.
+func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
+	projectCode, err := h.repo.handle.Config("project-code")
+	if err != nil {
+		return fmt.Errorf("hub: read project-code for fossil-sync subscriber: %w", err)
+	}
+	if projectCode == "" {
+		return fmt.Errorf("hub: project-code is empty; refusing to start fossil-sync subscriber")
+	}
+
+	prefix := cfg.FossilSyncSubjectPrefix
+	if prefix == "" {
+		prefix = "fossil"
+	}
+	subject := prefix + "." + projectCode + ".sync"
+
+	nc, err := nats.Connect(h.natsURL,
+		nats.Name("edgesync-hub"),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2*time.Second),
+		nats.RetryOnFailedConnect(true),
+		nats.Timeout(5*time.Second),
+	)
+	if err != nil {
+		return fmt.Errorf("hub: connect local NATS for fossil-sync subscriber: %w", err)
+	}
+
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		respBytes, hsErr := h.repo.handle.HandleSync(context.Background(), msg.Data)
+		if hsErr != nil {
+			// Empty response signals failure to the caller without hanging.
+			_ = msg.Respond([]byte{})
+			return
+		}
+		_ = msg.Respond(respBytes)
+	})
+	if err != nil {
+		nc.Close()
+		return fmt.Errorf("hub: subscribe %s: %w", subject, err)
+	}
+
+	// Flush so the server has registered the subscription before NewHub
+	// returns. Tests that publish immediately after NewHub depend on this.
+	if err := nc.FlushTimeout(2 * time.Second); err != nil {
+		_ = sub.Unsubscribe()
+		nc.Close()
+		return fmt.Errorf("hub: flush fossil-sync subscription: %w", err)
+	}
+
+	h.natsClient = nc
+	h.natsSyncSub = sub
+	h.syncSubject = subject
+	return nil
 }
 
 // ServeHTTP runs the fossil HTTP server (timeline UI + xfer endpoint)
@@ -166,6 +258,12 @@ func (h *Hub) Stop() error {
 		} else if h.httpListener != nil {
 			h.httpListener.Close()
 		}
+		if h.natsSyncSub != nil {
+			_ = h.natsSyncSub.Unsubscribe()
+		}
+		if h.natsClient != nil {
+			h.natsClient.Close()
+		}
 		if h.server != nil {
 			h.server.Shutdown()
 			h.server.WaitForShutdown()
@@ -189,6 +287,11 @@ func (h *Hub) LeafUpstream() string { return h.leafUpstream }
 
 // HTTPAddr returns the host:port the fossil HTTP server is bound to.
 func (h *Hub) HTTPAddr() string { return h.httpAddr }
+
+// FossilSyncSubject returns the NATS subject the hub subscribes to for
+// incoming fossil-sync xfer requests, or "" if Config.DisableFossilSyncOverNATS
+// was set. Format: "<prefix>.<project-code>.sync".
+func (h *Hub) FossilSyncSubject() string { return h.syncSubject }
 
 // Repo returns the underlying fossil-repo handle the hub serves from. Use
 // this to share the handle with another component in the same process —

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -132,12 +132,13 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	}
 	files := make([]libfossil.FileToCommit, len(opts.Files))
 	for i, f := range opts.Files {
-		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
+		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content, Perm: f.Perm}
 	}
 	_, uuid, err := r.handle.Commit(libfossil.CommitOpts{
 		Files:   files,
 		Comment: opts.Message,
 		User:    opts.Author,
+		Time:    opts.Time,
 	})
 	if err != nil {
 		return "", fmt.Errorf("hub: commit: %w", err)

--- a/leaf/agent/agent.go
+++ b/leaf/agent/agent.go
@@ -85,6 +85,16 @@ func New(cfg Config) (*Agent, error) {
 		return nil, err
 	}
 
+	if cfg.CloneFromHubURL != "" {
+		if _, statErr := os.Stat(cfg.RepoPath); os.IsNotExist(statErr) {
+			if err := cloneFromHub(cfg.RepoPath, cfg.CloneFromHubURL); err != nil {
+				return nil, fmt.Errorf("agent: clone from %s: %w", cfg.CloneFromHubURL, err)
+			}
+		} else if statErr != nil {
+			return nil, fmt.Errorf("agent: stat repo path %s: %w", cfg.RepoPath, statErr)
+		}
+	}
+
 	r, err := libfossil.Open(cfg.RepoPath)
 	if err != nil {
 		return nil, fmt.Errorf("agent: open repo: %w", err)

--- a/leaf/agent/clone.go
+++ b/leaf/agent/clone.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// cloneFromHub clones a fossil repo from hubURL into repoPath. The cloned
+// handle is closed before returning so subsequent libfossil.Open in New
+// reopens it through the same code path as a pre-existing repo.
+//
+// Used by New when Config.CloneFromHubURL is set and Config.RepoPath does
+// not yet exist on disk. Callers that need a clone helper independent of
+// agent construction can use this function directly via CloneRepo.
+func cloneFromHub(repoPath, hubURL string) error {
+	return CloneRepo(context.Background(), repoPath, hubURL)
+}
+
+// CloneRepo clones a fossil repo from hubURL into repoPath. Standalone
+// helper that does not require an Agent instance — callers that need to
+// bootstrap a leaf repo before any agent exists can use it directly,
+// though most callers should prefer Config.CloneFromHubURL on agent.New.
+//
+// The cloned repo is closed before returning. Reopen via libfossil.Open
+// or simply construct an Agent that points at the same path.
+func CloneRepo(ctx context.Context, repoPath, hubURL string) error {
+	if repoPath == "" {
+		return fmt.Errorf("agent.CloneRepo: repoPath is required")
+	}
+	if hubURL == "" {
+		return fmt.Errorf("agent.CloneRepo: hubURL is required")
+	}
+	transport := libfossil.NewHTTPTransport(hubURL)
+	r, _, err := libfossil.Clone(ctx, repoPath, transport, libfossil.CloneOpts{})
+	if err != nil {
+		return fmt.Errorf("clone %s -> %s: %w", hubURL, repoPath, err)
+	}
+	if r != nil {
+		_ = r.Close()
+	}
+	return nil
+}

--- a/leaf/agent/config.go
+++ b/leaf/agent/config.go
@@ -28,6 +28,17 @@ type Config struct {
 	// RepoPath is the path to the local Fossil repository file (required).
 	RepoPath string
 
+	// CloneFromHubURL, when set and RepoPath does not yet exist on disk,
+	// causes New to clone the leaf repo from this fossil HTTP URL before
+	// proceeding. Matching project-codes between leaf and hub are required
+	// for downstream NATS sync subjects to align, so callers that need to
+	// bootstrap a leaf against an existing hub should use this field rather
+	// than letting libfossil create an empty repo.
+	//
+	// When empty, New behaves as before: opens RepoPath if it exists, errors
+	// otherwise.
+	CloneFromHubURL string
+
 	// NATSUpstream is an optional external NATS URL that the embedded server
 	// joins as a leaf node. Empty means standalone mesh (no upstream).
 	NATSUpstream string

--- a/sim/agent_clone_test.go
+++ b/sim/agent_clone_test.go
@@ -1,0 +1,94 @@
+package sim
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+
+	"github.com/danmestas/EdgeSync/hub"
+	"github.com/danmestas/EdgeSync/leaf/agent"
+)
+
+// TestAgentNew_ClonesWhenRepoAbsent proves that agent.New, given
+// Config.CloneFromHubURL, clones the leaf repo from the hub before
+// opening it. Locks the contract that downstream consumers (bones)
+// rely on to avoid pulling libfossil into their import graph just for
+// the pre-agent clone step.
+func TestAgentNew_ClonesWhenRepoAbsent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hub bootstrap is too slow for -short")
+	}
+
+	dir := t.TempDir()
+	hubPath := filepath.Join(dir, "hub.fossil")
+	leafPath := filepath.Join(dir, "leaf.fossil")
+
+	h, err := hub.NewHub(context.Background(), hub.Config{RepoPath: hubPath})
+	if err != nil {
+		t.Fatalf("hub.NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	serveCtx, serveCancel := context.WithCancel(context.Background())
+	defer serveCancel()
+	go func() { _ = h.ServeHTTP(serveCtx) }()
+	if !waitForHTTP(t, "http://"+h.HTTPAddr()+"/", 2*time.Second) {
+		t.Fatal("hub HTTP not ready within 2s")
+	}
+
+	hubURL := "http://" + h.HTTPAddr() + "/"
+
+	a, err := agent.New(agent.Config{
+		RepoPath:        leafPath,
+		CloneFromHubURL: hubURL,
+		User:            "leaf",
+	})
+	if err != nil {
+		t.Fatalf("agent.New with CloneFromHubURL: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Stop() })
+
+	leaf, err := libfossil.Open(leafPath)
+	if err != nil {
+		t.Fatalf("open cloned leaf repo: %v", err)
+	}
+	defer leaf.Close()
+
+	leafCode, err := leaf.Config("project-code")
+	if err != nil {
+		t.Fatalf("leaf project-code: %v", err)
+	}
+
+	hubRepo, err := libfossil.Open(hubPath)
+	if err != nil {
+		t.Fatalf("open hub repo: %v", err)
+	}
+	defer hubRepo.Close()
+	hubCode, err := hubRepo.Config("project-code")
+	if err != nil {
+		t.Fatalf("hub project-code: %v", err)
+	}
+
+	if leafCode == "" {
+		t.Fatal("leaf project-code is empty after clone")
+	}
+	if leafCode != hubCode {
+		t.Errorf("project-code mismatch: leaf=%q hub=%q", leafCode, hubCode)
+	}
+}
+
+// TestAgentNew_RejectsMissingRepoWithoutCloneURL preserves prior behavior:
+// when CloneFromHubURL is empty and RepoPath does not exist, agent.New
+// surfaces the libfossil.Open error rather than silently bootstrapping.
+func TestAgentNew_RejectsMissingRepoWithoutCloneURL(t *testing.T) {
+	dir := t.TempDir()
+	leafPath := filepath.Join(dir, "leaf.fossil")
+
+	if _, err := agent.New(agent.Config{RepoPath: leafPath}); err == nil {
+		t.Fatal("agent.New on missing repo with no CloneFromHubURL returned nil error")
+	}
+}

--- a/sim/hub_nats_sync_test.go
+++ b/sim/hub_nats_sync_test.go
@@ -1,0 +1,135 @@
+package sim
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+	"github.com/nats-io/nats.go"
+
+	"github.com/danmestas/EdgeSync/hub"
+	"github.com/danmestas/EdgeSync/leaf/agent"
+)
+
+// TestHubNATSFossilSync_LeafPushLandsOnHub proves that a hub created via
+// hub.NewHub (with no leaf-agent serve-mode helper running on top) accepts
+// fossil-sync xfer requests over NATS and applies them to the hub repo.
+//
+// This is the contract that lets downstream consumers drop libfossil from
+// their go.mod — previously they had to spin up a leaf-agent in serve mode
+// (Pull=false, Push=false, Autosync=AutosyncOff, ServeNATSEnabled=true)
+// to get a NATS subscriber on fossil.<code>.sync, transitively pulling
+// libfossil into their import graph.
+func TestHubNATSFossilSync_LeafPushLandsOnHub(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hub bootstrap is too slow for -short")
+	}
+
+	dir := t.TempDir()
+	hubPath := filepath.Join(dir, "hub.fossil")
+	leafPath := filepath.Join(dir, "leaf.fossil")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	h, err := hub.NewHub(ctx, hub.Config{RepoPath: hubPath})
+	if err != nil {
+		t.Fatalf("hub.NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	if h.FossilSyncSubject() == "" {
+		t.Fatal("hub.FossilSyncSubject() empty: subscriber should be enabled by default")
+	}
+	if err := h.AddUser(hub.User{Login: "leaf", Caps: "asghbcofkimnqru"}); err != nil {
+		t.Fatalf("hub.AddUser: %v", err)
+	}
+
+	go func() { _ = h.ServeHTTP(ctx) }()
+	if !waitForHTTP(t, "http://"+h.HTTPAddr()+"/", 2*time.Second) {
+		t.Fatal("hub HTTP not ready within 2s")
+	}
+	hubURL := "http://" + h.HTTPAddr() + "/"
+
+	cloneCtx, cloneCancel := context.WithTimeout(ctx, 15*time.Second)
+	leafRepo, _, err := libfossil.Clone(cloneCtx, leafPath, libfossil.NewHTTPTransport(hubURL), libfossil.CloneOpts{
+		User: "leaf",
+	})
+	cloneCancel()
+	if err != nil {
+		t.Fatalf("libfossil.Clone: %v", err)
+	}
+	t.Cleanup(func() { _ = leafRepo.Close() })
+
+	projectCode, err := leafRepo.Config("project-code")
+	if err != nil {
+		t.Fatalf("leaf project-code: %v", err)
+	}
+
+	if _, _, err := leafRepo.Commit(libfossil.CommitOpts{
+		Files:   []libfossil.FileToCommit{{Name: "leaf-nats-push.txt", Content: []byte("hello-via-nats\n")}},
+		Comment: "leaf push over nats",
+		User:    "leaf",
+	}); err != nil {
+		t.Fatalf("leaf commit: %v", err)
+	}
+
+	nc, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("connect leaf NATS client to hub: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	transport := agent.NewNATSTransport(nc, projectCode, 5*time.Second, "fossil")
+
+	syncCtx, syncCancel := context.WithTimeout(ctx, 15*time.Second)
+	res, err := leafRepo.Sync(syncCtx, transport, libfossil.SyncOpts{
+		Push:        true,
+		Pull:        true,
+		ProjectCode: projectCode,
+		User:        "leaf",
+		PeerID:      "leaf-test",
+	})
+	syncCancel()
+	if err != nil {
+		t.Fatalf("leaf Sync over NATS to hub: %v", err)
+	}
+	if res == nil {
+		t.Fatal("leaf Sync returned nil result")
+	}
+
+	got, err := h.Read(ctx, "leaf-nats-push.txt")
+	if err != nil {
+		t.Fatalf("hub.Read(leaf-nats-push.txt): %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello-via-nats\n")) {
+		t.Errorf("hub got %q, want %q", got, "hello-via-nats\n")
+	}
+}
+
+// TestHubNATSFossilSync_DisableSkipsSubscriber proves that
+// Config.DisableFossilSyncOverNATS turns the subscriber off. Used by
+// callers that want a read-only HTTP-only mirror.
+func TestHubNATSFossilSync_DisableSkipsSubscriber(t *testing.T) {
+	if testing.Short() {
+		t.Skip("hub bootstrap is too slow for -short")
+	}
+
+	dir := t.TempDir()
+	h, err := hub.NewHub(context.Background(), hub.Config{
+		RepoPath:                  filepath.Join(dir, "hub.fossil"),
+		DisableFossilSyncOverNATS: true,
+	})
+	if err != nil {
+		t.Fatalf("hub.NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	if h.FossilSyncSubject() != "" {
+		t.Errorf("FossilSyncSubject() = %q with DisableFossilSyncOverNATS=true; want empty", h.FossilSyncSubject())
+	}
+}


### PR DESCRIPTION
## Summary

Closes the three EdgeSync API gaps in #137 so bones can drop `libfossil` from `go.mod` in a one-line follow-up:

- **Gap A** (`leaf/agent`): `Config.CloneFromHubURL` + `agent.New` clones-if-absent. Also exposes `agent.CloneRepo(ctx, repoPath, hubURL)` as a standalone helper. Replaces the pre-agent `libfossil.Clone` step in `bones/internal/coord/leaf.go`.
- **Gap B** (`hub`): `hub.NewHub` connects a local NATS client and subscribes to `fossil.<project-code>.sync` so peer leaves can push xfer requests to the hub over NATS — alongside the existing HTTP path. Default-on; opt out via `Config.DisableFossilSyncOverNATS`. Replaces the leaf-agent serve-mode helper that `bones/internal/coord/hub.go` was using to get the same subscriber transitively (and pulling libfossil into the import graph in the process).
- **Gap C** (`hub`): `FileToCommit.Perm` and `CommitOpts.Time` pass-through. Lets `bones/internal/hub/hub.go::seedHubRepo` preserve executable bits and explicit commit timestamps without going to libfossil directly.

After this lands and an EdgeSync release tag includes it, bones drops `libfossil` from `go.mod` plus the four direct/blank imports tracked in #137 in a single follow-up.

## Naming deviation

Issue brief proposed `Config.ServeFossilSyncOverNATS bool` defaulting to true. Go bool zero-value semantics make default-true awkward without pointers, so this PR uses the inverted-name shape (`DisableFossilSyncOverNATS bool`, defaults false = enabled). Same semantics, fewer pointer-bools.

## Test plan

- [x] `make test` (CI-equivalent: vet + leaf/bridge/sim short tests + sim serve tests + interop short)
- [x] New tests pass under verbose runs:
  - `TestAgentNew_ClonesWhenRepoAbsent` — clones leaf from hub, asserts matching project-code
  - `TestAgentNew_RejectsMissingRepoWithoutCloneURL` — preserves prior behavior
  - `TestHubNATSFossilSync_LeafPushLandsOnHub` — leaf publishes via `agent.NewNATSTransport` to a hub built only with `hub.NewHub`; commit lands on hub repo
  - `TestHubNATSFossilSync_DisableSkipsSubscriber` — `DisableFossilSyncOverNATS: true` leaves `FossilSyncSubject()` empty
  - `TestHub_FileToCommit_PermXMarksExecutable` — round-trips `Perm: "x"` via `libfossil.Repo.ListFiles`
  - `TestHub_CommitOpts_TimeIsHonoured` — explicit `Time` survives via `Timeline`
  - `TestHub_CommitOpts_ZeroTimeDefaultsToNow` — zero `Time` falls back to current time
- [x] Sim test patterns added to both `Makefile` and `.github/workflows/test.yml` so the new tests run in CI
- [ ] Wait for remote CI green before merge
- [ ] Tag release after merge so bones can bump `EdgeSync` and drop libfossil

Closes #137.