### PR TITLE
chore: bump goreleaser-action v6 → v7 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: '1.26.0'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## Summary

- `goreleaser/goreleaser-action@v6` runs on Node.js 20, deprecated by GitHub Actions on 2026-09-16. v7.0.0 (released 2026-02-21) moved to Node 24; latest is v7.2.1 (2026-04-26).
- Annotation surfaced on the v0.0.14 release run.
- Release pipeline only — no consumer impact.

## Test plan

- [x] `make ci-fast` clean (vet + unit tests across root/leaf/bridge).
- [ ] Next release tag exercises the new action version. The CI gates here don't run `release.yml`.