### PR TITLE
refactor(hub): register modernc SQL driver internally

### DIFF
--- a/hub/commit_perm_time_test.go
+++ b/hub/commit_perm_time_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	libfossil "github.com/danmestas/libfossil"
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
 func TestHub_FileToCommit_PermXMarksExecutable(t *testing.T) {

--- a/hub/commit_tags_test.go
+++ b/hub/commit_tags_test.go
@@ -3,8 +3,6 @@ package hub
 import (
 	"context"
 	"testing"
-
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
 // TestCommit_BranchTags_LandsOnNamedBranch verifies that supplying the fossil

--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	libfossil "github.com/danmestas/libfossil"
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 )
 
 // sharedProjectCode is a fixed 40-char lowercase hex string used as the

--- a/hub/driver.go
+++ b/hub/driver.go
@@ -1,0 +1,12 @@
+package hub
+
+// libfossil's db layer requires a SQL driver to be registered before any
+// Repo can be opened. Registering it here means consumers of EdgeSync can
+// `import "github.com/danmestas/EdgeSync/hub"` without also taking a direct
+// dependency on libfossil's internal SQL machinery — the package doc
+// promise that consumers don't need to import libfossil holds end-to-end.
+//
+// modernc is the production default. If a consumer ever needs ncruces
+// (WASM/WASI), expose an escape hatch then — don't preemptively widen
+// the API surface for a hypothetical caller.
+import _ "github.com/danmestas/libfossil/db/driver/modernc"

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 	"github.com/nats-io/nats.go"
 )
 

--- a/hub/nats_transport_test.go
+++ b/hub/nats_transport_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/danmestas/libfossil/db/driver/modernc"
 	"github.com/nats-io/nats.go"
 )
 


### PR DESCRIPTION
## Summary

- `hub` now registers `_ "github.com/danmestas/libfossil/db/driver/modernc"` in its own `init()` (new `hub/driver.go`), so consumers no longer have to know about libfossil's internal SQL machinery to open a hub.
- Drops the now-redundant blank import from the 5 tests in `hub/` that had it.
- No public API change. Behavioral change for consumers: importing `EdgeSync/hub` is now sufficient to open repos; the blank libfossil-driver import is no longer required at the consumer.

## Why

The `hub` package doc already promises: *"consumers can host a hub without importing libfossil or nats-server."* That promise was leaky — downstream consumers (e.g., sesh) still had to:

```go
_ "github.com/danmestas/libfossil/db/driver/modernc"
```

just to satisfy libfossil's db layer driver-registration requirement. That's an architectural leak — the consumer's only intended dependency on libfossil should be transitive, mediated entirely by EdgeSync's hub API.

## Option chosen

Three plausible shapes were considered:

1. **`init()` in hub package** — chosen.
2. Separate sub-package `EdgeSync/hub/driver/modernc` — rejected; still forces a blank import at the consumer, just one layer up.
3. `hub.Config.SQLDriver` field — rejected; YAGNI, no ncruces consumer of `hub` exists today (the only ncruces blank imports in the tree are in `leaf/cmd/wasm` + `leaf/cmd/leaf/driver_wasi.go`, neither of which imports `hub`).

Option 1 keeps the diff tiny, fulfills the package doc promise end-to-end, and leaves the escape hatch (option 3) as a real future option if a real ncruces consumer of `hub` materializes.

## Test plan

- [x] `go vet ./...` — clean (root + leaf + bridge)
- [x] `go test ./hub/...` — 38 passed
- [x] `cd leaf && GOWORK=off go test ./... -short -count=1` — 151 passed in 5 packages
- [x] `cd bridge && GOWORK=off go test ./... -short -count=1` — 14 passed in 2 packages
- [x] `GOWORK=off go build -buildvcs=false ./cmd/edgesync/` — clean
- [x] `GOWORK=off go test -buildvcs=false ./cmd/edgesync/` — 4 passed
- [x] `GOWORK=off make vet && GOWORK=off make build` — clean
- [x] Mental model check: with this in place, `sesh/cmd/sesh/main.go` would compile and run after dropping its own `_ "github.com/danmestas/libfossil/db/driver/modernc"` line (sesh untouched in this PR; cleanup ships as a follow-up).

## Follow-up

After this lands and EdgeSync gets tagged, sesh's `cmd/sesh/main.go` and `cli/multi_session_integration_test.go` will drop their blank libfossil-driver imports in a separate PR. Other in-tree EdgeSync packages (`leaf/`, `sim/`, `bridge/`, `cmd/edgesync`) still carry the blank import; converting them is out of scope for this PR (each is its own dependency-shape question).