### PR TITLE
chore: bump modernc driver to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/danmestas/EdgeSync/bridge v0.0.3
 	github.com/danmestas/EdgeSync/leaf v0.0.11
 	github.com/danmestas/libfossil v0.6.2
-	github.com/danmestas/libfossil/db/driver/modernc v0.1.0
+	github.com/danmestas/libfossil/db/driver/modernc v0.2.0
 	github.com/nats-io/nats-server/v2 v2.12.6
 	github.com/nats-io/nats.go v1.49.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/danmestas/go-sqlite3-opfs v0.2.0 h1:bO6iQYobgWCqTCQZ4NQ147x3yU2v+J+nn
 github.com/danmestas/go-sqlite3-opfs v0.2.0/go.mod h1:eAYxwG9hykpkB6oNMnsM8sSGB9HhHZv/NIN6yO9ZVQE=
 github.com/danmestas/libfossil v0.6.2 h1:ijBfh7d83tHQdzhJVh80/nUZ3Ru1763w/W348nOCUkc=
 github.com/danmestas/libfossil v0.6.2/go.mod h1:Ex+ADZ0kBLkBhSqnyrKg+KHbANVyQpKEWvVHUq8qMLc=
-github.com/danmestas/libfossil/db/driver/modernc v0.1.0 h1:w3elyVSdXdbGNZ3Iu9xE6RP4XTz6JRlkpk0RZKBMl1Y=
-github.com/danmestas/libfossil/db/driver/modernc v0.1.0/go.mod h1:sXeYxCmAkz3Tb/zLIOo7X2CoZDelYQ1MWyoUrySD/vU=
+github.com/danmestas/libfossil/db/driver/modernc v0.2.0 h1:5qhxKjOZc3xTkXos+ebCh1niW3uqez6RHYGkwRqetQc=
+github.com/danmestas/libfossil/db/driver/modernc v0.2.0/go.mod h1:PhgxmpF3jhfhO1lRFTOIyGGpL/GwYC8Q6yiEfkTVxYA=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0 h1:GWlyrNicyBYSUi68w4G4uXL34SIqmwSFco5a8IuutY0=
 github.com/danmestas/libfossil/db/driver/ncruces v0.1.0/go.mod h1:fA+18RPKWC5YxA2yimMNtr2YzMvt1yjMYNlc/p56PvY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

- Bump `github.com/danmestas/libfossil/db/driver/modernc` from v0.1.0 → **v0.2.0** to pick up the `_txlock=immediate` DSN fix from [libfossil#33](https://github.com/danmestas/libfossil/issues/33) / [#34](https://github.com/danmestas/libfossil/pull/34).
- Closes #167.

## Why

EdgeSync v0.0.18 added `hub`'s init() to auto-register the modernc driver internally — closes the abstraction-leak that forced consumers (sesh) to blank-import libfossil's driver. But EdgeSync's own `go.mod` still pinned the driver at v0.1.0, which is the pre-fix version.

When sesh drops its direct `libfossil/db/driver/modernc v0.2.0` require (as planned in the next sesh cleanup PR), the transitive resolution falls back to EdgeSync's v0.1.0 — and the busy_timeout fix vanishes. sesh's `TestScope_Project_ConcurrentCommits` regresses immediately.

This PR bumps EdgeSync's pinned modernc to v0.2.0 so the transitive chain keeps the fix.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./hub/...` — 38/38 pass

After merge: tag v0.0.19 so the sesh cleanup PR can bump and finish dropping its libfossil blank imports.