### PR TITLE
feat(hub): expose embedded NATS WebSocket endpoint

### DIFF
--- a/docs/architecture/hub-package.md
+++ b/docs/architecture/hub-package.md
@@ -19,6 +19,8 @@ type Config struct {
     FossilHTTPPort     int           // 0 = auto-pick
     NATSClientPort     int           // 0 = auto-pick
     NATSLeafPort       int           // 0 = auto-pick
+    EnableWebSocket    bool          // false = WS listener off (default; opt-in, no TLS/WSS)
+    NATSWebSocketPort  int           // 0 = auto-pick when EnableWebSocket=true; ignored otherwise
     LeafUpstream       string        // optional "nats-leaf://host:port" to solicit upstream; empty = root hub
     CheckpointInterval time.Duration // 0 = 10s (PASSIVE WAL checkpoint cadence)
 }
@@ -29,10 +31,11 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error)
 func (h *Hub) ServeHTTP(ctx context.Context) error
 func (h *Hub) Stop() error
 
-func (h *Hub) NATSURL() string       // "nats://127.0.0.1:NNNN"
-func (h *Hub) LeafUpstream() string  // "nats-leaf://127.0.0.1:LLLL" (this hub's leafnode listener)
-func (h *Hub) HTTPAddr() string      // "127.0.0.1:HHHH"
-func (h *Hub) ServerName() string    // live NATS server identity (Config.ServerName or auto-generated)
+func (h *Hub) NATSURL() string          // "nats://127.0.0.1:NNNN"
+func (h *Hub) NATSWebSocketURL() string // "ws://127.0.0.1:NNNN" when EnableWebSocket; "" otherwise
+func (h *Hub) LeafUpstream() string     // "nats-leaf://127.0.0.1:LLLL" (this hub's leafnode listener)
+func (h *Hub) HTTPAddr() string         // "127.0.0.1:HHHH"
+func (h *Hub) ServerName() string       // live NATS server identity (Config.ServerName or auto-generated)
 
 type User struct{ Login, Caps string }
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -60,6 +60,21 @@ type Config struct {
 	// 0 = auto-pick.
 	NATSLeafPort int
 
+	// EnableWebSocket turns on the embedded NATS server's WebSocket
+	// listener. Off by default — opt-in for security (no TLS/WSS is wired
+	// up here; see issue #176). When true the listener binds on
+	// 127.0.0.1:NATSWebSocketPort with NoTLS=true.
+	//
+	// A separate bool (rather than overloading NATSWebSocketPort) is
+	// required because 0 already means "auto-pick" for the sibling port
+	// knobs, leaving no room for a "disabled" sentinel.
+	EnableWebSocket bool
+
+	// NATSWebSocketPort is the embedded NATS server's WebSocket listener
+	// port when EnableWebSocket is true. 0 = auto-pick. Ignored when
+	// EnableWebSocket is false.
+	NATSWebSocketPort int
+
 	// LeafUpstream is an optional upstream leafnode URL to solicit a
 	// connection toward (e.g. "nats-leaf://hub.example:7422"). When set,
 	// this hub acts as a leaf of that upstream — subjects published locally
@@ -153,9 +168,10 @@ type Hub struct {
 	syncSubject   string
 	commitSubject string
 
-	httpAddr string
-	natsURL  string
-	leafURL  string
+	httpAddr     string
+	natsURL      string
+	leafURL      string
+	websocketURL string
 
 	checkpointStop chan struct{}
 	checkpointDone chan struct{}
@@ -236,6 +252,11 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		leafAddr = fmt.Sprintf("nats-leaf://127.0.0.1:%d", varz.LeafNode.Port)
 	}
 
+	wsURL := ""
+	if cfg.EnableWebSocket {
+		wsURL = natsServer.WebsocketURL()
+	}
+
 	h := &Hub{
 		repo:         repo,
 		server:       natsServer,
@@ -243,6 +264,7 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 		httpAddr:     httpLn.Addr().String(),
 		natsURL:      natsServer.ClientURL(),
 		leafURL:      leafAddr,
+		websocketURL: wsURL,
 		ready:        make(chan struct{}),
 	}
 
@@ -585,6 +607,11 @@ func (h *Hub) ServerName() string { return h.server.Name() }
 // from Config.LeafUpstream, which is the input URL this hub itself solicits.
 func (h *Hub) LeafURL() string { return h.leafURL }
 
+// NATSWebSocketURL returns the embedded NATS server's WebSocket client URL
+// (e.g. "ws://127.0.0.1:NNNN") when Config.EnableWebSocket is true, or "" when
+// WebSocket is disabled (the default). No TLS/WSS is wired up — see issue #176.
+func (h *Hub) NATSWebSocketURL() string { return h.websocketURL }
+
 // HTTPAddr returns the host:port the fossil HTTP server is bound to.
 func (h *Hub) HTTPAddr() string { return h.httpAddr }
 
@@ -649,6 +676,14 @@ func startNATS(cfg Config) (*natsserver.Server, error) {
 	}
 	opts.LeafNode.Host = "127.0.0.1"
 	opts.LeafNode.Port = portOrAuto(cfg.NATSLeafPort)
+
+	if cfg.EnableWebSocket {
+		opts.Websocket = natsserver.WebsocketOpts{
+			Host:  "127.0.0.1",
+			Port:  portOrAuto(cfg.NATSWebSocketPort),
+			NoTLS: true, // TLS/WSS out of scope — issue #176
+		}
+	}
 
 	if cfg.LeafUpstream != "" {
 		u, err := url.Parse(cfg.LeafUpstream)

--- a/hub/websocket_test.go
+++ b/hub/websocket_test.go
@@ -1,0 +1,109 @@
+package hub
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestHub_NATSWebSocketURL_DisabledByDefault asserts that WebSocket is opt-in:
+// a default Config leaves NATSWebSocketURL empty so consumers know the
+// listener isn't running.
+func TestHub_NATSWebSocketURL_DisabledByDefault(t *testing.T) {
+	h := newTestHub(t)
+
+	if got := h.NATSWebSocketURL(); got != "" {
+		t.Errorf("NATSWebSocketURL() = %q, want empty when EnableWebSocket is false", got)
+	}
+}
+
+// TestHub_NATSWebSocketURL_AutoPick confirms EnableWebSocket=true with
+// NATSWebSocketPort=0 yields a parseable ws://127.0.0.1:NNNN URL with a
+// non-zero resolved port.
+func TestHub_NATSWebSocketURL_AutoPick(t *testing.T) {
+	dir := t.TempDir()
+	h, err := NewHub(context.Background(), Config{
+		RepoPath:        filepath.Join(dir, "hub.fossil"),
+		EnableWebSocket: true,
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	got := h.NATSWebSocketURL()
+	if got == "" {
+		t.Fatal("NATSWebSocketURL() empty when EnableWebSocket=true")
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", got, err)
+	}
+	if u.Scheme != "ws" {
+		t.Errorf("scheme = %q, want %q", u.Scheme, "ws")
+	}
+	if !strings.HasPrefix(u.Host, "127.0.0.1:") {
+		t.Errorf("host = %q, want 127.0.0.1: prefix (loopback parity with TCP/leaf)", u.Host)
+	}
+	if port := u.Port(); port == "" || port == "0" {
+		t.Errorf("port = %q, want auto-picked non-zero port", port)
+	}
+}
+
+// TestHub_NATSWebSocket_RoundTrip dials the WS listener via the standard
+// nats.go client (which supports ws://) and proves end-to-end pub/sub works
+// across the WS<->TCP boundary: a WS subscriber receives a message published
+// by a TCP publisher on the same embedded server.
+func TestHub_NATSWebSocket_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	h, err := NewHub(context.Background(), Config{
+		RepoPath:        filepath.Join(dir, "hub.fossil"),
+		EnableWebSocket: true,
+	})
+	if err != nil {
+		t.Fatalf("NewHub: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Stop() })
+
+	wsConn, err := nats.Connect(h.NATSWebSocketURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect(ws %s): %v", h.NATSWebSocketURL(), err)
+	}
+	defer wsConn.Close()
+
+	tcpConn, err := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("nats.Connect(tcp %s): %v", h.NATSURL(), err)
+	}
+	defer tcpConn.Close()
+
+	const subject = "ws.roundtrip.test"
+	const payload = "hello-over-ws"
+
+	sub, err := wsConn.SubscribeSync(subject)
+	if err != nil {
+		t.Fatalf("SubscribeSync over WS: %v", err)
+	}
+	// Flush so the server registers the WS subscription before the TCP
+	// publish races ahead.
+	if err := wsConn.FlushTimeout(2 * time.Second); err != nil {
+		t.Fatalf("flush WS subscription: %v", err)
+	}
+
+	if err := tcpConn.Publish(subject, []byte(payload)); err != nil {
+		t.Fatalf("Publish over TCP: %v", err)
+	}
+
+	msg, err := sub.NextMsg(2 * time.Second)
+	if err != nil {
+		t.Fatalf("NextMsg over WS: %v", err)
+	}
+	if got := string(msg.Data); got != payload {
+		t.Errorf("WS subscriber got %q, want %q", got, payload)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #176. Adds an opt-in WebSocket listener to the embedded nats-server hosted by `hub.Hub`, so browser / WASM clients can reach the same NATS plane as TCP clients.

- New `Config.EnableWebSocket` (bool; default `false`, opt-in because no TLS/WSS is wired up here) and `Config.NATSWebSocketPort` (int; `0` = auto-pick, mirroring the existing `NATSClientPort` / `NATSLeafPort` convention).
- When enabled, the embedded server binds a WS listener on `127.0.0.1:NNNN` with `NoTLS=true` (loopback parity with the TCP/leaf listeners).
- New `Hub.NATSWebSocketURL() string` getter — returns `ws://127.0.0.1:NNNN` when enabled, `""` otherwise. Same shape as `NATSURL()` / `LeafURL()`.
- `docs/architecture/hub-package.md` updated with the new field + getter.

A separate `EnableWebSocket bool` was chosen over overloading `NATSWebSocketPort` because `0` already means "auto-pick" for the sibling port knobs, leaving no spare sentinel for "disabled" — and "disabled" must be the default for security.

## Test plan

Three new tests in `hub/websocket_test.go`:

- `TestHub_NATSWebSocketURL_DisabledByDefault` — default Config leaves `NATSWebSocketURL()` empty.
- `TestHub_NATSWebSocketURL_AutoPick` — with `EnableWebSocket: true`, the URL parses as `ws://127.0.0.1:NNNN` with a non-zero auto-picked port.
- `TestHub_NATSWebSocket_RoundTrip` — proves end-to-end pub/sub across the WS<->TCP boundary:

```go
wsConn, _ := nats.Connect(h.NATSWebSocketURL(), nats.Timeout(2*time.Second))
tcpConn, _ := nats.Connect(h.NATSURL(), nats.Timeout(2*time.Second))

sub, _ := wsConn.SubscribeSync(subject)
_ = wsConn.FlushTimeout(2 * time.Second)
_ = tcpConn.Publish(subject, []byte(payload))

msg, _ := sub.NextMsg(2 * time.Second)
// msg.Data == payload
```

`nats.go` v1.49.0 already supports `nats.Connect("ws://...")` natively, so no dep bump is needed.

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./hub/...` passes (full suite, no regressions)
- [x] Three new tests pass
- [x] Default behavior unchanged: WS listener stays off unless `EnableWebSocket=true`