### PR TITLE
chore: bump leaf v0.0.9 → v0.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.2
-	github.com/danmestas/EdgeSync/leaf v0.0.9
+	github.com/danmestas/EdgeSync/leaf v0.0.10
 	github.com/danmestas/libfossil v0.5.0
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6


### PR DESCRIPTION
## Summary

Bumps the root module's leaf pin from \`v0.0.9\` to \`v0.0.10\`. \`leaf/v0.0.10\` is already tagged and pushed.

\`leaf/v0.0.10\` ships:
- **feat(leaf/agent)** \`Config.CloneFromHubURL\` + \`agent.CloneRepo\` helper (#137 gap A, PR #138). Lets downstream consumers bootstrap a leaf repo against an existing hub without importing libfossil directly.

After this merges, the next root tag (\`v0.0.12\`) cuts the full release including the matching hub additions (#137 gaps B + C, also PR #138) — that's enough for bones to drop libfossil from \`go.mod\` entirely.

## Test plan

- [x] \`make ci-fast\` green (local replace means build still uses ./leaf — go.sum unchanged)
- [ ] CI green