### PR TITLE
fix(agent): preserve parent's tracked files in agent.Commit (#152)

### DIFF
--- a/leaf/agent/code_artifact.go
+++ b/leaf/agent/code_artifact.go
@@ -80,10 +80,19 @@ type SyncResult struct {
 // Commit commits a set of files to the agent's repo with the given message
 // and author. Returns the new manifest UUID as an opaque RevID.
 //
+// opts.Files is interpreted with `fossil ci` semantics — "files this
+// commit changes" — and is merged on top of the parent commit's tracked
+// files (supplied wins by name). Files at the parent that are not in
+// opts.Files are carried forward unchanged. Without that merge,
+// libfossil.Commit would emit a partial manifest containing only the
+// supplied subset, silently dropping every other file the parent tracked
+// (#152, chains to libfossil#30). There is no delete-file API today;
+// once libfossil grows one, plumb it through CommitOpts.
+//
 // When opts.ParentID is 0, the current trunk tip is resolved and used as
 // the parent — matching `fossil ci`'s default chain-onto-tip behavior. On
 // an empty repo (no trunk tip yet), the resolution returns 0 and the
-// commit is a legitimate orphan root.
+// commit is a legitimate orphan root with no parent files to inherit.
 func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	if opts.Author == "" {
 		return "", errors.New("agent: Commit: Author is required")
@@ -92,9 +101,9 @@ func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	if err != nil {
 		return "", err
 	}
-	files := make([]libfossil.FileToCommit, len(opts.Files))
-	for i, f := range opts.Files {
-		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
+	files, err := a.mergeWithParent(parentID, opts.Files)
+	if err != nil {
+		return "", err
 	}
 	var tags []libfossil.TagSpec
 	if len(opts.Tags) > 0 {
@@ -115,6 +124,65 @@ func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 		return "", fmt.Errorf("agent: commit: %w", err)
 	}
 	return RevID(uuid), nil
+}
+
+// mergeWithParent computes the full F-card set for a new commit. Starts
+// from the parent commit's tracked files (preserving each file's Perm),
+// then overlays the supplied opts.Files — supplied wins by name. Parent
+// files not overridden are carried forward by reading their content out
+// of the parent checkin.
+//
+// parentID == 0 is the orphan-root case (first commit in a fresh repo);
+// nothing to inherit, so the result is just opts.Files in the libfossil
+// shape.
+//
+// Reading each preserved file out of the parent is O(parent file count)
+// per commit. Acceptable for the workloads agent.Commit targets; if
+// large-tree repos surface as a hotspot, a future libfossil API that
+// emits a manifest by referencing parent F-card UUIDs without rehydrating
+// the content would be the right place to optimise — agent.Commit can
+// stay shaped the way it is.
+func (a *Agent) mergeWithParent(parentID int64, supplied []FileToCommit) ([]libfossil.FileToCommit, error) {
+	suppliedByName := make(map[string]struct{}, len(supplied))
+	for _, f := range supplied {
+		suppliedByName[f.Name] = struct{}{}
+	}
+
+	var merged []libfossil.FileToCommit
+	if parentID != 0 {
+		parentFiles, err := a.repo.ListFiles(parentID)
+		if err != nil {
+			return nil, fmt.Errorf("agent: commit: list parent rid=%d files: %w", parentID, err)
+		}
+		merged = make([]libfossil.FileToCommit, 0, len(parentFiles)+len(supplied))
+		for _, pf := range parentFiles {
+			if _, overridden := suppliedByName[pf.Name]; overridden {
+				continue
+			}
+			content, err := a.repo.ReadFile(parentID, pf.Name)
+			if err != nil {
+				return nil, fmt.Errorf("agent: commit: read parent file %q at rid=%d: %w", pf.Name, parentID, err)
+			}
+			merged = append(merged, libfossil.FileToCommit{
+				Name:    pf.Name,
+				Content: content,
+				Perm:    pf.Perm,
+			})
+		}
+	} else {
+		merged = make([]libfossil.FileToCommit, 0, len(supplied))
+	}
+	for _, sf := range supplied {
+		// agent.FileToCommit doesn't carry Perm — supplied files get
+		// libfossil's default. Parent-inherited entries above preserve
+		// the parent's Perm explicitly so file modes don't silently
+		// regress across a commit that didn't touch them.
+		merged = append(merged, libfossil.FileToCommit{
+			Name:    sf.Name,
+			Content: sf.Content,
+		})
+	}
+	return merged, nil
 }
 
 // resolveCommitParent maps the caller-supplied ParentID to the rid the

--- a/leaf/agent/code_artifact_test.go
+++ b/leaf/agent/code_artifact_test.go
@@ -344,6 +344,118 @@ func TestAgent_Commit_ChainsOntoTrunkTipByDefault(t *testing.T) {
 	}
 }
 
+// TestAgent_Commit_PreservesParentFiles asserts the #152 fix: when a
+// caller supplies only the files this commit changes (matching `fossil
+// ci` semantics), the resulting manifest must still carry every file
+// the parent commit tracked, not just the supplied subset.
+//
+// Before the fix, agent.Commit passed opts.Files straight through to
+// libfossil.Commit, which wrote a partial manifest. A linear chain of
+// commits on disjoint paths silently lost every prior commit's files at
+// the next commit — bones' multi-slot workflow surfaced the bug
+// (bones#366 → EdgeSync#152 → libfossil#30).
+func TestAgent_Commit_PreservesParentFiles(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	// Slot alpha commits its own file.
+	if _, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "alpha/n.md", Content: []byte("alpha-work")}},
+		Message: "alpha work",
+		Author:  "slot-alpha",
+	}); err != nil {
+		t.Fatalf("Commit alpha: %v", err)
+	}
+
+	// Slot bravo commits a disjoint file. Auto-resolves parent to alpha's
+	// tip — agent.Commit must merge bravo's file with alpha's existing
+	// tracked files, not replace them.
+	if _, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "bravo/n.md", Content: []byte("bravo-work")}},
+		Message: "bravo work",
+		Author:  "slot-bravo",
+	}); err != nil {
+		t.Fatalf("Commit bravo: %v", err)
+	}
+
+	// Both files must be visible at trunk's tip.
+	files, err := a.Files(ctx)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if !slices.Contains(files, "alpha/n.md") {
+		t.Errorf("Files = %v, want to contain alpha/n.md (parent file dropped — #152)", files)
+	}
+	if !slices.Contains(files, "bravo/n.md") {
+		t.Errorf("Files = %v, want to contain bravo/n.md", files)
+	}
+
+	// Read content directly against the trunk tip rid. a.Read goes
+	// through libfossil's ResolveVersion("trunk"), which resolves via the
+	// sym-trunk singleton tag — that tag isn't propagated by
+	// libfossil.Commit so it stays pinned to the first commit. Files() is
+	// fine here because it uses BranchTip, which resolves via the
+	// branch=trunk propagating tag.
+	tipRID, err := a.repo.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip trunk: %v", err)
+	}
+	gotAlpha, err := a.repo.ReadFile(tipRID, "alpha/n.md")
+	if err != nil {
+		t.Fatalf("ReadFile alpha/n.md at tip: %v", err)
+	}
+	if !bytes.Equal(gotAlpha, []byte("alpha-work")) {
+		t.Errorf("alpha/n.md content = %q, want %q", gotAlpha, "alpha-work")
+	}
+	gotBravo, err := a.repo.ReadFile(tipRID, "bravo/n.md")
+	if err != nil {
+		t.Fatalf("ReadFile bravo/n.md at tip: %v", err)
+	}
+	if !bytes.Equal(gotBravo, []byte("bravo-work")) {
+		t.Errorf("bravo/n.md content = %q, want %q", gotBravo, "bravo-work")
+	}
+}
+
+// TestAgent_Commit_SuppliedFileOverridesParent asserts the merge rule:
+// when opts.Files contains a name that the parent also tracks, the
+// supplied content wins. Without this, every commit would inherit the
+// parent's content verbatim and updates would no-op.
+func TestAgent_Commit_SuppliedFileOverridesParent(t *testing.T) {
+	a := newAgentForCommitTests(t)
+	ctx := context.Background()
+
+	if _, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "doc.md", Content: []byte("v1")}},
+		Message: "v1",
+		Author:  "testuser",
+	}); err != nil {
+		t.Fatalf("Commit v1: %v", err)
+	}
+
+	if _, err := a.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "doc.md", Content: []byte("v2")}},
+		Message: "v2",
+		Author:  "testuser",
+	}); err != nil {
+		t.Fatalf("Commit v2: %v", err)
+	}
+
+	// Resolve trunk tip directly — a.Read can't be used here because
+	// ResolveVersion("trunk") uses the sym-trunk singleton tag, which
+	// libfossil.Commit doesn't propagate forward.
+	tipRID, err := a.repo.BranchTip("trunk")
+	if err != nil {
+		t.Fatalf("BranchTip trunk: %v", err)
+	}
+	got, err := a.repo.ReadFile(tipRID, "doc.md")
+	if err != nil {
+		t.Fatalf("ReadFile doc.md at tip: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v2")) {
+		t.Errorf("doc.md content = %q, want %q (supplied must win over parent)", got, "v2")
+	}
+}
+
 // TestAgent_Commit_ExplicitParentIDOverride proves that a caller-supplied
 // ParentID is used verbatim — useful for committing onto a non-trunk
 // branch via Agent.Tip(ctx, branchName).


### PR DESCRIPTION
## Summary
- `agent.Commit` was passing `opts.Files` straight through to `libfossil.Commit`, which emits a partial manifest. Files at the parent that weren't in `opts.Files` got silently dropped. bones' multi-slot workflow (disjoint paths, linear chain) lost every prior slot's work — full repro in #152, chains to libfossil#30.
- New `Agent.mergeWithParent` enumerates the parent's F-cards via `libfossil.Repo.ListFiles`, overlays the supplied `opts.Files` (supplied wins by name), reads inherited content via `libfossil.Repo.ReadFile`, and hands the full set to `libfossil.Commit`. Inherited entries preserve the parent's `Perm`; supplied entries take libfossil's default (`agent.FileToCommit` has no `Perm` field today).
- `parentID == 0` stays an orphan-root commit with no parent files to inherit. Reading the parent's content per commit is O(parent file count) — fine for the workloads `agent.Commit` targets; a future libfossil API that references parent F-card UUIDs without rehydrating would be where to optimise.
- Issue scopes this as a consumer-side shield: even if libfossil#30 keeps partial-manifest semantics for backwards compatibility, `agent.Commit`'s doc reads as `fossil ci` semantics and must honor that.

## Test plan
- [x] `TestAgent_Commit_PreservesParentFiles` — disjoint paths (alpha → bravo) on a linear chain, both must surface at trunk tip. Asserts via `BranchTip` + `ListFiles` + `ReadFile`.
- [x] `TestAgent_Commit_SuppliedFileOverridesParent` — same-name supplied content must win over parent.
- [x] Both tests fail without the fix (verified before implementing) and pass after.
- [x] Full `go test ./agent/ -count=1` — 74 passed.
- [x] Full `go test ./... -short` from leaf — 151 passed.
- [x] `go vet ./...` clean across leaf + bridge + root.
- [x] Bridge tests (14), hub tests (37, no regressions), CLI build + tests (4) — all green.

## A note on verification
Tests assert against `BranchTip("trunk")` + direct `ReadFile(rid, name)`. They can't use `a.Read(ctx, name)` because that goes through `libfossil.ResolveVersion("trunk")`, which resolves via the `sym-trunk` singleton tag — `libfossil.Commit` doesn't propagate that forward, so only the first commit on trunk is reachable through it. Orthogonal to #152; surfacing as a separate observation for whoever owns the libfossil resolution path.

Closes #152