### PR TITLE
feat(hub): machine-level hub CLI + ServerName / LeafUpstream

### DIFF
--- a/cli/hub_serve.go
+++ b/cli/hub_serve.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/danmestas/EdgeSync/hub"
+	libfossilcli "github.com/danmestas/libfossil/cli"
+)
+
+// HubCmd is the top-level command group for the in-process EdgeSync hub.
+type HubCmd struct {
+	Serve HubServeCmd `cmd:"" help:"Run an embedded hub (NATS + fossil) at the machine level"`
+}
+
+type HubServeCmd struct {
+	Name           string `help:"NATS server name (defaults to <hostname>-hub)"`
+	StoreDir       string `help:"JetStream store dir (default sibling of repo)"`
+	HTTPPort       int    `help:"Fossil HTTP port (0 = auto)" default:"0"`
+	NATSClientPort int    `help:"NATS client port (0 = auto)" default:"0"`
+	NATSLeafPort   int    `help:"NATS leafnode port (0 = auto)" default:"0"`
+	LeafUpstream   string `help:"Solicit leafnode connection to this URL (e.g. nats-leaf://host:port)"`
+	NobodyCaps     string `help:"Caps for unauthenticated 'nobody' user (e.g. 'gio' for clone access)" default:"gio"`
+}
+
+func (c *HubServeCmd) Run(g *libfossilcli.Globals) error {
+	name := c.Name
+	if name == "" {
+		host, err := os.Hostname()
+		if err != nil {
+			return fmt.Errorf("hostname: %w", err)
+		}
+		name = shortHost(host) + "-hub"
+	}
+
+	repoPath := g.Repo
+	if repoPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		repoPath = filepath.Join(home, ".edgesync", name, "hub.repo")
+		if err := os.MkdirAll(filepath.Dir(repoPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(repoPath), err)
+		}
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	h, err := hub.NewHub(ctx, hub.Config{
+		RepoPath:       repoPath,
+		ServerName:     name,
+		NATSStoreDir:   c.StoreDir,
+		FossilHTTPPort: c.HTTPPort,
+		NATSClientPort: c.NATSClientPort,
+		NATSLeafPort:   c.NATSLeafPort,
+		LeafUpstream:   c.LeafUpstream,
+		NobodyCaps:     c.NobodyCaps,
+	})
+	if err != nil {
+		return fmt.Errorf("hub: %w", err)
+	}
+
+	slog.Info("edgesync hub running",
+		"name", h.ServerName(),
+		"repo", repoPath,
+		"http", "http://"+h.HTTPAddr(),
+		"nats", h.NATSURL(),
+		"leaf_upstream", h.LeafUpstream(),
+		"sync_subject", h.FossilSyncSubject(),
+	)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- h.ServeHTTP(ctx) }()
+
+	select {
+	case <-ctx.Done():
+	case err := <-serveErr:
+		if err != nil {
+			slog.Error("hub HTTP server stopped", "err", err)
+		}
+	}
+
+	slog.Info("shutting down hub", "name", name)
+	return h.Stop()
+}
+
+// shortHost trims a FQDN to its first label, mirroring `hostname -s`.
+func shortHost(h string) string {
+	for i := 0; i < len(h); i++ {
+		if h[i] == '.' {
+			return h[:i]
+		}
+	}
+	return h
+}

--- a/cmd/edgesync/cli.go
+++ b/cmd/edgesync/cli.go
@@ -11,6 +11,7 @@ type CLI struct {
 	Repo   repocli.Cmd       `cmd:"" help:"Repository operations"`
 	Sync   edgecli.SyncCmd   `cmd:"" help:"Leaf agent sync"`
 	Bridge edgecli.BridgeCmd `cmd:"" help:"NATS-to-Fossil bridge"`
+	Hub    edgecli.HubCmd    `cmd:"" help:"Embedded NATS + fossil hub (root or soliciting via --leaf-upstream)"`
 	Notify edgecli.NotifyCmd `cmd:"" help:"Bidirectional notification messaging"`
 	Doctor edgecli.DoctorCmd `cmd:"" help:"Check development environment health"`
 }

--- a/docs/architecture/hub-package.md
+++ b/docs/architecture/hub-package.md
@@ -12,12 +12,14 @@ All types are libfossil-free and nats-server-free. Consumers import only `github
 
 ```go
 type Config struct {
-    RepoPath           string        // hub.fossil path; created if absent
+    RepoPath           string        // fossil repo path; created if absent
+    ServerName         string        // NATS server identity; empty = nats-server auto-generated random
     BootstrapUser      string        // default "hub"
-    NATSStoreDir       string        // default <repo dir>/nats-store
+    NATSStoreDir       string        // default <repo dir>/messaging
     FossilHTTPPort     int           // 0 = auto-pick
     NATSClientPort     int           // 0 = auto-pick
     NATSLeafPort       int           // 0 = auto-pick
+    LeafUpstream       string        // optional "nats-leaf://host:port" to solicit upstream; empty = root hub
     CheckpointInterval time.Duration // 0 = 10s (PASSIVE WAL checkpoint cadence)
 }
 
@@ -28,8 +30,9 @@ func (h *Hub) ServeHTTP(ctx context.Context) error
 func (h *Hub) Stop() error
 
 func (h *Hub) NATSURL() string       // "nats://127.0.0.1:NNNN"
-func (h *Hub) LeafUpstream() string  // "nats-leaf://127.0.0.1:LLLL"
+func (h *Hub) LeafUpstream() string  // "nats-leaf://127.0.0.1:LLLL" (this hub's leafnode listener)
 func (h *Hub) HTTPAddr() string      // "127.0.0.1:HHHH"
+func (h *Hub) ServerName() string    // live NATS server identity (Config.ServerName or auto-generated)
 
 type User struct{ Login, Caps string }
 
@@ -58,7 +61,7 @@ func (h *Hub) ReadAt(ctx context.Context, rev RevID, path string) ([]byte, error
 ctx, cancel := context.WithCancel(context.Background())
 defer cancel()
 
-h, err := hub.NewHub(ctx, hub.Config{RepoPath: "/data/hub.fossil"})
+h, err := hub.NewHub(ctx, hub.Config{RepoPath: "/data/hub.repo"})
 if err != nil { return err }
 defer h.Stop()
 
@@ -74,12 +77,12 @@ The hub deliberately does **not** cap `MaxOpenConns`. An earlier iteration set `
 
 ## Vanilla Fossil Interop
 
-`hub.fossil` is opened in WAL journal mode (libfossil's default). Without periodic checkpoints, the on-disk file would stay as a ~4 KiB stub plus a multi-hundred-KiB `*-wal` sidecar for the lifetime of the hub — and vanilla `fossil ui` / `fossil info` / third-party SQLite tooling would refuse to open it because their validity probe stats the main file before consulting the WAL.
+The hub repo file is opened in WAL journal mode (libfossil's default). Without periodic checkpoints, the on-disk file would stay as a ~4 KiB stub plus a multi-hundred-KiB `*-wal` sidecar for the lifetime of the hub — and vanilla `fossil ui` / `fossil info` / third-party SQLite tooling would refuse to open it because their validity probe stats the main file before consulting the WAL.
 
 The hub guards both ends of that contract:
 
-- **While serving:** a background goroutine runs `PRAGMA wal_checkpoint(PASSIVE)` every `Config.CheckpointInterval` (default 10s). PASSIVE never blocks readers or writers, so vanilla fossil can read `hub.fossil` at any time without coordinating with the hub.
-- **After Stop:** `Hub.Stop` halts the checkpoint goroutine, then closes the libfossil handle. libfossil's own `(*Repo).Close` runs `PRAGMA wal_checkpoint(TRUNCATE)` before releasing the connection (libfossil v0.6.0+), so the on-disk `hub.fossil` is self-contained — no `-wal` / `-shm` sidecar required.
+- **While serving:** a background goroutine runs `PRAGMA wal_checkpoint(PASSIVE)` every `Config.CheckpointInterval` (default 10s). PASSIVE never blocks readers or writers, so vanilla fossil can read the repo file at any time without coordinating with the hub.
+- **After Stop:** `Hub.Stop` halts the checkpoint goroutine, then closes the libfossil handle. libfossil's own `(*Repo).Close` runs `PRAGMA wal_checkpoint(TRUNCATE)` before releasing the connection (libfossil v0.6.0+), so the on-disk repo file is self-contained — no `-wal` / `-shm` sidecar required.
 
 There is no "disable" knob: vanilla-fossil readability is the contract this package exists to uphold. Set a long `CheckpointInterval` if you really want to dilute the cadence.
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"sync"
 	"time"
@@ -31,12 +32,18 @@ type Config struct {
 	// RepoPath is the absolute path to hub.fossil. Created if absent.
 	RepoPath string
 
+	// ServerName is the NATS server identity. Surfaces in leafnode
+	// handshakes, varz, and gossip. Empty leaves nats-server's
+	// auto-generated random name.
+	ServerName string
+
 	// BootstrapUser is the libfossil user created at hub bootstrap.
 	// Default: "hub".
 	BootstrapUser string
 
 	// NATSStoreDir is the JetStream storage directory. When empty, defaults
-	// to filepath.Dir(RepoPath) + "/nats-store".
+	// to filepath.Dir(RepoPath) + "/messaging" — implementation-agnostic on
+	// disk; the contents underneath are still NATS JetStream format.
 	NATSStoreDir string
 
 	// FossilHTTPPort is the port to serve fossil HTTP on. 0 = auto-pick.
@@ -49,6 +56,12 @@ type Config struct {
 	// NATSLeafPort is the leafnode listener port for remote agents.
 	// 0 = auto-pick.
 	NATSLeafPort int
+
+	// LeafUpstream is an optional upstream leafnode URL to solicit a
+	// connection toward (e.g. "nats-leaf://hub.example:7422"). When set,
+	// this hub acts as a leaf of that upstream — subjects published locally
+	// are forwarded upstream and vice versa. Empty = no upstream solicit.
+	LeafUpstream string
 
 	// NobodyCaps grants the libfossil-pre-populated 'nobody' user these
 	// caps after hub bootstrap. Empty leaves nobody at libfossil's defaults
@@ -129,7 +142,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		cfg.BootstrapUser = "hub"
 	}
 	if cfg.NATSStoreDir == "" {
-		cfg.NATSStoreDir = filepath.Join(filepath.Dir(cfg.RepoPath), "nats-store")
+		cfg.NATSStoreDir = filepath.Join(filepath.Dir(cfg.RepoPath), "messaging")
 	}
 
 	libfossilRepo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser)
@@ -336,6 +349,10 @@ func (h *Hub) Stop() error {
 // NATSURL returns the embedded NATS server's client URL.
 func (h *Hub) NATSURL() string { return h.natsURL }
 
+// ServerName returns the NATS server identity (Config.ServerName, or the
+// auto-generated random name if Config.ServerName was empty).
+func (h *Hub) ServerName() string { return h.server.Name() }
+
 // LeafUpstream returns the leafnode listener URL, suitable for passing to
 // remote agents as their NATS leaf upstream. Empty if no leaf port is
 // configured.
@@ -369,15 +386,26 @@ func openOrCreateRepo(path, bootstrapUser string) (*libfossil.Repo, error) {
 
 func startNATS(cfg Config) (*natsserver.Server, error) {
 	opts := &natsserver.Options{
-		Host:      "127.0.0.1",
-		Port:      portOrAuto(cfg.NATSClientPort),
-		NoLog:     true,
-		NoSigs:    true,
-		JetStream: true,
-		StoreDir:  cfg.NATSStoreDir,
+		Host:       "127.0.0.1",
+		Port:       portOrAuto(cfg.NATSClientPort),
+		ServerName: cfg.ServerName,
+		NoLog:      true,
+		NoSigs:     true,
+		JetStream:  true,
+		StoreDir:   cfg.NATSStoreDir,
 	}
 	opts.LeafNode.Host = "127.0.0.1"
 	opts.LeafNode.Port = portOrAuto(cfg.NATSLeafPort)
+
+	if cfg.LeafUpstream != "" {
+		u, err := url.Parse(cfg.LeafUpstream)
+		if err != nil {
+			return nil, fmt.Errorf("hub: parse LeafUpstream %q: %w", cfg.LeafUpstream, err)
+		}
+		opts.LeafNode.Remotes = []*natsserver.RemoteLeafOpts{
+			{URLs: []*url.URL{u}},
+		}
+	}
 
 	srv, err := natsserver.NewServer(opts)
 	if err != nil {


### PR DESCRIPTION
## Summary
- New \`edgesync hub serve\` subcommand: spins up an embedded NATS+fossil hub at the machine level, default name \`<hostname>-hub\`, repo at \`~/.edgesync/<name>/hub.repo\`
- \`hub.Config.ServerName\` — sets the NATS server identity (surfaces in leafnode handshakes, varz, gossip)
- \`hub.Config.LeafUpstream\` — optional leafnode-solicit URL so one hub can attach as a leaf of another
- \`Hub.ServerName()\` getter — live server-side truth
- \`NATSStoreDir\` default renamed \`nats-store\` → \`messaging\` — implementation-agnostic on-disk path (Go field name unchanged)
- Docs updated: \`docs/architecture/hub-package.md\` reflects new fields, \`messaging/\` default, and a generic repo-file naming convention

## Why
The hub is the machine-singleton substrate consumers (sesh, bones, etc.) sit on top of. Until now there was no CLI for it and no way to name it at the NATS level — the leafnode listener had no identity in handshakes. Session/agent vocabulary deliberately lives in a wrapper repo (\`sesh\`) above this layer; EdgeSync stays a sync engine.

## Verified end-to-end
- **Hub-to-hub leaf solicit:** two hubs on this machine, one solicits via \`--leaf-upstream\`; bidirectional pub/sub flows across the handshake
- **3-edge star:** 1 root hub + 3 leaf processes, fan-in / cross-leaf / subject-filter all behave as expected (also surfaced that NATS subjects are flat across the hub — leaf project tokens are descriptive, not enforcement)
- **CLI smoke:** \`edgesync hub serve\` → starts on auto-picked ports, NATS req/reply works through embedded server, clean SIGINT shutdown leaves repo self-contained (no \`-wal\` / \`-shm\` sidecars; vanilla fossil can read \`hub.repo\` immediately)

## Test plan
- [x] \`go test ./hub/... ./cli/...\` — 31 pass
- [x] \`go vet ./...\` — clean
- [x] CLI smoke on m4-macbook (\`edgesync hub serve\` with default + \`--name\` override)
- [x] Two-hub leaf solicit smoke
- [x] Existing \`TestHub_StopLeavesRepoVanillaReadable\` still passes

## Out of scope (filed/discussed separately)
- Session-level leaf CLI — moved to https://github.com/danmestas/sesh (depends on this hub package via the \`hub.Config.ServerName\` + \`LeafUpstream\` additions in this PR)
- Coord/lease registry (sessions, agents) — belongs in the \`sesh\` layer, not here