### PR TITLE
fix: exclude modernc driver registration from wasm builds

### DIFF
--- a/hub/driver.go
+++ b/hub/driver.go
@@ -1,3 +1,5 @@
+//go:build !js && !wasm
+
 package hub
 
 // libfossil's db layer requires a SQL driver to be registered before any
@@ -6,7 +8,9 @@ package hub
 // dependency on libfossil's internal SQL machinery — the package doc
 // promise that consumers don't need to import libfossil holds end-to-end.
 //
-// modernc is the production default. If a consumer ever needs ncruces
-// (WASM/WASI), expose an escape hatch then — don't preemptively widen
-// the API surface for a hypothetical caller.
+// modernc is a pure-Go cgo-free SQLite driver suitable for every supported
+// GOOS/GOARCH except js/wasm — its generated code references unsupported
+// syscalls under those targets. The build constraint above excludes this
+// file from wasm compilation; wasm consumers must register their own
+// driver (libfossil's ncruces driver has wasm support via ncruces_js.go).
 import _ "github.com/danmestas/libfossil/db/driver/modernc"


### PR DESCRIPTION
## Summary

The `init()`-based modernc registration added in #166 (released as v0.0.18) blocked wasm builds because modernc generates code referencing syscalls unavailable under `js/wasm`.

This PR adds a `//go:build !js && !wasm` constraint to `hub/driver.go` so the registration is skipped on wasm targets. Wasm consumers register their own driver (libfossil's ncruces driver supports wasm via `ncruces_js.go`).

## Behavior

- **Native builds (unchanged):** hub still auto-registers modernc on package import.
- **Wasm builds (new):** hub package compiles successfully under `GOOS=js GOARCH=wasm`. Consumer brings its own driver registration.

## Verified

```
GOOS=js GOARCH=wasm go vet ./hub/...   # clean
GOOS=js GOARCH=wasm go build ./hub/... # success
go test ./hub/... -timeout 120s        # 38/38 pass on native
```

## Plan

Tag this + #168 together as v0.0.19. After tag, the downstream sesh cleanup PR ([`chore/drop-libfossil-blank-imports`](https://github.com/danmestas/sesh/tree/chore/drop-libfossil-blank-imports)) bumps to v0.0.19 and finishes dropping its libfossil blank imports.