### PR TITLE
test(hub): add 3-hub cross-leaf propagation test — reproduces #179 / #162 race

### DIFF
--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -406,6 +406,130 @@ func TestCrossLeaf_SubjectsAlign(t *testing.T) {
 	}
 }
 
+// TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll exercises the
+// 3-hub star topology that production sesh actually runs (per-session
+// hubs leaf-linked to a central ~/.sesh/hub.repo), which the existing
+// 2-hub propagation tests do not cover. hubB and hubC both leaf-link to
+// hubA; all three share the same project-code so they're subscribed to
+// the same .sync and .commit subjects.
+//
+// Asserts the property the original brief on #179 claimed was broken:
+// a commit on any peer propagates to BOTH of the other two peers via
+// the .commit notify → .sync pull pipeline. If this test hangs at the
+// 10s wait, we've reproduced what `orch/test/docker-sesh` F11 sees in
+// production sesh and the underlying cause is #162 (multi-responder
+// race on .sync — every peer with a sub matches the request, only the
+// first reply wins, and a stale responder silently starves the pulling
+// hub). If it passes, the hub layer is sound for 3+ hub topologies and
+// F11's gap lives downstream of EdgeSync (sesh wiring, project-code
+// drift, or docker-sesh infra).
+//
+// Both directions are checked: a commit on B is asserted at A AND C;
+// then a commit on C is asserted at A AND B. The reverse direction
+// covers the case where the publishing hub is *not* the topology root.
+func TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll(t *testing.T) {
+	if testing.Short() {
+		// BLOCKED ON #162 — cross-leaf 3-hub commit propagation hangs on
+		// the multi-responder .sync race. Remove this skip once #162 is
+		// fixed; the test then serves as the regression sentinel for the
+		// 3+ hub topology that production sesh relies on.
+		t.Skip("reproduces #162 — multi-responder .sync race; enable in -short once #162 fix lands")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// hubA is the topology root; B and C both leaf-link to it.
+	dirA := t.TempDir()
+	hubA, err := NewHub(ctx, Config{
+		RepoPath:    filepath.Join(dirA, "hubA.fossil"),
+		ProjectCode: sharedProjectCode,
+		NobodyCaps:  "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub A: %v", err)
+	}
+	t.Cleanup(func() { _ = hubA.Stop() })
+
+	httpCtxA, httpCancelA := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelA)
+	go func() { _ = hubA.ServeHTTP(httpCtxA) }()
+
+	dirB := t.TempDir()
+	hubB, err := NewHub(ctx, Config{
+		RepoPath:     filepath.Join(dirB, "hubB.fossil"),
+		ProjectCode:  sharedProjectCode,
+		LeafUpstream: hubA.LeafURL(),
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub B: %v", err)
+	}
+	t.Cleanup(func() { _ = hubB.Stop() })
+
+	httpCtxB, httpCancelB := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelB)
+	go func() { _ = hubB.ServeHTTP(httpCtxB) }()
+
+	dirC := t.TempDir()
+	hubC, err := NewHub(ctx, Config{
+		RepoPath:     filepath.Join(dirC, "hubC.fossil"),
+		ProjectCode:  sharedProjectCode,
+		LeafUpstream: hubA.LeafURL(),
+		NobodyCaps:   "gio",
+	})
+	if err != nil {
+		t.Fatalf("NewHub C: %v", err)
+	}
+	t.Cleanup(func() { _ = hubC.Stop() })
+
+	httpCtxC, httpCancelC := context.WithCancel(context.Background())
+	t.Cleanup(httpCancelC)
+	go func() { _ = hubC.ServeHTTP(httpCtxC) }()
+
+	// Both leaves must be up before any commit fires; otherwise the
+	// .commit notify lands in the void and the test sees a false
+	// "propagation broken" signal.
+	waitFor(t, 10*time.Second, "leaf links B→A and C→A", func() bool {
+		return hubA.NumLeafs() >= 2
+	})
+
+	// Direction 1: commit on B, assert A and C converge.
+	if _, err := hubB.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "from-b.txt", Content: []byte("hello-from-B")}},
+		Message: "commit on B (3-hub star)",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("hubB.Commit: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "A sees from-b.txt at trunk", func() bool {
+		got, readErr := hubA.Read(ctx, "from-b.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-B"))
+	})
+	waitFor(t, 10*time.Second, "C sees from-b.txt at trunk", func() bool {
+		got, readErr := hubC.Read(ctx, "from-b.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-B"))
+	})
+
+	// Direction 2: commit on C, assert A and B converge.
+	if _, err := hubC.Commit(ctx, CommitOpts{
+		Files:   []FileToCommit{{Name: "from-c.txt", Content: []byte("hello-from-C")}},
+		Message: "commit on C (3-hub star)",
+		Author:  "hub",
+	}); err != nil {
+		t.Fatalf("hubC.Commit: %v", err)
+	}
+
+	waitFor(t, 10*time.Second, "A sees from-c.txt at trunk", func() bool {
+		got, readErr := hubA.Read(ctx, "from-c.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-C"))
+	})
+	waitFor(t, 10*time.Second, "B sees from-c.txt at trunk", func() bool {
+		got, readErr := hubB.Read(ctx, "from-c.txt")
+		return readErr == nil && bytes.Equal(got, []byte("hello-from-C"))
+	})
+}
+
 // TestNewHub_ProjectCodeMismatchOnExistingRepo asserts the drift-guard:
 // reopening a repo with a different ProjectCode than what's on disk
 // fails fast.


### PR DESCRIPTION
## Summary

- Adds `TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll` in `hub/cross_leaf_test.go`. Star topology around hubA; hubB and hubC both leaf-link to it; both directions of propagation are asserted (commit on B → A and C see it; commit on C → A and B see it).
- **Reproduces the cross-leaf propagation symptom reported in #179** and confirms the underlying cause is **#162 (multi-responder `.sync` race)**. No production code changes — the test is the artifact.
- Gated under `-short` with a `t.Skip` pointing at #162 so pre-commit and CI stay green. Without `-short` the test fails at the first 10s wait, demonstrating the bug.

## What the test catches

Same 2-hub topology as `TestCrossLeaf_SharedProjectCode_PropagatesCommit` but with a third leaf (hubC) attached to the same root. The publish-side wiring is identical to the 2-hub case that ships green today — what changes is that **three** hubs are now subscribed to `<prefix>.<sharedProjectCode>.sync`. When the publishing hub's commit triggers any peer's `.commit` callback, that peer fires a `nats.Request` on `.sync`. Every other peer matches the subscription and answers, and `nats.Request` only delivers the first reply — if the racing stale responder wins, the pull converges to zero blobs and the file silently fails to materialise. That is #162 verbatim, and that is the gap the F11 finding in `orch/test/docker-sesh` runs into (sesh's production topology is `session-A → ~/.sesh/hub.repo (central) ← session-B (+ verifier)`, which is exactly 3+ hubs on the shared subject).

## Local repro

```
$ go test ./hub/ -run TestCrossLeaf_ThreeHubs -count=1 -timeout 90s -v
=== RUN   TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll
    cross_leaf_test.go:505: timeout after 10s waiting for: A sees from-b.txt at trunk
--- FAIL: TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll (10.05s)
FAIL    github.com/danmestas/EdgeSync/hub       10.443s
```

Note the failure hits even at the **first hop** (B → A), not at the multi-hop second peer — A's `.sync` request is enough to race against C's empty responder. This rules out "interest doesn't cross the leaf link" (the original brief's hypothesis): the `.commit` notify reaches A fine; the pull-back is where it dies.

Under `-short` the test skips cleanly:

```
$ go test ./hub/ -run TestCrossLeaf -count=1 -short -v
... existing 5 cross-leaf tests pass ...
=== RUN   TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll
    cross_leaf_test.go:436: reproduces #162 — multi-responder .sync race; enable in -short once #162 fix lands
--- SKIP: TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll (0.00s)
PASS
```

## Why a skip rather than landing it red

Pre-commit (`make ci-fast`) and CI both run `-short`. A red sentinel test would block every other PR until #162 lands. Skipping under `-short` keeps the test available as documentation + manual repro now, and the one-line `t.Skip` removal once #162 is fixed promotes it into the regression sentinel for the 3-hub topology. The skip line explicitly names #162 so the dependency is auditable.

## Test plan

- [x] `go test ./hub/ -run TestCrossLeaf -count=1 -short -v` — passes (skip line visible).
- [x] `go test ./hub/ -run TestCrossLeaf_ThreeHubs -count=1 -timeout 90s -v` — fails at the 10s wait, reproducing #162.
- [x] `make ci-fast` — passes locally (the leaf-agent `TestIrohTransportRoundTrip` socket-bind flake in `~/.ctx-mode-*` sandbox tempdirs is sandbox infra, not in scope here).
- [ ] Remote CI green on push (run by GitHub Actions).

## Next steps (out of scope here)

- Pivot to a fix slice for #162. The two fix-shapes already in #162's body — queue-group routing on `.sync` (cheap, needs a fallback when chosen responder lacks the commit) or per-peer reply subjects (correct, changes the `commitNotification` wire format) — both want their own design+test PRs. After #162 lands, the follow-up is the one-line skip removal in this file.
- Close #179 once #162 lands. The original brief's Options 1 and 2 should not ship as proposed (see #179 triage comment).

Closes: none yet. Refs #179, #162.
