### PR TITLE
refactor(agent): drop mergeWithParent now that libfossil v0.6.2 ships the fix

### DIFF
--- a/bridge/go.mod
+++ b/bridge/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/danmestas/EdgeSync/leaf v0.0.3
-	github.com/danmestas/libfossil v0.5.0
+	github.com/danmestas/libfossil v0.6.2
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/bridge/go.sum
+++ b/bridge/go.sum
@@ -4,8 +4,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.5.0 h1:mnadgfhLSqlql1tA9TIF+wkmwpBy88x4SgfdIev+1bQ=
-github.com/danmestas/libfossil v0.5.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.6.2 h1:ijBfh7d83tHQdzhJVh80/nUZ3Ru1763w/W348nOCUkc=
+github.com/danmestas/libfossil v0.6.2/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/danmestas/EdgeSync/bridge v0.0.3
 	github.com/danmestas/EdgeSync/leaf v0.0.11
-	github.com/danmestas/libfossil v0.6.1
+	github.com/danmestas/libfossil v0.6.2
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.6.1 h1:r/j6Mv5lDD27pWRO43nZR7nND4M9gZ1kY45hNhIxYWw=
-github.com/danmestas/libfossil v0.6.1/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.6.2 h1:ijBfh7d83tHQdzhJVh80/nUZ3Ru1763w/W348nOCUkc=
+github.com/danmestas/libfossil v0.6.2/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=

--- a/leaf/agent/code_artifact.go
+++ b/leaf/agent/code_artifact.go
@@ -80,19 +80,16 @@ type SyncResult struct {
 // Commit commits a set of files to the agent's repo with the given message
 // and author. Returns the new manifest UUID as an opaque RevID.
 //
-// opts.Files is interpreted with `fossil ci` semantics — "files this
-// commit changes" — and is merged on top of the parent commit's tracked
-// files (supplied wins by name). Files at the parent that are not in
-// opts.Files are carried forward unchanged. Without that merge,
-// libfossil.Commit would emit a partial manifest containing only the
-// supplied subset, silently dropping every other file the parent tracked
-// (#152, chains to libfossil#30). There is no delete-file API today;
-// once libfossil grows one, plumb it through CommitOpts.
+// opts.Files reads with `fossil ci` semantics — "files this commit
+// changes." Files at the parent that are not in opts.Files are carried
+// forward unchanged. libfossil.Repo.Commit handles the merge against
+// the parent's F-card set internally as of v0.6.2 (the fix for
+// libfossil#30 / EdgeSync#152); the agent layer is a thin pass-through.
 //
 // When opts.ParentID is 0, the current trunk tip is resolved and used as
 // the parent — matching `fossil ci`'s default chain-onto-tip behavior. On
 // an empty repo (no trunk tip yet), the resolution returns 0 and the
-// commit is a legitimate orphan root with no parent files to inherit.
+// commit is a legitimate orphan root.
 func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	if opts.Author == "" {
 		return "", errors.New("agent: Commit: Author is required")
@@ -101,9 +98,9 @@ func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 	if err != nil {
 		return "", err
 	}
-	files, err := a.mergeWithParent(parentID, opts.Files)
-	if err != nil {
-		return "", err
+	files := make([]libfossil.FileToCommit, len(opts.Files))
+	for i, f := range opts.Files {
+		files[i] = libfossil.FileToCommit{Name: f.Name, Content: f.Content}
 	}
 	var tags []libfossil.TagSpec
 	if len(opts.Tags) > 0 {
@@ -124,65 +121,6 @@ func (a *Agent) Commit(ctx context.Context, opts CommitOpts) (RevID, error) {
 		return "", fmt.Errorf("agent: commit: %w", err)
 	}
 	return RevID(uuid), nil
-}
-
-// mergeWithParent computes the full F-card set for a new commit. Starts
-// from the parent commit's tracked files (preserving each file's Perm),
-// then overlays the supplied opts.Files — supplied wins by name. Parent
-// files not overridden are carried forward by reading their content out
-// of the parent checkin.
-//
-// parentID == 0 is the orphan-root case (first commit in a fresh repo);
-// nothing to inherit, so the result is just opts.Files in the libfossil
-// shape.
-//
-// Reading each preserved file out of the parent is O(parent file count)
-// per commit. Acceptable for the workloads agent.Commit targets; if
-// large-tree repos surface as a hotspot, a future libfossil API that
-// emits a manifest by referencing parent F-card UUIDs without rehydrating
-// the content would be the right place to optimise — agent.Commit can
-// stay shaped the way it is.
-func (a *Agent) mergeWithParent(parentID int64, supplied []FileToCommit) ([]libfossil.FileToCommit, error) {
-	suppliedByName := make(map[string]struct{}, len(supplied))
-	for _, f := range supplied {
-		suppliedByName[f.Name] = struct{}{}
-	}
-
-	var merged []libfossil.FileToCommit
-	if parentID != 0 {
-		parentFiles, err := a.repo.ListFiles(parentID)
-		if err != nil {
-			return nil, fmt.Errorf("agent: commit: list parent rid=%d files: %w", parentID, err)
-		}
-		merged = make([]libfossil.FileToCommit, 0, len(parentFiles)+len(supplied))
-		for _, pf := range parentFiles {
-			if _, overridden := suppliedByName[pf.Name]; overridden {
-				continue
-			}
-			content, err := a.repo.ReadFile(parentID, pf.Name)
-			if err != nil {
-				return nil, fmt.Errorf("agent: commit: read parent file %q at rid=%d: %w", pf.Name, parentID, err)
-			}
-			merged = append(merged, libfossil.FileToCommit{
-				Name:    pf.Name,
-				Content: content,
-				Perm:    pf.Perm,
-			})
-		}
-	} else {
-		merged = make([]libfossil.FileToCommit, 0, len(supplied))
-	}
-	for _, sf := range supplied {
-		// agent.FileToCommit doesn't carry Perm — supplied files get
-		// libfossil's default. Parent-inherited entries above preserve
-		// the parent's Perm explicitly so file modes don't silently
-		// regress across a commit that didn't touch them.
-		merged = append(merged, libfossil.FileToCommit{
-			Name:    sf.Name,
-			Content: sf.Content,
-		})
-	}
-	return merged, nil
 }
 
 // resolveCommitParent maps the caller-supplied ParentID to the rid the

--- a/leaf/go.mod
+++ b/leaf/go.mod
@@ -3,7 +3,7 @@ module github.com/danmestas/EdgeSync/leaf
 go 1.26.0
 
 require (
-	github.com/danmestas/libfossil v0.5.0
+	github.com/danmestas/libfossil v0.6.2
 	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
 	github.com/danmestas/libfossil/db/driver/ncruces v0.1.0
 	github.com/nats-io/nats-server/v2 v2.12.6

--- a/leaf/go.sum
+++ b/leaf/go.sum
@@ -12,8 +12,8 @@ github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipw
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn0Sq3y1b7sk=
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
-github.com/danmestas/libfossil v0.5.0 h1:mnadgfhLSqlql1tA9TIF+wkmwpBy88x4SgfdIev+1bQ=
-github.com/danmestas/libfossil v0.5.0/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
+github.com/danmestas/libfossil v0.6.2 h1:ijBfh7d83tHQdzhJVh80/nUZ3Ru1763w/W348nOCUkc=
+github.com/danmestas/libfossil v0.6.2/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
 github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=


### PR DESCRIPTION
## Summary
- libfossil v0.6.2 (PR #32, commit e6d34fb) ships the upstream fix for #30 / EdgeSync#152: `Repo.Commit` merges parent F-cards with supplied `Files` internally when `ParentID > 0`. Opt-out via `CommitOpts.PartialManifest`.
- Remove `agent.mergeWithParent` — the workaround we shipped in #163 emulated exactly the behavior libfossil now provides. Per the global upstream-fix policy ("when a fix lands in a repo we own, the workaround in the consuming repo should be removed"), defense-in-depth against our own library creates duplicate logic and confused ownership.
- Bump libfossil pins:
  - `go.mod` (root): v0.6.1 → v0.6.2
  - `leaf/go.mod`: v0.5.0 → v0.6.2 (was lagging — `bump-upstream` workflow has been failing per #146/#158)
  - `bridge/go.mod`: v0.5.0 → v0.6.2 (same)

## Why this PR includes the leaf + bridge bumps too
The drop only works if `leaf/agent` is on v0.6.2 (otherwise `libfossil.Commit` is still partial-manifest). `go mod tidy` on leaf and bridge organically pulled them to v0.6.2 since the workflow that normally handles this is broken; folded the bumps in rather than open three coordinated PRs.

## Test plan
- [x] `TestAgent_Commit_PreservesParentFiles` and `TestAgent_Commit_SuppliedFileOverridesParent` pass against libfossil's internal merge — same behavior, no agent-layer logic. Kept as integration coverage so any libfossil regression on full-tree manifest emission surfaces in EdgeSync CI.
- [x] `go vet ./...` clean across root + leaf + bridge.
- [x] Leaf 151 short-tests pass.
- [x] Hub 38 tests pass.
- [x] Bridge 14 tests pass.
- [x] CLI build + 4 tests pass.

## Diff shape
- `leaf/agent/code_artifact.go`: −63 lines (delete `mergeWithParent`, simplify `Commit` to thin pass-through, refresh comment).
- Three `go.mod` + three `go.sum` files: version pin bumps.

No behavior change — the test suite is the proof.