### PR TITLE
feat(hub): expose Ready() channel for serve-loop start barrier

### DIFF
--- a/hub/hub.go
+++ b/hub/hub.go
@@ -163,6 +163,8 @@ type Hub struct {
 	catchupStop chan struct{}
 	catchupDone chan struct{}
 
+	ready chan struct{}
+
 	stopOnce sync.Once
 }
 
@@ -241,6 +243,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		httpAddr:     httpLn.Addr().String(),
 		natsURL:      natsServer.ClientURL(),
 		leafURL:      leafAddr,
+		ready:        make(chan struct{}),
 	}
 
 	if !cfg.DisableFossilSyncOverNATS {
@@ -501,11 +504,30 @@ func (h *Hub) ServeHTTP(ctx context.Context) error {
 		_ = srv.Shutdown(shutdownCtx)
 	}()
 
+	close(h.ready)
+
 	if err := srv.Serve(h.httpListener); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("hub: serve HTTP: %w", err)
 	}
 	return nil
 }
+
+// Ready returns a channel closed once ServeHTTP has finished configuring
+// the HTTP server and is about to enter the Accept loop. Callers that
+// advertise the hub's URLs externally — e.g. session state JSON or peer
+// discovery — should wait on Ready before publishing, to close the window
+// where the listener is bound at the kernel level but the goroutine running
+// ServeHTTP hasn't started processing requests yet.
+//
+// The TCP listener is bound earlier (inside NewHub), so TCP-level connects
+// succeed immediately after NewHub returns. Ready closes after the
+// http.Server is wired up and just before srv.Serve runs, giving consumers
+// a clean barrier for "HTTP request processing is about to be live."
+//
+// Safe to call from any goroutine; safe to call multiple times. Returns
+// the same channel each time. The channel never closes if ServeHTTP is
+// never called.
+func (h *Hub) Ready() <-chan struct{} { return h.ready }
 
 // Stop tears down the embedded NATS server and any HTTP listeners. Safe to
 // call multiple times.

--- a/hub/hub_test.go
+++ b/hub/hub_test.go
@@ -238,6 +238,91 @@ func TestHub_ServeHTTP_RespondsAndShutsDownOnContextCancel(t *testing.T) {
 	}
 }
 
+// TestHub_Ready_ClosesAfterServeHTTPStarts asserts the Ready() channel
+// closes once ServeHTTP has wired up the http.Server and is about to
+// enter the Accept loop, and that an HTTP GET issued immediately after
+// the close succeeds without retry. Regression for #171.
+func TestHub_Ready_ClosesAfterServeHTTPStarts(t *testing.T) {
+	h := newTestHub(t)
+
+	select {
+	case <-h.Ready():
+		t.Fatal("Ready closed before ServeHTTP was called")
+	default:
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- h.ServeHTTP(ctx) }()
+
+	select {
+	case <-h.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ready did not close within 2s of ServeHTTP start")
+	}
+
+	resp, err := http.Get("http://" + h.HTTPAddr() + "/")
+	if err != nil {
+		t.Fatalf("HTTP GET immediately after Ready close: %v", err)
+	}
+	resp.Body.Close()
+
+	cancel()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Error("ServeHTTP did not shut down within 2s of ctx cancel")
+	}
+}
+
+// TestHub_Ready_BroadcastsToManyWaiters asserts the channel-close pattern
+// fans out to many concurrent waiters with no goroutine timing out. 100
+// goroutines select on Ready() plus a deadline; all must receive the close.
+// Regression for #171 acceptance criterion "race test".
+func TestHub_Ready_BroadcastsToManyWaiters(t *testing.T) {
+	h := newTestHub(t)
+
+	const waiters = 100
+	results := make(chan bool, waiters)
+	for range waiters {
+		go func() {
+			select {
+			case <-h.Ready():
+				results <- true
+			case <-time.After(3 * time.Second):
+				results <- false
+			}
+		}()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- h.ServeHTTP(ctx) }()
+
+	for i := range waiters {
+		if !<-results {
+			t.Errorf("waiter %d timed out instead of seeing Ready close", i)
+		}
+	}
+
+	cancel()
+	<-serveDone
+}
+
+// TestHub_Ready_SameChannelOnRepeatedCalls asserts the documented contract
+// that Ready() returns the same channel on every call (no per-call
+// allocation, idempotent for callers that cache the return value).
+func TestHub_Ready_SameChannelOnRepeatedCalls(t *testing.T) {
+	h := newTestHub(t)
+	first := h.Ready()
+	second := h.Ready()
+	if first != second {
+		t.Error("Ready() returned a different channel on a second call")
+	}
+}
+
 func TestHub_Stop_IsIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	h, err := NewHub(context.Background(), Config{


### PR DESCRIPTION
## Summary

- Adds `Hub.Ready() <-chan struct{}` — closes when `ServeHTTP` has wired up `http.Server` and is about to enter the `Accept` loop.
- Lets consumers (sesh `cli/up.go`, peer-discovery JSON writers) wait for HTTP-level readiness before advertising hub URLs externally, closing the TCP-bound-but-not-Accepting window.
- Field added to `Hub`; initialized in `NewHub`; closed just before `srv.Serve(h.httpListener)`.

## Test plan

- [x] `go test ./hub/ -run 'TestHub_Ready_' -count=1` — 3 new tests pass:
  - `TestHub_Ready_ClosesAfterServeHTTPStarts` — channel is open after `NewHub` and closes within 2s of `ServeHTTP`; subsequent HTTP GET succeeds without retry.
  - `TestHub_Ready_BroadcastsToManyWaiters` — 100 concurrent goroutines all receive the close, none time out.
  - `TestHub_Ready_SameChannelOnRepeatedCalls` — `Ready()` returns the same channel on repeated calls.
- [x] Full hub suite: 41/41 pass.
- [x] CI parity locally: `make vet`, `make build`, leaf/bridge/cmd `go test ./... -short -count=1` all green.

Closes #171.