### PR TITLE
refactor(hub): rename Hub.LeafUpstream() → LeafURL()

### DIFF
--- a/cli/hub_serve.go
+++ b/cli/hub_serve.go
@@ -72,7 +72,7 @@ func (c *HubServeCmd) Run(g *libfossilcli.Globals) error {
 		"repo", repoPath,
 		"http", "http://"+h.HTTPAddr(),
 		"nats", h.NATSURL(),
-		"leaf_upstream", h.LeafUpstream(),
+		"leaf_url", h.LeafURL(),
 		"sync_subject", h.FossilSyncSubject(),
 	)
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -121,9 +121,9 @@ type Hub struct {
 	natsSyncSub   *nats.Subscription
 	syncSubject   string
 
-	httpAddr     string
-	natsURL      string
-	leafUpstream string
+	httpAddr string
+	natsURL  string
+	leafURL  string
 
 	checkpointStop chan struct{}
 	checkpointDone chan struct{}
@@ -184,7 +184,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		httpListener: httpLn,
 		httpAddr:     httpLn.Addr().String(),
 		natsURL:      natsServer.ClientURL(),
-		leafUpstream: leafAddr,
+		leafURL:      leafAddr,
 	}
 
 	if !cfg.DisableFossilSyncOverNATS {
@@ -353,10 +353,10 @@ func (h *Hub) NATSURL() string { return h.natsURL }
 // auto-generated random name if Config.ServerName was empty).
 func (h *Hub) ServerName() string { return h.server.Name() }
 
-// LeafUpstream returns the leafnode listener URL, suitable for passing to
-// remote agents as their NATS leaf upstream. Empty if no leaf port is
-// configured.
-func (h *Hub) LeafUpstream() string { return h.leafUpstream }
+// LeafURL returns this hub's leafnode listener URL — the URL remote leaves
+// dial as their upstream. Empty if no leaf port is configured. Distinct
+// from Config.LeafUpstream, which is the input URL this hub itself solicits.
+func (h *Hub) LeafURL() string { return h.leafURL }
 
 // HTTPAddr returns the host:port the fossil HTTP server is bound to.
 func (h *Hub) HTTPAddr() string { return h.httpAddr }

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -37,8 +37,8 @@ func TestNewHub_BootstrapAndAddresses(t *testing.T) {
 	if h.NATSURL() == "" {
 		t.Error("NATSURL empty after NewHub")
 	}
-	if h.LeafUpstream() == "" {
-		t.Error("LeafUpstream empty after NewHub")
+	if h.LeafURL() == "" {
+		t.Error("LeafURL empty after NewHub")
 	}
 }
 
@@ -46,7 +46,7 @@ func TestNewHub_AutoPortsAreDistinct(t *testing.T) {
 	h := newTestHub(t)
 
 	natsURL := h.NATSURL()         // nats://127.0.0.1:NNNN
-	leafURL := h.LeafUpstream()    // nats-leaf://127.0.0.1:LLLL
+	leafURL := h.LeafURL()         // nats-leaf://127.0.0.1:LLLL
 	httpAddr := h.HTTPAddr()       // 127.0.0.1:HHHH
 
 	if natsURL == leafURL || natsURL == httpAddr || leafURL == httpAddr {


### PR DESCRIPTION
## Summary

- `Hub.LeafUpstream()` getter returns the local leafnode listener URL. Its name collided with `Config.LeafUpstream` (the URL this hub solicits to) — same word, opposite direction on the same struct family.
- Renamed getter to `LeafURL()` (symmetric with the existing `NATSURL()`).
- Renamed private field `leafUpstream` → `leafURL`.
- `Config.LeafUpstream` stays — that name is correct on the input side.

Surfaced while wiring sesh PR #3, which needed to publish the URL in its session-state JSON.

## Compatibility

No callers outside this repo in the v0.0.16 dependency graph — bones pins v0.0.16. Sesh consumes EdgeSync via a local replace directive and gets a one-line update on its open PR.

## Test plan

- [x] \`go vet ./...\`
- [x] \`go build ./...\`
- [x] \`go test ./hub/... ./cli/...\` — TestNewHub_BootstrapAndAddresses, TestNewHub_AutoPortsAreDistinct updated to call \`LeafURL()\`