### PR TITLE
feat(hub): persist .commit publish watermark across hub restarts

### DIFF
--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"bytes"
 	"context"
+	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -247,6 +248,119 @@ func TestCrossLeaf_HTTPPush_PropagatesCommit(t *testing.T) {
 	waitFor(t, 10*time.Second, "B sees from-agent.txt at trunk", func() bool {
 		got, readErr := hubB.Read(ctx, "from-agent.txt")
 		return readErr == nil && bytes.Equal(got, []byte("hello-from-agent"))
+	})
+}
+
+// TestCrossLeaf_HubRestart_RepublishesUnannouncedCommits covers the
+// crash-safety half of the #161 follow-up: if a commit lands in the hub
+// repo but the .commit notification never goes out (process killed mid-
+// publish, or commit made by an offline tool against the repo while the
+// hub is down), the next hub startup must scan past the persisted
+// watermark and republish the backlog so peers catch up.
+//
+// Topology: hubA leaf-binds on a fixed port so hubB's LeafUpstream URL
+// survives hubA's restart; hubB leaf-links and stays running the whole
+// time. The "unannounced commit" is simulated by opening hubA's repo
+// file directly via libfossil after Stop — no hub plumbing, no publish
+// hook, no NATS — and committing through that handle. Before the
+// watermark-persistence fix, the restart snapshots max-rid into a fresh
+// in-memory watermark and the offline commit is never broadcast; peers
+// stay stale until some future commit triggers a publish, and even then
+// only by the lucky idempotency of pull.
+func TestCrossLeaf_HubRestart_RepublishesUnannouncedCommits(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Reserve a stable leaf port. hubA picks it on first boot and reuses
+	// it on restart so hubB's leafnode reconnect lands on the same URL.
+	leafLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve leaf port: %v", err)
+	}
+	leafPort := leafLn.Addr().(*net.TCPAddr).Port
+	if err := leafLn.Close(); err != nil {
+		t.Fatalf("close reserved leaf listener: %v", err)
+	}
+
+	dirA := t.TempDir()
+	repoPath := filepath.Join(dirA, "hubA.fossil")
+
+	hubA1, err := NewHub(ctx, Config{
+		RepoPath:     repoPath,
+		ProjectCode:  sharedProjectCode,
+		NATSLeafPort: leafPort,
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub A first boot: %v", err)
+	}
+
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:     filepath.Join(dirB, "hubB.fossil"),
+		ProjectCode:  sharedProjectCode,
+		LeafUpstream: hubA1.LeafURL(),
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	waitFor(t, 5*time.Second, "leaf link A1↔B", func() bool {
+		return hubA1.NumLeafs() >= 1
+	})
+
+	// Stop A so we can edit the repo file while NATS is down. This is
+	// the moral equivalent of "A's process was killed after a libfossil
+	// write but before the .commit publish went out" — the difference
+	// is procedurally how the unannounced commit got in, not where the
+	// crash-safety gap lives.
+	if err := hubA1.Stop(); err != nil {
+		t.Fatalf("Stop A first boot: %v", err)
+	}
+
+	offline, err := libfossil.Open(repoPath)
+	if err != nil {
+		t.Fatalf("libfossil.Open offline: %v", err)
+	}
+	if _, _, err := offline.Commit(libfossil.CommitOpts{
+		Files: []libfossil.FileToCommit{
+			{Name: "while-down.txt", Content: []byte("offline-commit")},
+		},
+		Comment: "commit while hub A was down",
+		User:    "ghost",
+	}); err != nil {
+		_ = offline.Close()
+		t.Fatalf("offline Commit: %v", err)
+	}
+	if err := offline.Close(); err != nil {
+		t.Fatalf("offline Close: %v", err)
+	}
+
+	// Restart A with the same RepoPath and the same leaf port. The
+	// startup catchup in startCommitSubscriber must read the persisted
+	// watermark (which is at the pre-offline max), then republish for
+	// every rid past it — picking up the offline commit and pushing it
+	// out on the .commit subject so hubB pulls and converges.
+	hubA2, err := NewHub(ctx, Config{
+		RepoPath:     repoPath,
+		ProjectCode:  sharedProjectCode,
+		NATSLeafPort: leafPort,
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub A restart: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA2.Stop() })
+
+	waitFor(t, 10*time.Second, "leaf link A2↔B after restart", func() bool {
+		return hubA2.NumLeafs() >= 1
+	})
+
+	waitFor(t, 15*time.Second, "B sees while-down.txt via startup catchup", func() bool {
+		got, readErr := hubB.Read(ctx, "while-down.txt")
+		return readErr == nil && bytes.Equal(got, []byte("offline-commit"))
 	})
 }
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -160,8 +160,24 @@ type Hub struct {
 	checkpointStop chan struct{}
 	checkpointDone chan struct{}
 
+	catchupStop chan struct{}
+	catchupDone chan struct{}
+
 	stopOnce sync.Once
 }
+
+// publishCatchupDelay is how long after NewHub returns the hub waits
+// before scanning past the persisted watermark and republishing any
+// commits that landed while the hub was down. The delay gives NATS
+// leaf clients (default ReconnectWait 2s in startFossilSyncSubscriber)
+// time to reconnect after a hub restart on the same leaf port; without
+// it, the catchup publish would land before peers reconnect and the
+// notification would be lost.
+//
+// Bounded by the test window in TestCrossLeaf_HubRestart_RepublishesUnannouncedCommits;
+// production tolerates a slightly longer wait if reconnect backoff is
+// tuned wider.
+const publishCatchupDelay = 3 * time.Second
 
 // NewHub bootstraps the hub repo if absent, applies SQLite tunings, binds
 // the HTTP listener (so HTTPAddr is immediately available), and starts the
@@ -411,14 +427,50 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 			log.Printf("hub commit publish: publish to %s rid=%d uuid=%s: %v", commitSubject, rid, uuid, pubErr)
 		}
 	}
-	// Snapshot the current max ci rid so any commits already in the repo
-	// (notably anything pulled in by SeedFromUpstream) are not republished
-	// by the first call to publishNewCommits.
+	// Restore the watermark from the persisted value if present, else
+	// snapshot the current max ci rid. Schedule a delayed catchup that
+	// republishes any commits past the persisted watermark — handles
+	// the crash-mid-publish case (commit landed via HTTP push, hub
+	// died before the .commit notification went out) and any commit
+	// made by an offline tool against the same repo file while the
+	// hub was down.
+	//
+	// The delay matters: an immediate catchup would fire before NATS
+	// leaf clients reconnect after a hub restart on the same leaf port,
+	// and the notification would land in the void. publishCatchupDelay
+	// gives clients time to reconnect first.
 	h.repo.initPublishWatermark()
+	h.startPublishCatchup()
 
 	h.natsCommitSub = sub
 	h.commitSubject = commitSubject
 	return nil
+}
+
+// startPublishCatchup schedules a one-shot publishNewCommits call after
+// publishCatchupDelay. Caller-cancellable via the catchupStop channel
+// owned by Hub so Stop tears it down cleanly even if it fires before the
+// delay elapses.
+//
+// Best-effort by contract: if no peer reconnects within the delay window
+// the catchup publish is lost (NATS Core is fire-and-forget with no
+// per-subscriber queuing). Next commit through Repo.Commit or the HTTP
+// xfer-push wrapper triggers another scan, so peers eventually catch up
+// on activity; a long quiet period after a crash with no peers connected
+// leaves the backlog hanging. Tracked as a follow-up — JetStream-durable
+// .commit subject would close the gap.
+func (h *Hub) startPublishCatchup() {
+	h.catchupStop = make(chan struct{})
+	h.catchupDone = make(chan struct{})
+	go func() {
+		defer close(h.catchupDone)
+		select {
+		case <-h.catchupStop:
+			return
+		case <-time.After(publishCatchupDelay):
+			h.repo.publishNewCommits()
+		}
+	}()
 }
 
 // ServeHTTP runs the fossil HTTP server (timeline UI + xfer endpoint)
@@ -481,6 +533,10 @@ func (h *Hub) Stop() error {
 		if h.server != nil {
 			h.server.Shutdown()
 			h.server.WaitForShutdown()
+		}
+		if h.catchupStop != nil {
+			close(h.catchupStop)
+			<-h.catchupDone
 		}
 		if h.checkpointStop != nil {
 			close(h.checkpointStop)

--- a/hub/repo.go
+++ b/hub/repo.go
@@ -2,13 +2,22 @@ package hub
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"sync"
 
 	libfossil "github.com/danmestas/libfossil"
 )
+
+// publishedRIDConfigKey is the libfossil-config row that persists the
+// .commit publish watermark across hub restarts. Stored in the repo's
+// own config table (rather than a sidecar file) so the watermark moves
+// with the repo and operators can inspect it via fossil tooling. The
+// "edgesync:" prefix namespaces against fossil's own config keys.
+const publishedRIDConfigKey = "edgesync:hub-published-rid"
 
 // Repo is a hub fossil repo opened for direct operations — user mgmt,
 // commits, reads. No embedded NATS server, no HTTP listener; it's the
@@ -43,9 +52,11 @@ type Repo struct {
 
 	// publishedRID is the highest 'ci' event rid that has been emitted on
 	// the .commit subject. publishNewCommits only emits for rids strictly
-	// greater than this, then advances it. Initialised at hub startup
-	// (in startCommitSubscriber) to the current max ci rid so any commits
-	// that landed via SeedFromUpstream are not republished.
+	// greater than this, then advances it. Persisted to the repo's config
+	// table under publishedRIDConfigKey after each advance and reloaded
+	// by initPublishWatermark on hub startup so commits that landed via
+	// HTTP push but never got their .commit publish out before a crash
+	// can be republished by the startup catchup in startCommitSubscriber.
 	publishedRID int64
 }
 
@@ -237,31 +248,69 @@ func (r *Repo) publishNewCommits() {
 		}
 		r.publish(rid, uuid)
 		r.publishedRID = rid
+		if setErr := r.handle.SetConfig(publishedRIDConfigKey, strconv.FormatInt(rid, 10)); setErr != nil {
+			// Best-effort: a failed persist means a future restart may
+			// republish this rid. Idempotent on the subscriber side
+			// (the .commit subscriber's pull converges to zero blobs
+			// when nothing new), so harmless beyond a little extra
+			// chatter. Log so the drift is visible.
+			log.Printf("hub publish: persist watermark rid=%d: %v", rid, setErr)
+		}
 	}
 }
 
-// initPublishWatermark snapshots the current max 'ci' event rid into
-// publishedRID. NewHub calls this in startCommitSubscriber immediately
-// after wiring r.publish — that's the boundary at which any commits
-// already in the repo (e.g. from SeedFromUpstream's clone) are considered
-// "already known to peers" by definition, and future publishNewCommits
-// scans must not re-emit them.
+// initPublishWatermark restores publishedRID from the previous hub run.
+// NewHub calls this in startCommitSubscriber immediately after wiring
+// r.publish, before the startup catchup. Two paths:
 //
-// Best-effort: a query error leaves publishedRID at 0, which would cause
-// the first publishNewCommits call to (harmlessly) emit notifications for
-// every commit in the repo. Logged so the divergence is visible.
+//   - Warm start: a persisted value exists under publishedRIDConfigKey.
+//     Load it. The startup catchup will then republish any commits that
+//     landed while the hub was down (e.g. an HTTP push that crashed the
+//     hub mid-publish, or commits made by an offline tool against the
+//     same repo file).
+//
+//   - Cold start: no persisted value (first run on this repo, or a v1
+//     upgrade). Snapshot the current max ci rid and persist it. Commits
+//     already in the repo (notably anything pulled in by
+//     SeedFromUpstream) are treated as "already known to peers" — the
+//     same semantic as before persistence was added. Commits made while
+//     a previous v1 hub was alive but un-announced before crash do NOT
+//     get republished on the v1→v2 transition; tracked in the PR as a
+//     known limitation and recoverable by a subsequent commit (whose
+//     publish notification triggers a pull that idempotently catches the
+//     backlog up).
+//
+// Best-effort across the board: failure to read or persist leaves
+// publishedRID at its zero value, which the subsequent publishNewCommits
+// would treat as "republish everything" — harmless because the .commit
+// subscriber's pull is idempotent, but logged so the drift is visible.
 func (r *Repo) initPublishWatermark() {
 	r.publishMu.Lock()
 	defer r.publishMu.Unlock()
+
+	val, err := r.handle.Config(publishedRIDConfigKey)
+	if err == nil {
+		parsed, parseErr := strconv.ParseInt(val, 10, 64)
+		if parseErr == nil {
+			r.publishedRID = parsed
+			return
+		}
+		log.Printf("hub publish: parse persisted watermark %q: %v; falling back to max-rid snapshot", val, parseErr)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("hub publish: read persisted watermark: %v; falling back to max-rid snapshot", err)
+	}
+
 	var maxRID int64
-	err := r.handle.DB().QueryRow(
+	if scanErr := r.handle.DB().QueryRow(
 		"SELECT COALESCE(MAX(objid), 0) FROM event WHERE type='ci'",
-	).Scan(&maxRID)
-	if err != nil {
-		log.Printf("hub publish: init watermark: %v", err)
+	).Scan(&maxRID); scanErr != nil {
+		log.Printf("hub publish: init watermark: %v", scanErr)
 		return
 	}
 	r.publishedRID = maxRID
+	if setErr := r.handle.SetConfig(publishedRIDConfigKey, strconv.FormatInt(maxRID, 10)); setErr != nil {
+		log.Printf("hub publish: persist initial watermark %d: %v", maxRID, setErr)
+	}
 }
 
 // Read returns the contents of path at the current trunk tip.


### PR DESCRIPTION
## Summary
- `publishedRID` was in-memory only — every `initPublishWatermark` call snapshotted the current max ci rid. A crash between a commit landing and its `.commit` notification going out (HTTP push that wrote to SQLite but died before the wrapper called `publishNewCommits`, or any offline tool writing the repo while the hub was down) left the commit silently un-propagated. Peers caught up incidentally on the next commit, or not at all.
- Persist the watermark to the repo's config table under `edgesync:hub-published-rid` after each successful publish. `initPublishWatermark` reads the persisted value first and falls back to the max-rid snapshot only on cold start.
- Schedule a one-shot `publishNewCommits` call `publishCatchupDelay` (3s) after `NewHub` returns. Delay matters: an immediate catchup fires before NATS leaf clients reconnect after a restart on the same leaf port (default `ReconnectWait` is 2s), and the notification lands in the void because nats-core has no per-subscriber queuing.
- `Stop` cancels the pending catchup so the goroutine doesn't outlive the hub.

## Regression test
`TestCrossLeaf_HubRestart_RepublishesUnannouncedCommits`:
1. Two hubs leaf-linked on a stable, pre-reserved leaf port (so reconnect lands on the same URL).
2. Stop A.
3. Open the repo file directly via `libfossil.Open` and commit — no hub plumbing, no NATS, no publish hook. This is morally equivalent to "hub crashed after libfossil's SQLite write but before the wrapper's publish."
4. Restart A.
5. Assert B reads the offline file content via the delayed catchup.

Sanity-checked: without the persist-and-catchup change the same test times out after 15s.

## Test plan
- [x] New test passes; full hub suite 38/38.
- [x] `go vet ./...` clean across root + leaf + bridge.
- [x] Leaf 151 short-tests pass, bridge 14, CLI build + 4 tests.
- [x] No regressions in existing cross-leaf tests (in-process commit, SeedFromUpstream, HTTP push from #161).

## Known limitations (deferred)
- If no peer reconnects within `publishCatchupDelay`, the catchup publish is still lost. **JetStream-durable `.commit` subject** is the right long-term fix; tracked as a follow-up.
- The `.commit` subscriber on the pull side doesn't advance the receiving hub's watermark, so a pulled-in commit gets republished on the receiver's next restart. Idempotent on the far side (the subscriber's pull converges to zero blobs) but wasteful chatter.
- v1→v2 upgrade with un-announced backlog at upgrade time treats those commits as "already known" — same silent-loss behavior as v1; not made worse.

Addresses concern (2) from the #161 review. Concern (1) — info leakage from libfossil schema into hub via raw SQL on `event` table — is blocked on a libfossil API change and will be a separate PR after that ships.