### PR TITLE
chore: bump actions/checkout v4→v6 + actions/setup-go v5→v6

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,7 +36,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: main
@@ -47,7 +47,7 @@ jobs:
           # contents:write on this repo.
           token: ${{ secrets.RELEASE_PUSH_TOKEN || github.token }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/bump-upstream.yml
+++ b/.github/workflows/bump-upstream.yml
@@ -82,12 +82,12 @@ jobs:
           fi
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - if: steps.in.outputs.skip != 'true' && steps.idem.outputs.exists != 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.0'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: leaf
@@ -33,8 +33,8 @@ jobs:
     name: Sim & Interop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Install Fossil
@@ -50,8 +50,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Build all binaries


### PR DESCRIPTION
## Summary

Quiets the Node.js 20 deprecation annotation surfaced on the auto-release.yml dry-run (run 25349308880). \`v6\` of both actions ships on Node.js 24, ahead of GitHub's June 2026 forced-upgrade.

Touches all five workflow files:
- \`auto-release.yml\` (the trigger for this fix)
- \`ci.yml\`, \`test.yml\` — main CI
- \`bump-upstream.yml\` — downstream consumer-bump receiver
- \`release.yml\` — goreleaser entry point

No API changes between v4→v6 / v5→v6 for the inputs we use (\`go-version-file\`, \`fetch-depth\`, \`token\`, \`ref\`).

## Test plan

- [x] \`make ci-fast\` green via pre-commit
- [ ] CI green on this PR (will exercise the bumped \`checkout\` + \`setup-go\` directly)