### PR TITLE
feat(hub): auto-publish on HTTP xfer push (#160)

### DIFF
--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	libfossil "github.com/danmestas/libfossil"
 	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
@@ -150,6 +151,102 @@ func TestCrossLeaf_SeedFromUpstream_PropagatesCommit(t *testing.T) {
 	waitFor(t, 10*time.Second, "B sees seeded.txt at trunk", func() bool {
 		got, readErr := hubB.Read(ctx, "seeded.txt")
 		return readErr == nil && bytes.Equal(got, []byte("seeded-then-synced"))
+	})
+}
+
+// TestCrossLeaf_HTTPPush_PropagatesCommit covers issue #160: commits that
+// arrive at a hub via the HTTP xfer push endpoint (an external `fossil
+// push <hub-http>` from a CLI agent) write artifacts straight into the
+// SQLite repo, bypassing Repo.Commit and therefore the .commit
+// auto-publish hook. The wrapper installed by Hub.ServeHTTP must close
+// that gap so peers still see the commit.
+//
+// Topology: two hubs A and B share a project-code and are leaf-linked, so
+// .commit notifications on A's NATS subject reach B and trigger a pull.
+// A third standalone libfossil.Repo plays the external CLI agent — it
+// clones from A's HTTP endpoint, commits locally, then pushes back to A
+// via the same HTTP endpoint. The push lands through A's XferHandler.
+// Before the fix, the test would time out waiting for B to see the file.
+func TestCrossLeaf_HTTPPush_PropagatesCommit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dirA := t.TempDir()
+	hubA, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirA, "hubA.fossil"),
+		ProjectCode: sharedProjectCode,
+		NobodyCaps:  "gio", // allow unauthenticated clone + push from the agent
+	})
+	if err != nil {
+		t.Fatalf("NewHub A: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA.Stop() })
+
+	httpCtxA, httpCancelA := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelA)
+	go func() { _ = hubA.ServeHTTP(httpCtxA) }()
+
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:     filepath.Join(dirB, "hubB.fossil"),
+		ProjectCode:  sharedProjectCode,
+		LeafUpstream: hubA.LeafURL(),
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	httpCtxB, httpCancelB := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelB)
+	go func() { _ = hubB.ServeHTTP(httpCtxB) }()
+
+	waitFor(t, 5*time.Second, "leaf link A↔B", func() bool {
+		return hubA.NumLeafs() >= 1
+	})
+
+	// External CLI-agent equivalent: a libfossil.Repo with no hub, no
+	// NATS connection. Clones from A via HTTP, commits a file, pushes the
+	// commit back to A via HTTP. Mirrors the `fossil clone $HTTP && fossil
+	// commit && fossil push $HTTP` flow from the issue's reproduction.
+	agentPath := filepath.Join(t.TempDir(), "agent.fossil")
+	httpURL := "http://" + hubA.HTTPAddr() + "/"
+	agentRepo, _, err := libfossil.Clone(ctx, agentPath,
+		libfossil.NewHTTPTransport(httpURL),
+		libfossil.CloneOpts{ProjectCode: sharedProjectCode},
+	)
+	if err != nil {
+		t.Fatalf("agent clone from %s: %v", httpURL, err)
+	}
+	t.Cleanup(func() { _ = agentRepo.Close() })
+
+	if _, _, err := agentRepo.Commit(libfossil.CommitOpts{
+		Files: []libfossil.FileToCommit{
+			{Name: "from-agent.txt", Content: []byte("hello-from-agent")},
+		},
+		Comment: "external agent commit",
+		User:    "agent",
+	}); err != nil {
+		t.Fatalf("agent Commit: %v", err)
+	}
+
+	if _, err := agentRepo.Sync(ctx,
+		libfossil.NewHTTPTransport(httpURL),
+		libfossil.SyncOpts{
+			Push:        true,
+			ProjectCode: sharedProjectCode,
+			PeerID:      "agent",
+		},
+	); err != nil {
+		t.Fatalf("agent push to %s: %v", httpURL, err)
+	}
+
+	// Without the fix, B never sees the file — the HTTP push lands in A's
+	// repo but A doesn't publish on .commit, so B has no trigger to pull.
+	waitFor(t, 10*time.Second, "B sees from-agent.txt at trunk", func() bool {
+		got, readErr := hubB.Read(ctx, "from-agent.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-agent"))
 	})
 }
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -411,6 +411,10 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 			log.Printf("hub commit publish: publish to %s rid=%d uuid=%s: %v", commitSubject, rid, uuid, pubErr)
 		}
 	}
+	// Snapshot the current max ci rid so any commits already in the repo
+	// (notably anything pulled in by SeedFromUpstream) are not republished
+	// by the first call to publishNewCommits.
+	h.repo.initPublishWatermark()
 
 	h.natsCommitSub = sub
 	h.commitSubject = commitSubject
@@ -422,7 +426,18 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 // Stop is called.
 func (h *Hub) ServeHTTP(ctx context.Context) error {
 	mux := http.NewServeMux()
-	mux.Handle("/", h.repo.handle.XferHandler())
+	xfer := h.repo.handle.XferHandler()
+	// Wrap XferHandler so commits arriving via an external `fossil push
+	// <hub-http>` (which writes artifacts straight into the SQLite repo
+	// via libfossil's xfer protocol, bypassing Repo.Commit) still trigger
+	// the .commit auto-publish that Repo.Commit installs. publishNewCommits
+	// is a no-op when nothing new landed (typical for pull/clone) or when
+	// the publish hook isn't wired (DisableFossilSyncOverNATS), so it's
+	// safe to fire on every request. Issue #160.
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		xfer.ServeHTTP(w, r)
+		h.repo.publishNewCommits()
+	}))
 
 	srv := &http.Server{Handler: mux}
 	h.httpServer = srv

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 
 	libfossil "github.com/danmestas/libfossil"
@@ -34,6 +35,18 @@ type Repo struct {
 	// foreground path and a slow publisher would back-pressure writers.
 	// Best-effort by contract: publish failures must not fail the commit.
 	publish func(rid int64, uuid string)
+
+	// publishMu serializes publishNewCommits so concurrent callers (the
+	// local Commit path and the HTTP xfer-push wrapper) cannot interleave
+	// scans of the event table and race the publishedRID watermark.
+	publishMu sync.Mutex
+
+	// publishedRID is the highest 'ci' event rid that has been emitted on
+	// the .commit subject. publishNewCommits only emits for rids strictly
+	// greater than this, then advances it. Initialised at hub startup
+	// (in startCommitSubscriber) to the current max ci rid so any commits
+	// that landed via SeedFromUpstream are not republished.
+	publishedRID int64
 }
 
 // OpenRepo opens an existing hub repo at path. Returns an error if the
@@ -151,7 +164,7 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 			tags[i] = libfossil.TagSpec{Name: t.Name, Value: t.Value}
 		}
 	}
-	rid, uuid, err := r.handle.Commit(libfossil.CommitOpts{
+	_, uuid, err := r.handle.Commit(libfossil.CommitOpts{
 		Files:   files,
 		Comment: opts.Message,
 		User:    opts.Author,
@@ -161,10 +174,94 @@ func (r *Repo) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	if err != nil {
 		return "", fmt.Errorf("hub: commit: %w", err)
 	}
-	if r.publish != nil {
-		r.publish(rid, uuid)
-	}
+	r.publishNewCommits()
 	return RevID(uuid), nil
+}
+
+// publishNewCommits invokes r.publish for every 'ci' event whose rid is
+// strictly greater than r.publishedRID, in rid order, then advances the
+// watermark. No-op when r.publish is nil (standalone OpenRepo, or hub
+// constructed with Config.DisableFossilSyncOverNATS=true).
+//
+// Both code paths that can land a new commit funnel through here:
+//
+//   - Repo.Commit (local, in-process commits): calls this after libfossil
+//     has written the new event; the watermark scan picks up exactly the
+//     one rid that just landed.
+//   - The HTTP xfer-push wrapper installed by Hub.ServeHTTP: calls this
+//     after every xfer request so commits arriving via `fossil push
+//     <hub-http>` from an external CLI agent emit the same .commit
+//     notification a Repo.Commit caller would have. Without that wrapper,
+//     HTTP-pushed commits land in the repo but peers never get notified
+//     (issue #160). A single multi-commit push emits one notification per
+//     new ci event so each lands on the subject in rid order.
+//
+// publishMu serialises the scan/publish/advance triple so concurrent
+// callers cannot republish the same rid. Publish errors are logged inside
+// the publish hook (see startCommitSubscriber) and never bubble up — both
+// call sites treat publish as best-effort.
+func (r *Repo) publishNewCommits() {
+	r.publishMu.Lock()
+	defer r.publishMu.Unlock()
+	if r.publish == nil {
+		return
+	}
+	rows, err := r.handle.DB().Query(
+		"SELECT objid FROM event WHERE type='ci' AND objid > ? ORDER BY objid",
+		r.publishedRID,
+	)
+	if err != nil {
+		log.Printf("hub publish: enumerate new commits since rid=%d: %v", r.publishedRID, err)
+		return
+	}
+	var newRIDs []int64
+	for rows.Next() {
+		var rid int64
+		if scanErr := rows.Scan(&rid); scanErr != nil {
+			_ = rows.Close()
+			log.Printf("hub publish: scan rid: %v", scanErr)
+			return
+		}
+		newRIDs = append(newRIDs, rid)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		log.Printf("hub publish: enumerate new commits since rid=%d: rows error: %v", r.publishedRID, err)
+		return
+	}
+	for _, rid := range newRIDs {
+		uuid, err := r.handle.UUIDFromRID(rid)
+		if err != nil {
+			log.Printf("hub publish: uuid for rid=%d: %v", rid, err)
+			continue
+		}
+		r.publish(rid, uuid)
+		r.publishedRID = rid
+	}
+}
+
+// initPublishWatermark snapshots the current max 'ci' event rid into
+// publishedRID. NewHub calls this in startCommitSubscriber immediately
+// after wiring r.publish — that's the boundary at which any commits
+// already in the repo (e.g. from SeedFromUpstream's clone) are considered
+// "already known to peers" by definition, and future publishNewCommits
+// scans must not re-emit them.
+//
+// Best-effort: a query error leaves publishedRID at 0, which would cause
+// the first publishNewCommits call to (harmlessly) emit notifications for
+// every commit in the repo. Logged so the divergence is visible.
+func (r *Repo) initPublishWatermark() {
+	r.publishMu.Lock()
+	defer r.publishMu.Unlock()
+	var maxRID int64
+	err := r.handle.DB().QueryRow(
+		"SELECT COALESCE(MAX(objid), 0) FROM event WHERE type='ci'",
+	).Scan(&maxRID)
+	if err != nil {
+		log.Printf("hub publish: init watermark: %v", err)
+		return
+	}
+	r.publishedRID = maxRID
 }
 
 // Read returns the contents of path at the current trunk tip.


### PR DESCRIPTION
## Summary
- HTTP `fossil push <hub-http>` arrived through `XferHandler` and wrote artifacts straight into the repo, so the `.commit` auto-publish hook (attached to `Repo.Commit`) never fired and peers stayed at the prior commit count.
- Funnel both code paths through a new `Repo.publishNewCommits` helper: enumerates `event` rows with `type='ci'` and `objid > publishedRID`, emits one notification per rid in order, advances the watermark under `publishMu`.
- `Hub.ServeHTTP` wraps `XferHandler` to call the helper after every request. `Hub.startCommitSubscriber` snapshots the current max ci rid right after wiring the publish hook so `SeedFromUpstream` history is not republished.
- One multi-commit push emits one notification per new ci event in rid order.

## Test plan
- [x] `go vet ./...` (root + leaf + bridge) — clean
- [x] `go test ./hub/... -count=1` — 37 passed, including new `TestCrossLeaf_HTTPPush_PropagatesCommit`
- [x] `go test ./cli/... -count=1` — passed
- [x] `cd leaf && go test ./... -short -count=1` — passed
- [x] `cd bridge && go test ./... -short -count=1` — passed
- [x] `go build -buildvcs=false ./cmd/edgesync/` + `go test -buildvcs=false ./cmd/edgesync/ -count=1` — passed
- [x] Sanity: temporarily reverted the wrapper, ran new test → timed out waiting for B to see the file (confirms the test catches the bug, not just the happy path)

Closes #160