### PR TITLE
feat(hub): CommitOpts.Tags — attach tags at commit time (incl. branch=)

### DIFF
--- a/hub/commit.go
+++ b/hub/commit.go
@@ -31,6 +31,28 @@ type CommitOpts struct {
 	// production daemon bootstrapping a hub repo from on-disk content) should
 	// pass an explicit value.
 	Time time.Time
+
+	// Tags, when non-empty, are attached to the resulting checkin manifest.
+	// Tags are libfossil's primitive — fossil "branches" are themselves
+	// propagating "branch=<name>" + "sym-<name>" tag pairs. To land a commit
+	// on branch "agent/abc123":
+	//
+	//   Tags: []TagSpec{
+	//       {Name: "branch",            Value: "agent/abc123"},
+	//       {Name: "sym-agent/abc123",  Value: "*"},
+	//   }
+	//
+	// Empty preserves current behavior (commit to current branch, no extra tags).
+	Tags []TagSpec
+}
+
+// TagSpec describes a tag attached at commit time. Mirrors libfossil's
+// underlying tag primitive; pass these via CommitOpts.Tags to attach
+// arbitrary tags (including the propagating branch-tag pair that creates
+// or advances a fossil branch) on the resulting checkin.
+type TagSpec struct {
+	Name  string
+	Value string
 }
 
 // Commit commits a set of files to the hub repo.

--- a/hub/commit_tags_test.go
+++ b/hub/commit_tags_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+)
+
+// TestCommit_BranchTags_LandsOnNamedBranch verifies that supplying the fossil
+// branch tag pair (branch=<name> + sym-<name>=*) on CommitOpts.Tags lands the
+// checkin on that branch. After the commit, BranchTip(name) resolves to the
+// new commit and trunk's tip is unchanged.
+func TestCommit_BranchTags_LandsOnNamedBranch(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	trunkRev, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("seed\n")}},
+		Message: "seed trunk",
+		Author:  "hub",
+	})
+	if err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+	r := h.Repo().handle
+	trunkTipBefore, err := r.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip(trunk) before: %v", err)
+	}
+
+	const branch = "feature/x"
+	branchRev, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "branch.txt", Content: []byte("on branch\n")}},
+		Message: "first commit on " + branch,
+		Author:  "hub",
+		Tags: []TagSpec{
+			{Name: "branch", Value: branch},
+			{Name: "sym-" + branch, Value: "*"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("branch Commit: %v", err)
+	}
+	if branchRev == trunkRev {
+		t.Fatalf("branch commit produced the same RevID as trunk seed: %s", branchRev)
+	}
+
+	branchTip, err := r.BranchTip(branch)
+	if err != nil {
+		t.Fatalf("BranchTip(%q): %v", branch, err)
+	}
+	branchRID, err := r.ResolveVersion(string(branchRev))
+	if err != nil {
+		t.Fatalf("ResolveVersion(%s): %v", branchRev, err)
+	}
+	if branchTip != branchRID {
+		t.Errorf("BranchTip(%q) = %d, want %d (the new commit)", branch, branchTip, branchRID)
+	}
+
+	trunkTipAfter, err := r.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip(trunk) after: %v", err)
+	}
+	if trunkTipAfter != trunkTipBefore {
+		t.Errorf("trunk tip moved: was %d, now %d — branch commit must not advance trunk",
+			trunkTipBefore, trunkTipAfter)
+	}
+
+	got, err := h.ReadAt(ctx, branchRev, "branch.txt")
+	if err != nil {
+		t.Fatalf("ReadAt(branchRev): %v", err)
+	}
+	if string(got) != "on branch\n" {
+		t.Errorf("ReadAt(branchRev) = %q, want %q", got, "on branch\n")
+	}
+}
+
+// TestCommit_BranchTags_PropagateForward verifies that a second commit
+// carrying the same branch tag pair lands on the branch's tip (parented
+// by the previous branch commit), not on trunk. This is the propagation
+// path: subsequent commits don't fork unless explicitly told to.
+func TestCommit_BranchTags_PropagateForward(t *testing.T) {
+	h := newTestHub(t)
+	ctx := context.Background()
+
+	if _, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("seed\n")}},
+		Message: "seed trunk",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+
+	const branch = "feature/y"
+	branchTags := []TagSpec{
+		{Name: "branch", Value: branch},
+		{Name: "sym-" + branch, Value: "*"},
+	}
+
+	first, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("v1\n")}},
+		Message: "first on branch",
+		Author:  "hub",
+		Tags:    branchTags,
+	})
+	if err != nil {
+		t.Fatalf("first branch Commit: %v", err)
+	}
+
+	second, err := h.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("v2\n")}},
+		Message: "second on branch",
+		Author:  "hub",
+		Tags:    branchTags,
+	})
+	if err != nil {
+		t.Fatalf("second branch Commit: %v", err)
+	}
+	if first == second {
+		t.Fatalf("second commit returned same RevID as first: %s", first)
+	}
+
+	r := h.Repo().handle
+	tip, err := r.BranchTip(branch)
+	if err != nil {
+		t.Fatalf("BranchTip(%q): %v", branch, err)
+	}
+	secondRID, err := r.ResolveVersion(string(second))
+	if err != nil {
+		t.Fatalf("ResolveVersion(second): %v", err)
+	}
+	if tip != secondRID {
+		t.Errorf("BranchTip(%q) = %d, want %d (the second commit)", branch, tip, secondRID)
+	}
+
+	got, err := h.ReadAt(ctx, RevID(branch), "f.txt")
+	if err != nil {
+		t.Fatalf("ReadAt(branch symbolic): %v", err)
+	}
+	if string(got) != "v2\n" {
+		t.Errorf("ReadAt(%q, f.txt) = %q, want %q", branch, got, "v2\n")
+	}
+}

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -134,11 +134,19 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	for i, f := range opts.Files {
 		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content, Perm: f.Perm}
 	}
+	var tags []libfossil.TagSpec
+	if len(opts.Tags) > 0 {
+		tags = make([]libfossil.TagSpec, len(opts.Tags))
+		for i, t := range opts.Tags {
+			tags[i] = libfossil.TagSpec{Name: t.Name, Value: t.Value}
+		}
+	}
 	_, uuid, err := r.handle.Commit(libfossil.CommitOpts{
 		Files:   files,
 		Comment: opts.Message,
 		User:    opts.Author,
 		Time:    opts.Time,
+		Tags:    tags,
 	})
 	if err != nil {
 		return "", fmt.Errorf("hub: commit: %w", err)


### PR DESCRIPTION
## Summary

- Adds `Tags []TagSpec` to `hub.CommitOpts` and a re-exported `hub.TagSpec` type that mirrors `libfossil.TagSpec`.
- `Repo.Commit` translates `opts.Tags` and passes them through to `libfossil.CommitOpts.Tags`. Empty `Tags` preserves existing behavior — current trunk callsites are unchanged.
- Fossil-native API: callers compose the propagating `branch=<name>` + `sym-<name>=*` tag pair themselves to land a commit on a named branch. No git-flavored `Branch` field.

## Why tags, not "branch"

Fossil branches *are* propagating tags. Exposing the underlying primitive is strictly more expressive (any tag can be attached at commit time, not just branch creators) and accurately reflects what's happening at the libfossil layer. Downstream consumers wrap this with whatever ergonomic helper they want.

## Test plan

- [x] `go test ./hub/ -count=1` — passes (existing + new tests).
- [x] `go vet ./...` (root + leaf + bridge) — clean.
- [x] `go test ./... -short -count=1` (leaf + bridge) — passes.
- [x] `go build -buildvcs=false ./cmd/edgesync/` — builds.
- [x] `go test ./cmd/edgesync/ -count=1 -timeout=60s` — passes.

### New tests

- `TestCommit_BranchTags_LandsOnNamedBranch` — supplying `[{branch, "feature/x"}, {sym-feature/x, "*"}]` lands the checkin on `feature/x`; trunk tip unchanged; `BranchTip("feature/x")` resolves to the new commit.
- `TestCommit_BranchTags_PropagateForward` — a second commit on the same branch (same tag pair) lands on the branch's tip, not a new fork; `ReadAt(branch, path)` returns the latest content.
- Empty-`Tags` regression is implicitly covered by every existing hub test (all use `CommitOpts{}` with no tags).

Closes #147