### PR TITLE
feat(cli): expose hub --project-code and --seed-from-upstream

### DIFF
--- a/cli/hub_serve.go
+++ b/cli/hub_serve.go
@@ -19,16 +19,22 @@ type HubCmd struct {
 }
 
 type HubServeCmd struct {
-	Name           string `help:"NATS server name (defaults to <hostname>-hub)"`
-	StoreDir       string `help:"JetStream store dir (default sibling of repo)"`
-	HTTPPort       int    `help:"Fossil HTTP port (0 = auto)" default:"0"`
-	NATSClientPort int    `help:"NATS client port (0 = auto)" default:"0"`
-	NATSLeafPort   int    `help:"NATS leafnode port (0 = auto)" default:"0"`
-	LeafUpstream   string `help:"Solicit leafnode connection to this URL (e.g. nats-leaf://host:port)"`
-	NobodyCaps     string `help:"Caps for unauthenticated 'nobody' user (e.g. 'gio' for clone access)" default:"gio"`
+	Name             string `help:"NATS server name (defaults to <hostname>-hub)"`
+	StoreDir         string `help:"JetStream store dir (default sibling of repo)"`
+	HTTPPort         int    `help:"Fossil HTTP port (0 = auto)" default:"0"`
+	NATSClientPort   int    `help:"NATS client port (0 = auto)" default:"0"`
+	NATSLeafPort     int    `help:"NATS leafnode port (0 = auto)" default:"0"`
+	LeafUpstream     string `help:"Solicit leafnode connection to this URL (e.g. nats-leaf://host:port)"`
+	NobodyCaps       string `help:"Caps for unauthenticated 'nobody' user (e.g. 'gio' for clone access)" default:"gio"`
+	ProjectCode      string `help:"Pin the Fossil project-code (40-char lowercase hex). Share across hubs so they sync over the same NATS subject. Must match the on-disk project-code if the repo already exists."`
+	SeedFromUpstream string `help:"Clone from an upstream EdgeSync hub HTTP xfer endpoint (e.g. http://hub.local:8080/) before opening. No-op if the repo already exists at the target path."`
 }
 
 func (c *HubServeCmd) Run(g *libfossilcli.Globals) error {
+	if c.ProjectCode != "" && !validProjectCode(c.ProjectCode) {
+		return fmt.Errorf("--project-code must be 40-char lowercase hex, got %q", c.ProjectCode)
+	}
+
 	name := c.Name
 	if name == "" {
 		host, err := os.Hostname()
@@ -54,14 +60,16 @@ func (c *HubServeCmd) Run(g *libfossilcli.Globals) error {
 	defer cancel()
 
 	h, err := hub.NewHub(ctx, hub.Config{
-		RepoPath:       repoPath,
-		ServerName:     name,
-		NATSStoreDir:   c.StoreDir,
-		FossilHTTPPort: c.HTTPPort,
-		NATSClientPort: c.NATSClientPort,
-		NATSLeafPort:   c.NATSLeafPort,
-		LeafUpstream:   c.LeafUpstream,
-		NobodyCaps:     c.NobodyCaps,
+		RepoPath:         repoPath,
+		ServerName:       name,
+		NATSStoreDir:     c.StoreDir,
+		FossilHTTPPort:   c.HTTPPort,
+		NATSClientPort:   c.NATSClientPort,
+		NATSLeafPort:     c.NATSLeafPort,
+		LeafUpstream:     c.LeafUpstream,
+		NobodyCaps:       c.NobodyCaps,
+		ProjectCode:      c.ProjectCode,
+		SeedFromUpstream: c.SeedFromUpstream,
 	})
 	if err != nil {
 		return fmt.Errorf("hub: %w", err)
@@ -99,4 +107,22 @@ func shortHost(h string) string {
 		}
 	}
 	return h
+}
+
+// validProjectCode reports whether s matches libfossil's project-code
+// format: 40 lowercase hex characters. Matches `^[0-9a-f]{40}$`. Kept
+// inline rather than importing regexp for a one-off cheap check.
+func validProjectCode(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/hub/clone.go
+++ b/hub/clone.go
@@ -20,7 +20,13 @@ import (
 // If expectedProjectCode is non-empty, asserts the cloned repo's
 // project-code matches it. The cloned repo is removed before returning
 // the mismatch error so the caller can retry or give up cleanly.
-func seedFromUpstream(ctx context.Context, path, upstreamURL, bootstrapUser, expectedProjectCode string) error {
+//
+// Authentication: clones anonymously (no login card sent). The upstream
+// hub must grant clone caps to its "nobody" user — i.e. NobodyCaps must
+// include "g" (the standard NobodyCaps:"gio"). The local bootstrapUser
+// is a Create-time concept for the local repo, not an upstream-auth
+// identity, so it's intentionally not threaded through here.
+func seedFromUpstream(ctx context.Context, path, upstreamURL, expectedProjectCode string) error {
 	u, err := url.Parse(upstreamURL)
 	if err != nil {
 		return fmt.Errorf("hub: parse SeedFromUpstream %q: %w", upstreamURL, err)
@@ -31,7 +37,6 @@ func seedFromUpstream(ctx context.Context, path, upstreamURL, bootstrapUser, exp
 
 	transport := libfossil.NewHTTPTransport(upstreamURL)
 	repo, result, err := libfossil.Clone(ctx, path, transport, libfossil.CloneOpts{
-		User:        bootstrapUser,
 		ProjectCode: expectedProjectCode,
 	})
 	if err != nil {

--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -87,6 +87,72 @@ func TestCrossLeaf_SharedProjectCode_PropagatesCommit(t *testing.T) {
 	})
 }
 
+// TestCrossLeaf_SeedFromUpstream_PropagatesCommit covers the other half
+// of the issue #156 fix: hub B bootstraps via SeedFromUpstream pointing at
+// hub A's HTTP xfer endpoint, inheriting A's project-code through the
+// clone. Once leaf-linked, A's commits should propagate to B over NATS
+// sync, same as the shared-ProjectCode path.
+func TestCrossLeaf_SeedFromUpstream_PropagatesCommit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dirA := t.TempDir()
+	hubA, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirA, "hubA.fossil"),
+		ProjectCode: sharedProjectCode,
+		NobodyCaps:  "gio", // allow unauthenticated clone
+	})
+	if err != nil {
+		t.Fatalf("NewHub A: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA.Stop() })
+
+	httpCtxA, httpCancelA := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelA)
+	go func() { _ = hubA.ServeHTTP(httpCtxA) }()
+
+	// Bootstrap B by cloning from A's HTTP xfer endpoint. Deliberately
+	// omit ProjectCode on B — the whole point of SeedFromUpstream is that
+	// the project-code rides in via the clone.
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:         filepath.Join(dirB, "hubB.fossil"),
+		SeedFromUpstream: "http://" + hubA.HTTPAddr() + "/",
+		LeafUpstream:     hubA.LeafURL(),
+		NobodyCaps:       "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	if hubB.FossilSyncSubject() != hubA.FossilSyncSubject() {
+		t.Fatalf("after seed, sync subjects diverge: A=%q B=%q",
+			hubA.FossilSyncSubject(), hubB.FossilSyncSubject())
+	}
+
+	httpCtxB, httpCancelB := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelB)
+	go func() { _ = hubB.ServeHTTP(httpCtxB) }()
+
+	waitFor(t, 5*time.Second, "leaf link A↔B after seed", func() bool {
+		return hubA.NumLeafs() >= 1
+	})
+
+	if _, err := hubA.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "seeded.txt", Content: []byte("seeded-then-synced")}},
+		Message: "commit on A after seed",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("hubA.Commit: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "B sees seeded.txt at trunk", func() bool {
+		got, readErr := hubB.Read(ctx, "seeded.txt")
+		return readErr == nil && bytes.Equal(got, []byte("seeded-then-synced"))
+	})
+}
+
 // TestCrossLeaf_SubjectsAlign asserts that two hubs declaring the same
 // ProjectCode end up subscribed to the same .sync and .commit subjects.
 // Cheap structural check separate from the propagation gold-path.

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -179,7 +179,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 
 	if cfg.SeedFromUpstream != "" {
 		if _, statErr := os.Stat(cfg.RepoPath); errors.Is(statErr, os.ErrNotExist) {
-			if err := seedFromUpstream(ctx, cfg.RepoPath, cfg.SeedFromUpstream, cfg.BootstrapUser, cfg.ProjectCode); err != nil {
+			if err := seedFromUpstream(ctx, cfg.RepoPath, cfg.SeedFromUpstream, cfg.ProjectCode); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## Summary

- Wires `hub.Config.ProjectCode` and `hub.Config.SeedFromUpstream` (landed in #157) through to the `edgesync hub serve` CLI as `--project-code` and `--seed-from-upstream`.
- Fixes a latent auth bug in `seedFromUpstream`: it was passing the local `bootstrapUser` as `CloneOpts.User`, causing libfossil to send a login card for a user the upstream had never heard of. Drops the field so clones run anonymously, matching the typical `NobodyCaps:"gio"` deployment.
- Adds `TestCrossLeaf_SeedFromUpstream_PropagatesCommit` — bootstraps hub B by cloning hub A's HTTP xfer endpoint, leaf-links them, and verifies a commit on A surfaces at B via NATS sync.

## Why

Downstream (`sesh` PR #11) verifies cross-leaf sync over the deterministic project-code path against `hub.NewHub` directly. Sub-leaves spawned via `edgesync hub serve --leaf-upstream=...` still couldn't share a project-code because the CLI didn't accept one — every sub-leaf got a fresh random project-code at create time, so its NATS sync subject didn't align with the upstream's. Once this merges, `TestSubLeaf_DoesNotSyncToday` in `sesh` flips to a positive assertion.

## Decisions

- **Format pre-validation for `--project-code`**: 40-char lowercase hex, inline check (no `regexp` import). Friendlier than libfossil's downstream error and fails before NATS/listener boot.
- **No CLI-side validation for `--seed-from-upstream`**: `hub.NewHub` → `seedFromUpstream` already parses + scheme-checks the URL. Keeping the CLI thin.
- **Fixing `seedFromUpstream` in this PR rather than separately**: it's the same repo; the fix is one line + a doc comment; the new integration test would have failed without it.

## Test plan

- [x] `go vet ./...` clean across root, leaf, bridge.
- [x] `go test ./hub/ -run TestCrossLeaf -count=1` — 3/3 pass (the existing two + the new SeedFromUpstream test).
- [x] `go test ./hub/ ./cli/... ./cmd/...` — 42/42 pass.
- [x] `cd leaf && go test ./... -short -count=1` — 149 pass (CI parity).
- [x] `cd bridge && go test ./... -short -count=1` — 14 pass (CI parity).
- [x] `go build ./...` clean.
- [x] Pre-existing iroh-sidecar failures in `./sim/` are environmental (binary not built locally), unchanged by this PR.

Closes the CLI gap from #157; unblocks `sesh` PR #11's sub-leaf assertion flip.