### PR TITLE
feat(hub): cross-leaf fossil sync over NATS (#156)

### DIFF
--- a/docs/architecture/sync-protocol.md
+++ b/docs/architecture/sync-protocol.md
@@ -225,6 +225,75 @@ Two-pass architecture matching Fossil's `manifest_crosslink_begin`/`manifest_cro
 | Extension tables | `xigot`/`xgimme` exchange pending | Catalog hashes match or no rows exchanged |
 | Safety | -- | `MaxRounds` (100) or context cancellation |
 
+## NATS-Wrapped Sync (Cross-Leaf Propagation)
+
+The protocol above is transport-agnostic. EdgeSync's hub wraps it in two
+NATS subjects so multiple hubs sharing a project-code propagate commits
+without polling.
+
+### Subjects
+
+For a project-code `<pc>` and configurable prefix (default `fossil`):
+
+| Subject | Pattern | Role |
+|---------|---------|------|
+| Sync | `<prefix>.<pc>.sync` | Request/reply. Body = xfer payload. Hub subscribes; on receipt, dispatches to `HandleSync` and `Respond`s with the encoded reply. Pullers `Request` on the same subject; the `natsTransport` adapter turns this into an `RTT` for `libfossil.Sync`. |
+| Commit | `<prefix>.<pc>.commit` | Fire-and-forget notification. Body = JSON `{"rid": int64, "uuid": string}`. Hub publishes on every successful `Repo.Commit`; subscribers trigger a pull on the sibling `.sync` subject. |
+
+### Cross-leaf flow
+
+1. Hub A commits via `Hub.Repo().Commit(...)`. After libfossil returns
+   the new rid/uuid, A's `publish` hook fires a JSON notification on
+   `<prefix>.<pc>.commit`.
+2. NATS delivers the notification to every connected hub subscribed to
+   that subject. The publishing connection uses `NoEcho()` so A does
+   not receive its own notification.
+3. Hub B's `startCommitSubscriber` callback decodes the message and
+   calls `libfossil.Sync(ctx, natsTransport, SyncOpts{Pull: true,
+   ProjectCode: pc})`. The transport publishes the xfer request on
+   `<prefix>.<pc>.sync` and awaits the responder's reply.
+4. Hub A's `startFossilSyncSubscriber` callback handles the xfer
+   request, dispatches to `HandleSync`, and `Respond`s with the
+   manifest.
+5. B's `Sync` applies the manifest; trunk advances.
+
+### Project-code coordination
+
+Both hubs must end up with the same project-code for their subjects to
+align. Two coordination patterns:
+
+- **Explicit pinning.** `Config.ProjectCode` passed to every hub in
+  the topology; root hubs use this on first create
+  (`libfossil.CreateOpts.ProjectCode`). Reopening a repo with a
+  different `Config.ProjectCode` than what's on disk is rejected as
+  config drift.
+- **Clone-from-upstream.** `Config.SeedFromUpstream` — when set and
+  the local repo doesn't yet exist, NewHub clones from the given hub
+  HTTP xfer URL before opening. The clone copies the upstream's
+  project-code, so children declaring `SeedFromUpstream` typically
+  don't need to also set `ProjectCode` (both can be set and are
+  cross-checked).
+
+NATS-native clone (cloning over a `.sync` subject) is deferred until
+libfossil's `HandleSync` supports the clone protocol; today the seed
+path uses HTTP against an upstream hub's `XferHandler`.
+
+### Known limitations
+
+- **Multi-responder race on `.sync`.** With 3+ hubs sharing a
+  project-code, every subscriber on `.sync` responds to xfer
+  requests. `nats.Request` returns only the first reply. If the
+  first responder doesn't have the requested data, the pull
+  observes a no-op round and the caller falls back to retrying
+  on the next `.commit` notification. Acceptable for 2-node sesh
+  topologies (gold-path); a follow-up will add queue-group routing
+  or per-peer reply subjects for larger fan-outs.
+- **No backpressure on the `.commit` queue.** A burst of commits
+  produces a burst of notifications, each fanning out to all peers,
+  each triggering a pull. NATS subscription limits eventually drop
+  messages under load; subscribers recover via the next non-dropped
+  notification (idempotent pull).
+
 ## Key Constraints
 
 - **Blob format:** `[4-byte BE uncompressed size][zlib data]`. If `len(content) == declared size`, content is uncompressed.

--- a/docs/superpowers/specs/2026-05-12-cross-leaf-fossil-sync-design.md
+++ b/docs/superpowers/specs/2026-05-12-cross-leaf-fossil-sync-design.md
@@ -1,0 +1,232 @@
+# Cross-Leaf Fossil Sync Over NATS — EdgeSync PR Plan
+
+**Date**: 2026-05-12
+**Tracking**: EdgeSync #156
+**Dependency**: libfossil `CreateOpts.ProjectCode` (separate upstream issue, expected `v0.6.1`)
+
+## Context
+
+EdgeSync issue #156 documents two gaps that block cross-process Fossil
+sharing for sesh:
+
+1. The hub's NATS sync subject is keyed by per-repo `project-code`.
+   Each leaf creates a fresh repo → fresh code → siblings subscribe to
+   different subjects → commits don't propagate.
+2. The sync handler is subscribe-only — `Repo.Commit` never publishes
+   anything, so peers only learn of new commits by explicit polling.
+
+The fix is two coordinated changes, both EdgeSync-side (once the
+upstream libfossil PR lands):
+
+- **(a) Shared project-code.** New `Config.ProjectCode` for roots that
+  want to declare their identity, plus `Config.SeedFromUpstream` for
+  children that should inherit it by cloning at bootstrap time.
+- **(b) Notification on commit.** `Repo.Commit` publishes a
+  `{rid, uuid}` JSON message on a sibling `.commit` subject after the
+  underlying libfossil commit succeeds. Subscribers on that subject
+  pull via the existing `.sync` request/reply path.
+
+## Goal
+
+A single self-contained EdgeSync PR that, on green CI, makes the sesh
+integration tests (`TestSubLeaf_DoesNotSyncToday`,
+`TestHub_DoesNotAccumulateProjectCommitsToday`) flippable from
+"asserts no propagation" to "asserts propagation within N seconds."
+
+## In scope
+
+- Bump `github.com/danmestas/libfossil` pin to `v0.6.1`
+- `Config.ProjectCode` — explicit, optional, validated (re-uses
+  upstream's `^[0-9a-f]{40}$` constraint via Create's error path)
+- `Config.SeedFromUpstream` — URL of an upstream hub's HTTP xfer
+  endpoint; when the local repo doesn't yet exist, clone before open
+- Auto-publish on commit via the hub's `Repo.Commit` wrapper
+- New `.commit`-subject subscriber in the hub that triggers an xfer
+  pull on receipt
+- Integration test: two `NewHub` instances, shared project-code, on a
+  bridged NATS topology; commit on A appears on B within ~2s
+
+## Out of scope (deferred)
+
+- NATS-native clone (would need upstream `HandleSync` clone support —
+  CDG-148; HTTP seed is the fast path).
+- Leaf agent changes — its existing sync already works for its tier;
+  any cross-leaf propagation it needs comes via the hub. Filed as a
+  follow-up if integration testing reveals a gap.
+- Updating `leaf/` submodule pin — separate change, not required for
+  this PR to ship.
+- Multi-responder `.sync` race-condition hardening (see Q3 below).
+
+## Design
+
+### 1. `Config.ProjectCode`
+
+```go
+type Config struct {
+    // ... existing fields ...
+
+    // ProjectCode optionally pins the repo's project-code on first
+    // create. When the repo at RepoPath already exists, this value
+    // (if non-empty) must match the on-disk project-code or NewHub
+    // returns an error — guards against silent topology drift where
+    // a caller fixes their config but an old repo is still around.
+    // Empty preserves current behavior: generate on create, accept
+    // whatever's on disk on open.
+    ProjectCode string
+}
+```
+
+Threading: `openOrCreateRepo(path, bootstrapUser, projectCode)`. On the
+create branch, passes through to `libfossil.Create(path, CreateOpts{
+User: bootstrapUser, ProjectCode: projectCode})`. On the open branch,
+if `projectCode != ""`, read `Config("project-code")` and compare;
+error on mismatch.
+
+### 2. `Config.SeedFromUpstream`
+
+```go
+type Config struct {
+    // SeedFromUpstream, when set and RepoPath doesn't yet exist on
+    // disk, clones from this URL before opening. The cloned repo
+    // carries the upstream's project-code, so children declaring a
+    // SeedFromUpstream don't need to also set ProjectCode.
+    //
+    // URL is an EdgeSync hub HTTP xfer endpoint
+    // (e.g. "http://hub.local:8080/"). NATS-native clone is deferred
+    // until libfossil HandleSync supports the clone protocol.
+    SeedFromUpstream string
+}
+```
+
+If both `ProjectCode` and `SeedFromUpstream` are set and the clone
+result's project-code disagrees with `ProjectCode`, fail.
+
+### 3. Auto-publish on commit
+
+In `hub.Repo.Commit` (file: `hub/repo.go:129`), after the underlying
+`libfossil.Repo` commit returns successfully:
+
+- If the parent `Hub` has a NATS client and a `commitSubject`,
+  publish a JSON message: `{"rid": <int64>, "uuid": "<lowercase hex>"}`.
+- Best-effort: log publish failures, do not fail the commit. The repo
+  is the source of truth; downstream is eventually consistent.
+
+This requires `hub.Repo` to know about the Hub's NATS client. Two
+shapes:
+
+- **(a)** Add a back-reference: `Repo.publish func(rid, uuid)`,
+  wired by `NewHub` when constructing the wrapper.
+- **(b)** Move the auto-publish responsibility to a Hub-level method
+  that wraps Commit (`Hub.Commit(ctx, opts) (RevID, error)`).
+
+Lean (a) — keeps the existing `Hub.Repo()` API surface unchanged and
+lets direct callers of `Repo.Commit` benefit from publish without
+going through Hub. `OpenRepo` (the standalone path) leaves
+`publish == nil`, which the wrapper treats as "no-op."
+
+### 4. `.commit` subscriber
+
+New method `startCommitSubscriber(cfg Config)`, invoked from `NewHub`
+right after `startFossilSyncSubscriber`. Subscribes to
+`<prefix>.<project-code>.commit`. On message:
+
+- Decode `{rid, uuid}`.
+- If our local repo already has that uuid (cheap `Config` /
+  manifest lookup), drop.
+- Else trigger an xfer pull on `<prefix>.<project-code>.sync`, using
+  a NATS transport adapter. This is the request/reply path that
+  already exists on the receive side — we just need a *requester*.
+
+The requester is the new plumbing in this PR. Likely a small adapter
+that implements `libfossil.Transport` over NATS request/reply, then
+calling `h.repo.handle.Sync(ctx, SyncOpts{...})` against it. See
+Q2 below — there may be reusable bits in `leaf/agent`.
+
+### 5. Integration test
+
+`hub/cross_leaf_test.go` (new):
+
+- `cfgA, cfgB`: distinct `RepoPath`, same `ProjectCode`,
+  `LeafUpstream` wired so B solicits a connection to A (or both join a
+  third NATS for the test — see Q1).
+- `hubA, _ := NewHub(ctx, cfgA)` + serve.
+- `hubB, _ := NewHub(ctx, cfgB)` + serve. SeedFromUpstream points at A.
+- Commit on A: `rid, _ := hubA.Repo().Commit(ctx, ...)`.
+- Assert eventually (≤2s, 50ms poll) that B has a commit with the
+  same uuid.
+- Reverse direction: commit on B, assert A sees it.
+
+Skip via `t.Skip` if the host can't open two ephemeral ports — same
+pattern as existing hub tests.
+
+## Open questions
+
+- **Q1 — Test topology.** Two hubs, one NATS bridge? Easiest:
+  `hubB` configured with `LeafUpstream: hubA.LeafURL()` so the
+  embedded NATS servers are linked. Alternative: spin a third
+  standalone NATS server, both connect as clients. Lean leaf-link —
+  matches production topology and exercises the leafnode path.
+
+- **Q2 — Pull-via-NATS machinery.** `leaf/agent/code_artifact.go`
+  has `Agent.Sync` / `Agent.SyncTo` that pull from a hub URL — but
+  it's HTTP, not NATS request/reply on a subject. I haven't found a
+  reusable NATS-pull adapter; likely need to write one in `hub/`
+  (`natsTransport` implementing `libfossil.Transport.Send`). Confirm
+  this isn't already done somewhere I missed before I write it from
+  scratch.
+
+- **Q3 — `.sync` multi-responder race.** If multiple peers subscribe
+  to the same project-code's `.sync` subject (which is exactly what
+  this PR enables), `nc.Subscribe` puts them all in the deliver-set
+  and they all respond. `nc.Request()` returns the first reply;
+  if the first responder is a peer that doesn't have the data yet,
+  the puller sees a stale/empty response. For the 2-node test this
+  isn't a problem (only one responder has the data). For 3+
+  topologies we'll want either queue-group routing or per-peer
+  reply subjects. Flag for a follow-up, don't block this PR.
+
+## File touch list
+
+- `hub/hub.go` — Config fields, `startCommitSubscriber`, hook into
+  `NewHub`, `openOrCreateRepo` signature.
+- `hub/repo.go` — `Repo.publish` hook, `Commit` augmentation.
+- `hub/clone.go` *(new)* — `seedFromUpstream` helper invoked by
+  `NewHub` before `openOrCreateRepo` when the path is absent.
+- `hub/nats_transport.go` *(new, if Q2 lands here)* —
+  `libfossil.Transport` over NATS request/reply.
+- `hub/cross_leaf_test.go` *(new)* — integration test.
+- `go.mod` — libfossil pin → `v0.6.1`.
+- `docs/architecture/sync-protocol.md` — note the new subjects
+  (`.sync` and `.commit`) and the propagation model.
+
+## Tasks (in order)
+
+1. **Blocked**: upstream libfossil `CreateOpts.ProjectCode` lands and
+   `v0.6.1` is cut.
+2. Bump `go.mod` pin; `go mod tidy`; verify compile.
+3. `Config.ProjectCode` plumbing through `openOrCreateRepo`; tests for
+   mismatch on existing repo.
+4. `Config.SeedFromUpstream` + `hub/clone.go`; test against an HTTP
+   xfer endpoint (stand up a transient hub in the test).
+5. `Repo.publish` hook + `Commit` augmentation; unit test that a
+   commit produces a `.commit` message with correct payload.
+6. `startCommitSubscriber`; integration test the receive side
+   (publish a `.commit`, observe an xfer pull).
+7. NATS Transport adapter (Q2 outcome).
+8. Cross-leaf integration test (the gold-path one).
+9. `docs/architecture/sync-protocol.md` update.
+10. `make` / `go test ./...` / replicate CI locally per global policy.
+11. Push, open PR, wait for human merge.
+
+## Sesh side (out of this PR, follow-up by sesh-maintainer)
+
+Once this PR ships and sesh bumps its EdgeSync pin:
+
+- Set `Config.ProjectCode` from a deterministic seed
+  (e.g. SHA1 of project root path, lowercased hex, first 40 chars) on
+  the sesh project.repo.
+- Set `Config.SeedFromUpstream` on the hub.repo so the hub inherits
+  the project-code at bootstrap.
+- Flip the two integration tests in `sesh#11` from
+  `TestSubLeaf_DoesNotSyncToday` to
+  `TestSubLeaf_SyncsToday` (and the hub equivalent).

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.3
 	github.com/danmestas/EdgeSync/leaf v0.0.11
-	github.com/danmestas/libfossil v0.6.0
+	github.com/danmestas/libfossil v0.6.1
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.6.0 h1:f7U6MskBzFoU60lRYHQU8SQOVvfV3YC9A5y9olowQXE=
-github.com/danmestas/libfossil v0.6.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.6.1 h1:r/j6Mv5lDD27pWRO43nZR7nND4M9gZ1kY45hNhIxYWw=
+github.com/danmestas/libfossil v0.6.1/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/hub/clone.go
+++ b/hub/clone.go
@@ -1,0 +1,49 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	libfossil "github.com/danmestas/libfossil"
+)
+
+// seedFromUpstream clones a fossil repo at path from the given HTTP xfer
+// endpoint URL. The cloned repo carries the upstream's project-code, so
+// it can join the upstream's NATS fossil-sync subject after open.
+//
+// Validates that the URL is well-formed and has an http(s) scheme.
+// NATS-native clone is deferred until libfossil HandleSync supports the
+// clone protocol upstream (CDG-148).
+//
+// If expectedProjectCode is non-empty, asserts the cloned repo's
+// project-code matches it. The cloned repo is removed before returning
+// the mismatch error so the caller can retry or give up cleanly.
+func seedFromUpstream(ctx context.Context, path, upstreamURL, bootstrapUser, expectedProjectCode string) error {
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		return fmt.Errorf("hub: parse SeedFromUpstream %q: %w", upstreamURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("hub: SeedFromUpstream %q: only http(s) is supported (NATS-clone deferred to libfossil HandleSync support)", upstreamURL)
+	}
+
+	transport := libfossil.NewHTTPTransport(upstreamURL)
+	repo, result, err := libfossil.Clone(ctx, path, transport, libfossil.CloneOpts{
+		User:        bootstrapUser,
+		ProjectCode: expectedProjectCode,
+	})
+	if err != nil {
+		return fmt.Errorf("hub: clone from %s: %w", upstreamURL, err)
+	}
+	if err := repo.Close(); err != nil {
+		return fmt.Errorf("hub: close cloned repo: %w", err)
+	}
+
+	if expectedProjectCode != "" && result.ProjectCode != expectedProjectCode {
+		_ = os.Remove(path)
+		return fmt.Errorf("hub: cloned repo has project-code %q, want %q (config drift between hub and upstream)", result.ProjectCode, expectedProjectCode)
+	}
+	return nil
+}

--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -1,0 +1,175 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+)
+
+// sharedProjectCode is a fixed 40-char lowercase hex string used as the
+// project-code across the two hubs in cross-leaf tests. Format matches
+// libfossil's validation (^[0-9a-f]{40}$).
+const sharedProjectCode = "1111111111111111111111111111111111111111"
+
+// TestCrossLeaf_SharedProjectCode_PropagatesCommit asserts the headline
+// fix for issue #156: two hubs with a shared project-code, linked over a
+// NATS leafnode connection, see each other's commits via the
+// .commit → pull-on-notify flow.
+func TestCrossLeaf_SharedProjectCode_PropagatesCommit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dirA := t.TempDir()
+	hubA, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirA, "hubA.fossil"),
+		ProjectCode: sharedProjectCode,
+		NobodyCaps:  "gio", // allow unauthenticated xfer
+	})
+	if err != nil {
+		t.Fatalf("NewHub A: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA.Stop() })
+
+	httpCtxA, httpCancelA := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelA)
+	go func() { _ = hubA.ServeHTTP(httpCtxA) }()
+
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:     filepath.Join(dirB, "hubB.fossil"),
+		ProjectCode:  sharedProjectCode,
+		LeafUpstream: hubA.LeafURL(),
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	httpCtxB, httpCancelB := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelB)
+	go func() { _ = hubB.ServeHTTP(httpCtxB) }()
+
+	waitFor(t, 5*time.Second, "leaf link A↔B", func() bool {
+		return hubA.NumLeafs() >= 1
+	})
+
+	// Commit on A, expect B to see the file via pull-on-notify.
+	if _, err := hubA.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "from-a.txt", Content: []byte("hello-from-A")}},
+		Message: "commit on A",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("hubA.Commit: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "B sees from-a.txt at trunk", func() bool {
+		got, readErr := hubB.Read(ctx, "from-a.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-A"))
+	})
+
+	// Reverse direction: commit on B, expect A to see it.
+	if _, err := hubB.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "from-b.txt", Content: []byte("hello-from-B")}},
+		Message: "commit on B",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("hubB.Commit: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "A sees from-b.txt at trunk", func() bool {
+		got, readErr := hubA.Read(ctx, "from-b.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-B"))
+	})
+}
+
+// TestCrossLeaf_SubjectsAlign asserts that two hubs declaring the same
+// ProjectCode end up subscribed to the same .sync and .commit subjects.
+// Cheap structural check separate from the propagation gold-path.
+func TestCrossLeaf_SubjectsAlign(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dirA := t.TempDir()
+	hubA, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirA, "hubA.fossil"),
+		ProjectCode: sharedProjectCode,
+	})
+	if err != nil {
+		t.Fatalf("NewHub A: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA.Stop() })
+
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirB, "hubB.fossil"),
+		ProjectCode: sharedProjectCode,
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	if hubA.FossilSyncSubject() != hubB.FossilSyncSubject() {
+		t.Errorf("sync subjects diverge: A=%q B=%q", hubA.FossilSyncSubject(), hubB.FossilSyncSubject())
+	}
+	if hubA.FossilCommitSubject() != hubB.FossilCommitSubject() {
+		t.Errorf("commit subjects diverge: A=%q B=%q", hubA.FossilCommitSubject(), hubB.FossilCommitSubject())
+	}
+	wantSync := "fossil." + sharedProjectCode + ".sync"
+	wantCommit := "fossil." + sharedProjectCode + ".commit"
+	if hubA.FossilSyncSubject() != wantSync {
+		t.Errorf("sync subject = %q, want %q", hubA.FossilSyncSubject(), wantSync)
+	}
+	if hubA.FossilCommitSubject() != wantCommit {
+		t.Errorf("commit subject = %q, want %q", hubA.FossilCommitSubject(), wantCommit)
+	}
+}
+
+// TestNewHub_ProjectCodeMismatchOnExistingRepo asserts the drift-guard:
+// reopening a repo with a different ProjectCode than what's on disk
+// fails fast.
+func TestNewHub_ProjectCodeMismatchOnExistingRepo(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hub.fossil")
+
+	h, err := NewHub(ctx, Config{
+		RepoPath:    path,
+		ProjectCode: sharedProjectCode,
+	})
+	if err != nil {
+		t.Fatalf("first NewHub: %v", err)
+	}
+	if err := h.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	const otherCode = "2222222222222222222222222222222222222222"
+	if _, err := NewHub(ctx, Config{
+		RepoPath:    path,
+		ProjectCode: otherCode,
+	}); err == nil {
+		t.Fatal("NewHub with mismatched ProjectCode returned nil err; want config-drift error")
+	}
+}
+
+// waitFor polls cond every 50ms until it returns true or timeout fires.
+// Reports the description on timeout for diagnostic context.
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timeout after %v waiting for: %s", timeout, what)
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -13,11 +13,14 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -83,9 +86,36 @@ type Config struct {
 
 	// FossilSyncSubjectPrefix overrides the NATS subject prefix used by the
 	// fossil sync subscriber. Empty defaults to "fossil" (matching the
-	// leaf-agent default). The full subscribed subject is
-	// "<prefix>.<project-code>.sync".
+	// leaf-agent default). The full subscribed subjects are
+	// "<prefix>.<project-code>.sync" (xfer request/reply) and
+	// "<prefix>.<project-code>.commit" (notification on new commits).
 	FossilSyncSubjectPrefix string
+
+	// ProjectCode optionally pins the repo's project-code on first create
+	// (passed to libfossil.CreateOpts). When non-empty, must be 40-char
+	// lowercase hex (^[0-9a-f]{40}$).
+	//
+	// When the repo at RepoPath already exists, this value (if non-empty)
+	// must match the on-disk project-code or NewHub returns an error —
+	// guards against silent topology drift when a caller updates their
+	// config but an old repo lingers.
+	//
+	// Empty preserves current behavior: generate on create, accept whatever's
+	// on disk on open. Set this in topologies where multiple hubs/leaves
+	// must share a project-code so commits propagate over the same NATS
+	// sync subject.
+	ProjectCode string
+
+	// SeedFromUpstream, when set and RepoPath doesn't yet exist on disk,
+	// clones from this URL before opening. The cloned repo carries the
+	// upstream's project-code, so children declaring a SeedFromUpstream
+	// don't typically also need to set ProjectCode (though setting both
+	// and asserting they match is allowed and cross-checked).
+	//
+	// URL is an EdgeSync hub HTTP xfer endpoint (e.g. "http://hub.local:8080/").
+	// NATS-native clone is deferred until libfossil HandleSync supports the
+	// clone protocol upstream.
+	SeedFromUpstream string
 
 	// CheckpointInterval is how often the hub runs a PASSIVE WAL checkpoint
 	// against hub.fossil while serving. PASSIVE never blocks readers or
@@ -119,7 +149,9 @@ type Hub struct {
 
 	natsClient    *nats.Conn
 	natsSyncSub   *nats.Subscription
+	natsCommitSub *nats.Subscription
 	syncSubject   string
+	commitSubject string
 
 	httpAddr string
 	natsURL  string
@@ -145,7 +177,15 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		cfg.NATSStoreDir = filepath.Join(filepath.Dir(cfg.RepoPath), "messaging")
 	}
 
-	libfossilRepo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser)
+	if cfg.SeedFromUpstream != "" {
+		if _, statErr := os.Stat(cfg.RepoPath); errors.Is(statErr, os.ErrNotExist) {
+			if err := seedFromUpstream(ctx, cfg.RepoPath, cfg.SeedFromUpstream, cfg.BootstrapUser, cfg.ProjectCode); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	libfossilRepo, err := openOrCreateRepo(cfg.RepoPath, cfg.BootstrapUser, cfg.ProjectCode)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +229,19 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 
 	if !cfg.DisableFossilSyncOverNATS {
 		if err := h.startFossilSyncSubscriber(cfg); err != nil {
+			natsServer.Shutdown()
+			natsServer.WaitForShutdown()
+			httpLn.Close()
+			repo.Close()
+			return nil, err
+		}
+		if err := h.startCommitSubscriber(cfg); err != nil {
+			if h.natsSyncSub != nil {
+				_ = h.natsSyncSub.Unsubscribe()
+			}
+			if h.natsClient != nil {
+				h.natsClient.Close()
+			}
 			natsServer.Shutdown()
 			natsServer.WaitForShutdown()
 			httpLn.Close()
@@ -253,6 +306,7 @@ func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 		nats.ReconnectWait(2*time.Second),
 		nats.RetryOnFailedConnect(true),
 		nats.Timeout(5*time.Second),
+		nats.NoEcho(), // we publish on .commit + .sync ourselves; don't self-loop
 	)
 	if err != nil {
 		return fmt.Errorf("hub: connect local NATS for fossil-sync subscriber: %w", err)
@@ -283,6 +337,83 @@ func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 	h.natsClient = nc
 	h.natsSyncSub = sub
 	h.syncSubject = subject
+	return nil
+}
+
+// commitNotification is the JSON payload published on the .commit subject
+// when a new commit lands. Peers decode it and pull the manifest via the
+// .sync subject.
+type commitNotification struct {
+	RID  int64  `json:"rid"`
+	UUID string `json:"uuid"`
+}
+
+// startCommitSubscriber subscribes to "<prefix>.<project-code>.commit" and,
+// on receipt, triggers an xfer pull from peers on the sibling .sync
+// subject. Also wires the hub repo's publish hook so successful commits
+// publish a notification on the .commit subject.
+//
+// Requires startFossilSyncSubscriber to have run first (uses h.natsClient
+// and shares the project-code / prefix derivation).
+func (h *Hub) startCommitSubscriber(cfg Config) error {
+	projectCode, err := h.repo.handle.Config("project-code")
+	if err != nil {
+		return fmt.Errorf("hub: read project-code for commit subscriber: %w", err)
+	}
+	if projectCode == "" {
+		return fmt.Errorf("hub: project-code is empty; refusing to start commit subscriber")
+	}
+	prefix := cfg.FossilSyncSubjectPrefix
+	if prefix == "" {
+		prefix = "fossil"
+	}
+	commitSubject := prefix + "." + projectCode + ".commit"
+	syncSubject := prefix + "." + projectCode + ".sync"
+
+	pullTransport := newNATSTransport(h.natsClient, syncSubject, 0)
+	sub, err := h.natsClient.Subscribe(commitSubject, func(msg *nats.Msg) {
+		var n commitNotification
+		if jsonErr := json.Unmarshal(msg.Data, &n); jsonErr != nil {
+			log.Printf("hub commit subscriber: decode notification: %v", jsonErr)
+			return
+		}
+		// Pull is naturally idempotent — if we already have the uuid,
+		// the sync round converges with zero rounds / zero blobs. So
+		// we skip the up-front existence check and let the protocol
+		// handle dedup.
+		pullCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if _, syncErr := h.repo.handle.Sync(pullCtx, pullTransport, libfossil.SyncOpts{
+			Pull:        true,
+			ProjectCode: projectCode,
+			PeerID:      "edgesync-hub",
+		}); syncErr != nil {
+			log.Printf("hub commit subscriber: pull triggered by notification rid=%d uuid=%s: %v", n.RID, n.UUID, syncErr)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("hub: subscribe %s: %w", commitSubject, err)
+	}
+	if flushErr := h.natsClient.FlushTimeout(2 * time.Second); flushErr != nil {
+		_ = sub.Unsubscribe()
+		return fmt.Errorf("hub: flush commit subscription: %w", flushErr)
+	}
+
+	// Wire publish hook on the repo so future commits notify peers.
+	nc := h.natsClient
+	h.repo.publish = func(rid int64, uuid string) {
+		payload, jsonErr := json.Marshal(commitNotification{RID: rid, UUID: uuid})
+		if jsonErr != nil {
+			log.Printf("hub commit publish: encode notification rid=%d uuid=%s: %v", rid, uuid, jsonErr)
+			return
+		}
+		if pubErr := nc.Publish(commitSubject, payload); pubErr != nil {
+			log.Printf("hub commit publish: publish to %s rid=%d uuid=%s: %v", commitSubject, rid, uuid, pubErr)
+		}
+	}
+
+	h.natsCommitSub = sub
+	h.commitSubject = commitSubject
 	return nil
 }
 
@@ -322,6 +453,9 @@ func (h *Hub) Stop() error {
 			}
 		} else if h.httpListener != nil {
 			h.httpListener.Close()
+		}
+		if h.natsCommitSub != nil {
+			_ = h.natsCommitSub.Unsubscribe()
 		}
 		if h.natsSyncSub != nil {
 			_ = h.natsSyncSub.Unsubscribe()
@@ -372,6 +506,12 @@ func (h *Hub) NumLeafs() int { return h.server.NumLeafNodes() }
 // was set. Format: "<prefix>.<project-code>.sync".
 func (h *Hub) FossilSyncSubject() string { return h.syncSubject }
 
+// FossilCommitSubject returns the NATS subject the hub publishes on
+// after a successful commit, and subscribes to for peer notifications.
+// Empty if Config.DisableFossilSyncOverNATS was set. Format:
+// "<prefix>.<project-code>.commit".
+func (h *Hub) FossilCommitSubject() string { return h.commitSubject }
+
 // Repo returns the underlying fossil-repo handle the hub serves from. Use
 // this to share the handle with another component in the same process —
 // e.g. a coexisting CLI command path that needs user/commit/read access
@@ -379,11 +519,25 @@ func (h *Hub) FossilSyncSubject() string { return h.syncSubject }
 // while the Hub is still serving; use Hub.Stop for teardown.
 func (h *Hub) Repo() *Repo { return h.repo }
 
-func openOrCreateRepo(path, bootstrapUser string) (*libfossil.Repo, error) {
+func openOrCreateRepo(path, bootstrapUser, projectCode string) (*libfossil.Repo, error) {
 	if r, err := libfossil.Open(path); err == nil {
+		if projectCode != "" {
+			onDisk, cfgErr := r.Config("project-code")
+			if cfgErr != nil {
+				_ = r.Close()
+				return nil, fmt.Errorf("hub: read project-code from existing repo at %s: %w", path, cfgErr)
+			}
+			if onDisk != projectCode {
+				_ = r.Close()
+				return nil, fmt.Errorf("hub: existing repo at %s has project-code %q, Config.ProjectCode is %q (config drift)", path, onDisk, projectCode)
+			}
+		}
 		return r, nil
 	}
-	r, err := libfossil.Create(path, libfossil.CreateOpts{User: bootstrapUser})
+	r, err := libfossil.Create(path, libfossil.CreateOpts{
+		User:        bootstrapUser,
+		ProjectCode: projectCode,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("hub: create repo at %s: %w", path, err)
 	}

--- a/hub/nats_transport.go
+++ b/hub/nats_transport.go
@@ -1,0 +1,53 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	libfossil "github.com/danmestas/libfossil"
+	"github.com/nats-io/nats.go"
+)
+
+// natsTransport is a libfossil.Transport over NATS request/reply on a
+// single subject. RoundTrip publishes the xfer payload as a request,
+// waits for the responder, and returns the response bytes.
+//
+// Used by the hub to pull from peers on `<prefix>.<project-code>.sync`
+// after receiving a notification on the sibling `.commit` subject.
+type natsTransport struct {
+	nc      *nats.Conn
+	subject string
+	timeout time.Duration
+}
+
+const defaultNATSRoundTripTimeout = 30 * time.Second
+
+func newNATSTransport(nc *nats.Conn, subject string, timeout time.Duration) libfossil.Transport {
+	if timeout <= 0 {
+		timeout = defaultNATSRoundTripTimeout
+	}
+	return &natsTransport{nc: nc, subject: subject, timeout: timeout}
+}
+
+// RoundTrip publishes payload on the configured subject and blocks for
+// the reply, honoring ctx. Returns an error if the responder takes
+// longer than the transport's timeout (whichever fires first between
+// ctx and timeout). An empty reply body is treated as an error — the
+// hub-side handler uses an empty body to signal a HandleSync failure,
+// and a libfossil Sync round needs a non-empty manifest to make
+// progress.
+func (t *natsTransport) RoundTrip(ctx context.Context, payload []byte) ([]byte, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	msg, err := t.nc.RequestWithContext(reqCtx, t.subject, payload)
+	if err != nil {
+		return nil, fmt.Errorf("nats transport: request %s: %w", t.subject, err)
+	}
+	if len(msg.Data) == 0 {
+		return nil, errors.New("nats transport: empty reply (responder signaled HandleSync failure)")
+	}
+	return msg.Data, nil
+}

--- a/hub/nats_transport_test.go
+++ b/hub/nats_transport_test.go
@@ -1,0 +1,98 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/danmestas/libfossil/db/driver/modernc"
+	"github.com/nats-io/nats.go"
+)
+
+// TestNATSTransport_RoundTrip exercises the request/reply path end-to-end
+// against an embedded NATS server: a fake responder echoes the payload
+// with a known prefix; the transport hands the response back unchanged.
+func TestNATSTransport_RoundTrip(t *testing.T) {
+	h := newTestHub(t)
+
+	nc, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	const subject = "fossil.test.sync"
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		_ = msg.Respond(append([]byte("REPLY:"), msg.Data...))
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+	if err := nc.FlushTimeout(time.Second); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	tr := newNATSTransport(nc, subject, 5*time.Second)
+	got, err := tr.RoundTrip(context.Background(), []byte("hello"))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if string(got) != "REPLY:hello" {
+		t.Errorf("RoundTrip response = %q, want %q", string(got), "REPLY:hello")
+	}
+}
+
+// TestNATSTransport_EmptyReplyIsError asserts the contract that an
+// empty reply body (the hub's HandleSync failure signal) surfaces as
+// an error rather than being silently treated as a valid no-op.
+func TestNATSTransport_EmptyReplyIsError(t *testing.T) {
+	h := newTestHub(t)
+
+	nc, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	const subject = "fossil.test.empty"
+	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+		_ = msg.Respond([]byte{})
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+	if err := nc.FlushTimeout(time.Second); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	tr := newNATSTransport(nc, subject, 2*time.Second)
+	if _, err := tr.RoundTrip(context.Background(), []byte("ping")); err == nil {
+		t.Fatal("RoundTrip on empty reply: expected error, got nil")
+	}
+}
+
+// TestNATSTransport_TimeoutHonored asserts that a non-responsive subject
+// causes RoundTrip to error within the transport's configured timeout
+// rather than blocking indefinitely.
+func TestNATSTransport_TimeoutHonored(t *testing.T) {
+	h := newTestHub(t)
+
+	nc, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	defer nc.Close()
+
+	tr := newNATSTransport(nc, "fossil.test.silent", 200*time.Millisecond)
+	start := time.Now()
+	_, err = tr.RoundTrip(context.Background(), []byte("ping"))
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("RoundTrip against silent subject: expected error, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("RoundTrip took %v with 200ms timeout — timeout not honored", elapsed)
+	}
+}

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -24,6 +24,16 @@ type Repo struct {
 	handle  *libfossil.Repo
 	closeMu sync.Mutex
 	closed  bool
+
+	// publish, when non-nil, is invoked after a successful Commit with the
+	// new commit's rid and uuid. NewHub wires this to a NATS publisher on
+	// "<prefix>.<project-code>.commit" so peer hubs can pull the new
+	// commit. Standalone OpenRepo callers leave it nil (no publish).
+	//
+	// Implementations MUST be non-blocking — Commit calls publish on the
+	// foreground path and a slow publisher would back-pressure writers.
+	// Best-effort by contract: publish failures must not fail the commit.
+	publish func(rid int64, uuid string)
 }
 
 // OpenRepo opens an existing hub repo at path. Returns an error if the
@@ -141,7 +151,7 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 			tags[i] = libfossil.TagSpec{Name: t.Name, Value: t.Value}
 		}
 	}
-	_, uuid, err := r.handle.Commit(libfossil.CommitOpts{
+	rid, uuid, err := r.handle.Commit(libfossil.CommitOpts{
 		Files:   files,
 		Comment: opts.Message,
 		User:    opts.Author,
@@ -150,6 +160,9 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	})
 	if err != nil {
 		return "", fmt.Errorf("hub: commit: %w", err)
+	}
+	if r.publish != nil {
+		r.publish(rid, uuid)
 	}
 	return RevID(uuid), nil
 }


### PR DESCRIPTION
## Summary

- Closes the cross-process Fossil propagation gap documented in #156.
- New `Config.ProjectCode` (consumes libfossil v0.6.1's `CreateOpts.ProjectCode`) + `Config.SeedFromUpstream` lets multiple hubs share a project-code so their NATS sync subjects align.
- Auto-publish on commit: `Repo.Commit` fires a `{rid, uuid}` notification on `<prefix>.<project-code>.commit`; subscribers pull on the sibling `.sync` subject.

Design and rationale are filed at `docs/superpowers/specs/2026-05-12-cross-leaf-fossil-sync-design.md`; the protocol doc has a new "NATS-Wrapped Sync" section in `docs/architecture/sync-protocol.md`.

## What changes

- `hub/nats_transport.go` — `libfossil.Transport` over `nc.Request`. New file.
- `hub/clone.go` — `SeedFromUpstream` HTTP clone helper. NATS-native clone is deferred until libfossil's `HandleSync` supports the clone protocol upstream.
- `hub/repo.go` — `Repo.publish` hook, fired after a successful libfossil commit. `OpenRepo` leaves it nil (no-op).
- `hub/hub.go` — `Config.ProjectCode` / `Config.SeedFromUpstream` fields, `openOrCreateRepo` plumbing with mismatch validation, `startCommitSubscriber` wiring, `nats.NoEcho()` on the local client to avoid self-pull.
- `hub/cross_leaf_test.go` — three new tests: gold-path propagation, subject alignment, drift guard on reopening a repo with a different code.
- `go.mod` — libfossil pin `v0.6.0` → `v0.6.1`.

## Known limitations (filed as follow-ups in the design doc)

- Multi-responder race on `.sync` for 3+ hub topologies. Acceptable for sesh's 2-node gold path; will fix with queue-group routing.
- HTTP-only `SeedFromUpstream`. NATS-native clone blocked on upstream libfossil `HandleSync` clone support.

## Test plan

- [x] `go test ./hub/ -count=1` — 35 passed (32 existing + 3 new).
- [x] Local CI replication: `go vet ./...` (3 modules clean), leaf tests (149 passed `-short`), bridge tests (14 passed), CLI build + tests (4 passed).
- [x] Two new `iroh-sidecar`-dependent failures observed in the broader sim suite, unrelated to this PR (env, missing sidecar binary).
- [ ] Reviewer cross-checks the propagation against the sesh integration tests in `danmestas/sesh#11` — they currently assert *no* propagation and should be flippable on top of this PR.