### PR TITLE
fix(hub): periodic WAL checkpoint so vanilla fossil can read hub.fossil

### DIFF
--- a/docs/architecture/hub-package.md
+++ b/docs/architecture/hub-package.md
@@ -12,12 +12,13 @@ All types are libfossil-free and nats-server-free. Consumers import only `github
 
 ```go
 type Config struct {
-    RepoPath       string // hub.fossil path; created if absent
-    BootstrapUser  string // default "hub"
-    NATSStoreDir   string // default <repo dir>/nats-store
-    FossilHTTPPort int    // 0 = auto-pick
-    NATSClientPort int    // 0 = auto-pick
-    NATSLeafPort   int    // 0 = auto-pick
+    RepoPath           string        // hub.fossil path; created if absent
+    BootstrapUser      string        // default "hub"
+    NATSStoreDir       string        // default <repo dir>/nats-store
+    FossilHTTPPort     int           // 0 = auto-pick
+    NATSClientPort     int           // 0 = auto-pick
+    NATSLeafPort       int           // 0 = auto-pick
+    CheckpointInterval time.Duration // 0 = 10s (PASSIVE WAL checkpoint cadence)
 }
 
 type Hub struct{ /* opaque */ }
@@ -70,6 +71,17 @@ go h.ServeHTTP(ctx)
 `busy_timeout = 30000` is applied at hub bootstrap so concurrent operations retry on `SQLITE_BUSY` rather than failing fast.
 
 The hub deliberately does **not** cap `MaxOpenConns`. An earlier iteration set `SetMaxOpenConns(1)` (matching what bones did before this package existed), but libfossil's clone path has internal goroutines that all need a DB connection — capping the pool deadlocked every concurrent clone (issue #120). `busy_timeout` alone is the right primitive for concurrent-write safety.
+
+## Vanilla Fossil Interop
+
+`hub.fossil` is opened in WAL journal mode (libfossil's default). Without periodic checkpoints, the on-disk file would stay as a ~4 KiB stub plus a multi-hundred-KiB `*-wal` sidecar for the lifetime of the hub — and vanilla `fossil ui` / `fossil info` / third-party SQLite tooling would refuse to open it because their validity probe stats the main file before consulting the WAL.
+
+The hub guards both ends of that contract:
+
+- **While serving:** a background goroutine runs `PRAGMA wal_checkpoint(PASSIVE)` every `Config.CheckpointInterval` (default 10s). PASSIVE never blocks readers or writers, so vanilla fossil can read `hub.fossil` at any time without coordinating with the hub.
+- **After Stop:** `Hub.Stop` halts the checkpoint goroutine, then closes the libfossil handle. libfossil's own `(*Repo).Close` runs `PRAGMA wal_checkpoint(TRUNCATE)` before releasing the connection (libfossil v0.6.0+), so the on-disk `hub.fossil` is self-contained — no `-wal` / `-shm` sidecar required.
+
+There is no "disable" knob: vanilla-fossil readability is the contract this package exists to uphold. Set a long `CheckpointInterval` if you really want to dilute the cadence.
 
 ## Layout: in-root vs. separate module
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.3
 	github.com/danmestas/EdgeSync/leaf v0.0.10
-	github.com/danmestas/libfossil v0.5.0
+	github.com/danmestas/libfossil v0.6.0
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.5.0 h1:mnadgfhLSqlql1tA9TIF+wkmwpBy88x4SgfdIev+1bQ=
-github.com/danmestas/libfossil v0.5.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.6.0 h1:f7U6MskBzFoU60lRYHQU8SQOVvfV3YC9A5y9olowQXE=
+github.com/danmestas/libfossil v0.6.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -73,10 +73,31 @@ type Config struct {
 	// leaf-agent default). The full subscribed subject is
 	// "<prefix>.<project-code>.sync".
 	FossilSyncSubjectPrefix string
+
+	// CheckpointInterval is how often the hub runs a PASSIVE WAL checkpoint
+	// against hub.fossil while serving. PASSIVE never blocks readers or
+	// writers, so the file stays readable by vanilla fossil tooling
+	// (fossil ui / fossil info / fossil timeline) without coordinating
+	// with the hub. Zero defaults to defaultCheckpointInterval.
+	//
+	// No "disable" knob: vanilla-fossil readability is the contract this
+	// Config exists to uphold. Set a long interval if you really want to
+	// dilute the cadence; it should never be off.
+	CheckpointInterval time.Duration
 }
+
+// defaultCheckpointInterval is the period between background PASSIVE
+// checkpoints when Config.CheckpointInterval is zero.
+const defaultCheckpointInterval = 10 * time.Second
 
 // Hub hosts an EdgeSync hub in-process. Construct one via NewHub, then call
 // ServeHTTP in a goroutine. Use Stop to tear everything down.
+//
+// While serving, the hub runs a PASSIVE WAL checkpoint on hub.fossil every
+// Config.CheckpointInterval (default 10s) so vanilla fossil tooling can read
+// the file. After Stop returns nil, the on-disk hub.fossil is self-contained
+// — libfossil's Close runs a TRUNCATE checkpoint, leaving no WAL/SHM
+// sidecar.
 type Hub struct {
 	repo         *Repo
 	server       *natsserver.Server
@@ -90,6 +111,9 @@ type Hub struct {
 	httpAddr     string
 	natsURL      string
 	leafUpstream string
+
+	checkpointStop chan struct{}
+	checkpointDone chan struct{}
 
 	stopOnce sync.Once
 }
@@ -160,7 +184,35 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		}
 	}
 
+	h.startCheckpointLoop(cfg.CheckpointInterval)
+
 	return h, nil
+}
+
+// startCheckpointLoop runs PASSIVE WAL checkpoints against the hub repo on a
+// ticker so vanilla fossil tooling can read hub.fossil while the hub is
+// serving. PASSIVE never blocks readers or writers; checkpoint errors are
+// non-fatal (the next tick retries, and Hub.Stop's repo.Close runs a
+// TRUNCATE checkpoint anyway).
+func (h *Hub) startCheckpointLoop(interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultCheckpointInterval
+	}
+	h.checkpointStop = make(chan struct{})
+	h.checkpointDone = make(chan struct{})
+	go func() {
+		defer close(h.checkpointDone)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-h.checkpointStop:
+				return
+			case <-t.C:
+				_ = h.repo.handle.Checkpoint(libfossil.CheckpointPassive)
+			}
+		}
+	}()
 }
 
 // startFossilSyncSubscriber connects a local NATS client to the embedded
@@ -267,6 +319,10 @@ func (h *Hub) Stop() error {
 		if h.server != nil {
 			h.server.Shutdown()
 			h.server.WaitForShutdown()
+		}
+		if h.checkpointStop != nil {
+			close(h.checkpointStop)
+			<-h.checkpointDone
 		}
 		if h.repo != nil {
 			if err := h.repo.Close(); err != nil && firstErr == nil {

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -3,7 +3,9 @@ package hub
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -251,5 +253,89 @@ func TestHub_Stop_IsIdempotent(t *testing.T) {
 	}
 	if err := h.Stop(); err != nil {
 		t.Errorf("second Stop: %v", err)
+	}
+}
+
+// TestHub_StopLeavesRepoVanillaReadable asserts the contract that after
+// Hub.Stop returns nil, hub.fossil is a self-contained file: no WAL/SHM
+// sidecar required, and a fresh hub.OpenRepo against the path succeeds.
+// This is the behavior consumers like bones rely on for vanilla-fossil
+// interop. Regression for #143.
+func TestHub_StopLeavesRepoVanillaReadable(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(context.Background(), Config{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	if _, err := h.Commit(context.Background(), CommitOpts{
+		Files:   []FileToCommit{{Name: "f", Content: bytes.Repeat([]byte("x"), 8192)}},
+		Message: "trigger WAL traffic",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := h.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	walPath := repoPath + "-wal"
+	if info, err := os.Stat(walPath); err == nil && info.Size() != 0 {
+		t.Errorf("WAL still present with size %d after Stop; expected 0 or absent", info.Size())
+	}
+
+	r, err := OpenRepo(repoPath)
+	if err != nil {
+		t.Fatalf("OpenRepo on stopped hub.fossil: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	got, err := r.Read(context.Background(), "f")
+	if err != nil {
+		t.Fatalf("Read after reopen: %v", err)
+	}
+	if !bytes.Equal(got, bytes.Repeat([]byte("x"), 8192)) {
+		t.Errorf("Read after reopen: content mismatch (len=%d)", len(got))
+	}
+}
+
+// TestHub_PeriodicCheckpointPopulatesMainFile asserts the periodic PASSIVE
+// checkpoint goroutine runs while the hub serves: after several commits and
+// a few ticker periods, the main hub.fossil file holds more than the SQLite
+// stub. Without periodic checkpointing the main file stays at the stub size
+// (~4096 bytes) until SQLite's own auto-checkpoint at ~4 MiB fires, and
+// vanilla fossil rejects it. Regression for #143.
+func TestHub_PeriodicCheckpointPopulatesMainFile(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(context.Background(), Config{
+		RepoPath:           repoPath,
+		CheckpointInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	for i := range 10 {
+		if _, err := h.Commit(context.Background(), CommitOpts{
+			Files:   []FileToCommit{{Name: fmt.Sprintf("f%d", i), Content: bytes.Repeat([]byte("x"), 4096)}},
+			Message: fmt.Sprintf("commit %d", i),
+			Author:  "hub",
+		}); err != nil {
+			t.Fatalf("Commit %d: %v", i, err)
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	info, err := os.Stat(repoPath)
+	if err != nil {
+		t.Fatalf("Stat %s: %v", repoPath, err)
+	}
+	if info.Size() <= 4096 {
+		t.Errorf("main file size = %d after 10 commits + 200ms; expected > 4096 (WAL not being checkpointed mid-flight)", info.Size())
 	}
 }


### PR DESCRIPTION
## Summary

- Add `Config.CheckpointInterval` (default 10s) and run `PRAGMA wal_checkpoint(PASSIVE)` on a ticker in `NewHub` so vanilla fossil tooling (`fossil ui`, `fossil info`, `fossil timeline`) can read `hub.fossil` while the hub is serving.
- Drain the checkpoint goroutine from `(*Hub).Stop` before closing the libfossil handle. libfossil v0.6.0's `(*Repo).Close` runs a TRUNCATE checkpoint, so the post-Stop on-disk file is self-contained — no `-wal` / `-shm` sidecar.
- Bump `github.com/danmestas/libfossil` v0.5.0 → v0.6.0 to pick up the typed `Checkpoint(mode)` primitive and the close-time TRUNCATE behavior (danmestas/libfossil#28).
- Doc paragraph in `docs/architecture/hub-package.md` and one-line update on the `Hub` doc-comment describing the invariant.

Closes #143.

## Deviation from the agent brief

The brief had a step 5: expose a public `(*hub.Repo).Checkpoint(mode libfossil.CheckpointMode) error` wrapper. Skipped here because that signature leaks `libfossil.CheckpointMode` into the hub public API, which violates the package's "consumers don't import libfossil" contract (see hub.go:1-12). The bug is fully fixed without it (internal goroutine + libfossil's TRUNCATE-on-Close). When a consumer needs explicit mid-flight checkpoint control, we'll introduce a hub-flavored `CheckpointMode` enum in a follow-up.

## Test plan

- [x] `go test ./hub/... -count=1` — passes; two new regression tests:
  - `TestHub_StopLeavesRepoVanillaReadable` — asserts `hub.fossil-wal` is empty/absent after `Stop` and `OpenRepo` reopens cleanly.
  - `TestHub_PeriodicCheckpointPopulatesMainFile` — boots with 20ms interval, makes 10 commits, asserts main file > 4096 bytes after a few ticks (proves WAL is being drained mid-flight).
- [x] `make vet` clean.
- [x] `make build` succeeds (all binaries).
- [x] `cd leaf && go test ./... -short -count=1` — passes.
- [x] `cd bridge && go test ./... -short -count=1` — passes.
- [x] `cd sim && go test . -run 'TestHubLeafE2E|TestHubNATSFossilSync_'` — passes (hub integration).
- [x] `go test ./cmd/edgesync/ -count=1` — passes.
- [x] `make ci-fast` (pre-commit hook) clean.

## Downstream cleanup

The bones workaround at [`danmestas/bones@7384b64`](https://github.com/danmestas/bones/commit/7384b64) (PR [danmestas/bones#223](https://github.com/danmestas/bones/pull/223)) calls `PRAGMA wal_checkpoint(PASSIVE)` against `hub.fossil` before every shell-out from bones to vanilla fossil. Once this lands and bones picks up the new EdgeSync release, that workaround becomes redundant — calling PASSIVE against an already-checkpointed file is a near-no-op. Cleanup is a follow-up in bones, not in this PR.