### PR TITLE
feat(leaf/agent): CommitOpts.Tags — symmetric to hub.CommitOpts.Tags

### DIFF
--- a/leaf/agent/code_artifact.go
+++ b/leaf/agent/code_artifact.go
@@ -36,6 +36,28 @@ type CommitOpts struct {
 	// MergeParents lists additional parents for a merge commit. Each
 	// contributes a secondary entry on the manifest's P-card.
 	MergeParents []int64
+
+	// Tags, when non-empty, are attached to the resulting checkin manifest.
+	// Tags are libfossil's primitive — fossil "branches" are themselves
+	// propagating "branch=<name>" + "sym-<name>" tag pairs. To land a commit
+	// on branch "agent/abc123":
+	//
+	//   Tags: []TagSpec{
+	//       {Name: "branch",            Value: "agent/abc123"},
+	//       {Name: "sym-agent/abc123",  Value: "*"},
+	//   }
+	//
+	// Empty preserves current behavior (commit to current branch, no extra tags).
+	Tags []TagSpec
+}
+
+// TagSpec describes a tag attached at commit time. Mirrors libfossil's
+// underlying tag primitive; pass these via CommitOpts.Tags to attach
+// arbitrary tags (including the propagating branch-tag pair that creates
+// or advances a fossil branch) on the resulting checkin.
+type TagSpec struct {
+	Name  string
+	Value string
 }
 
 // SyncOpts configures Agent.SyncTo.
@@ -74,12 +96,20 @@ func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	for i, f := range opts.Files {
 		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
 	}
+	var tags []libfossil.TagSpec
+	if len(opts.Tags) > 0 {
+		tags = make([]libfossil.TagSpec, len(opts.Tags))
+		for i, t := range opts.Tags {
+			tags[i] = libfossil.TagSpec{Name: t.Name, Value: t.Value}
+		}
+	}
 	_, uuid, err := a.repo.Commit(libfossil.CommitOpts{
 		Files:        files,
 		Comment:      opts.Message,
 		User:         opts.Author,
 		ParentID:     parentID,
 		MergeParents: opts.MergeParents,
+		Tags:         tags,
 	})
 	if err != nil {
 		return "", fmt.Errorf("agent: commit: %w", err)

--- a/leaf/agent/code_artifact_test.go
+++ b/leaf/agent/code_artifact_test.go
@@ -77,6 +77,126 @@ func TestAgent_Commit_RejectsEmptyAuthor(t *testing.T) {
 	}
 }
 
+// TestAgent_Commit_BranchTags_LandsOnNamedBranch verifies that supplying the
+// fossil branch tag pair (branch=<name> + sym-<name>=*) on CommitOpts.Tags
+// lands the checkin on that branch. After the commit, BranchTip(name)
+// resolves to the new commit and trunk's tip is unchanged. This is the
+// symmetric leaf-side counterpart to hub.CommitOpts.Tags (#147/#148) and
+// unblocks bones' synthetic-agent-slot model (commits to agent/<id>).
+func TestAgent_Commit_BranchTags_LandsOnNamedBranch(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	trunkRev, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("seed\n")}},
+		Message: "seed trunk",
+		Author:  "testuser",
+	})
+	if err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+	trunkTipBefore, err := a.repo.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip(trunk) before: %v", err)
+	}
+
+	const branch = "agent/abc123"
+	branchRev, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "branch.txt", Content: []byte("on branch\n")}},
+		Message: "first commit on " + branch,
+		Author:  "testuser",
+		Tags: []TagSpec{
+			{Name: "branch", Value: branch},
+			{Name: "sym-" + branch, Value: "*"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("branch Commit: %v", err)
+	}
+	if branchRev == trunkRev {
+		t.Fatalf("branch commit produced the same RevID as trunk seed: %s", branchRev)
+	}
+
+	branchTip, err := a.repo.BranchTip(branch)
+	if err != nil {
+		t.Fatalf("BranchTip(%q): %v", branch, err)
+	}
+	branchRID, err := a.repo.ResolveVersion(string(branchRev))
+	if err != nil {
+		t.Fatalf("ResolveVersion(%s): %v", branchRev, err)
+	}
+	if branchTip != branchRID {
+		t.Errorf("BranchTip(%q) = %d, want %d (the new commit)", branch, branchTip, branchRID)
+	}
+
+	trunkTipAfter, err := a.repo.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip(trunk) after: %v", err)
+	}
+	if trunkTipAfter != trunkTipBefore {
+		t.Errorf("trunk tip moved: was %d, now %d — branch commit must not advance trunk",
+			trunkTipBefore, trunkTipAfter)
+	}
+}
+
+// TestAgent_Commit_BranchTags_PropagateForward verifies that a second commit
+// carrying the same branch tag pair lands on the branch's tip (parented by
+// the previous branch commit), not on trunk. Subsequent commits don't fork
+// unless explicitly told to.
+func TestAgent_Commit_BranchTags_PropagateForward(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	if _, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "seed.txt", Content: []byte("seed\n")}},
+		Message: "seed trunk",
+		Author:  "testuser",
+	}); err != nil {
+		t.Fatalf("seed Commit: %v", err)
+	}
+
+	const branch = "agent/xyz789"
+	branchTags := []TagSpec{
+		{Name: "branch", Value: branch},
+		{Name: "sym-" + branch, Value: "*"},
+	}
+
+	first, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("v1\n")}},
+		Message: "first on branch",
+		Author:  "testuser",
+		Tags:    branchTags,
+	})
+	if err != nil {
+		t.Fatalf("first branch Commit: %v", err)
+	}
+
+	second, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "f.txt", Content: []byte("v2\n")}},
+		Message: "second on branch",
+		Author:  "testuser",
+		Tags:    branchTags,
+	})
+	if err != nil {
+		t.Fatalf("second branch Commit: %v", err)
+	}
+	if first == second {
+		t.Fatalf("second commit returned same RevID as first: %s", first)
+	}
+
+	tip, err := a.repo.BranchTip(branch)
+	if err != nil {
+		t.Fatalf("BranchTip(%q): %v", branch, err)
+	}
+	secondRID, err := a.repo.ResolveVersion(string(second))
+	if err != nil {
+		t.Fatalf("ResolveVersion(second): %v", err)
+	}
+	if tip != secondRID {
+		t.Errorf("BranchTip(%q) = %d, want %d (the second commit)", branch, tip, secondRID)
+	}
+}
+
 func TestAgent_Tip_ReturnsCommitUUID(t *testing.T) {
 	a := newAgentForCommitTests(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Add `Tags []TagSpec` to `agent.CommitOpts`, mirroring the hub-side change from #148. Plumbed straight through to `libfossil.CommitOpts.Tags` at `leaf/agent/code_artifact.go:Commit`.
- `TagSpec` is defined locally in `leaf/agent` (not re-exported from `hub`) — the leaf module doesn't depend on the root module, so a sibling type keeps the dependency arrow correct. Field names (`Name`, `Value`) match `hub.TagSpec` exactly so callers passing through both paths can construct one slice.
- Two tests, mirroring `hub/commit_tags_test.go`: branch-tag pair lands the commit on the named branch (trunk tip unchanged), and a second commit with the same tag pair propagates forward (parented by the previous branch commit).

Closes #149. Unblocks bones synthetic-agent-slot model (bones #282/#283 / ADR 0050) — synthetic slots commit via the leaf, not the hub, so #148 alone wasn't enough.

## Test plan

- [x] `make ci` (vet + leaf + bridge + cmd/edgesync) green locally
- [x] New tests `TestAgent_Commit_BranchTags_LandsOnNamedBranch` and `TestAgent_Commit_BranchTags_PropagateForward` pass
- [ ] Remote CI green
- [ ] Cut leaf v0.0.16 once merged → bones bump-upstream auto-fires

## Out of scope (per #149)

The parallel `hub.CommitOpts` ↔ `agent.CommitOpts` hierarchy still drifts every time we add a libfossil pass-through field. A shared `CommitTags` / `CommitMeta` struct embedded in both would prevent the next instance. Worth raising as a separate follow-up; not blocking this fix.