### PR TITLE
feat(hub): expose Hub.NumLeafs() getter

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -361,6 +361,12 @@ func (h *Hub) LeafUpstream() string { return h.leafUpstream }
 // HTTPAddr returns the host:port the fossil HTTP server is bound to.
 func (h *Hub) HTTPAddr() string { return h.httpAddr }
 
+// NumLeafs returns the current count of active leafnode connections to
+// this hub. Consumers can poll this to implement auto-shutdown behavior
+// when the last remote leaf disconnects (e.g. sesh's "hub runs until the
+// last session closes" lifecycle).
+func (h *Hub) NumLeafs() int { return h.server.NumLeafNodes() }
+
 // FossilSyncSubject returns the NATS subject the hub subscribes to for
 // incoming fossil-sync xfer requests, or "" if Config.DisableFossilSyncOverNATS
 // was set. Format: "<prefix>.<project-code>.sync".


### PR DESCRIPTION
## Summary
- Adds \`Hub.NumLeafs() int\` — thin getter over the embedded NATS server's \`NumLeafNodes()\`
- Three lines, no behavior change

## Why
Consumers that want a \"hub auto-shuts down when the last leaf disconnects\" lifecycle need to read leaf-connection count. Immediate use case: the sesh wrapper spike (https://github.com/danmestas/sesh), where the hub spawns on first \`sesh up\` and exits on last.

## Test plan
- [x] \`go test ./hub/...\` — 29 pass
- [x] \`go vet ./...\` clean
- [ ] Smoke under sesh's auto-shutdown poll loop (separate sesh PR)