### PR TITLE
fix(hub): resolve multi-responder race on .sync request (#162)

### DIFF
--- a/hub/cross_leaf_test.go
+++ b/hub/cross_leaf_test.go
@@ -428,13 +428,11 @@ func TestCrossLeaf_SubjectsAlign(t *testing.T) {
 // then a commit on C is asserted at A AND B. The reverse direction
 // covers the case where the publishing hub is *not* the topology root.
 func TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll(t *testing.T) {
-	if testing.Short() {
-		// BLOCKED ON #162 — cross-leaf 3-hub commit propagation hangs on
-		// the multi-responder .sync race. Remove this skip once #162 is
-		// fixed; the test then serves as the regression sentinel for the
-		// 3+ hub topology that production sesh relies on.
-		t.Skip("reproduces #162 — multi-responder .sync race; enable in -short once #162 fix lands")
-	}
+	// Regression sentinel for #162: ran red under -short until the fix
+	// landed; now runs under both -short and full modes. If this flakes,
+	// the multi-responder .sync race is back. Production sesh's per-session
+	// hubs leaf-link to a central ~/.sesh/hub.repo, putting 3+ hubs on the
+	// same .commit/.sync subjects — exactly this topology.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -162,11 +162,14 @@ type Hub struct {
 	httpListener net.Listener
 	httpServer   *http.Server
 
-	natsClient    *nats.Conn
-	natsSyncSub   *nats.Subscription
-	natsCommitSub *nats.Subscription
-	syncSubject   string
-	commitSubject string
+	natsClient      *nats.Conn
+	natsSyncSub     *nats.Subscription
+	natsPeerSyncSub *nats.Subscription
+	natsCommitSub   *nats.Subscription
+	syncSubject     string
+	peerSyncSubject string
+	commitSubject   string
+	peerID          string
 
 	httpAddr     string
 	natsURL      string
@@ -280,6 +283,9 @@ func NewHub(ctx context.Context, cfg Config) (*Hub, error) {
 			if h.natsSyncSub != nil {
 				_ = h.natsSyncSub.Unsubscribe()
 			}
+			if h.natsPeerSyncSub != nil {
+				_ = h.natsPeerSyncSub.Unsubscribe()
+			}
 			if h.natsClient != nil {
 				h.natsClient.Close()
 			}
@@ -323,9 +329,26 @@ func (h *Hub) startCheckpointLoop(interval time.Duration) {
 }
 
 // startFossilSyncSubscriber connects a local NATS client to the embedded
-// server and subscribes to "<prefix>.<project-code>.sync", dispatching
-// incoming xfer payloads to the hub repo's HandleSync. Invoked by NewHub
-// when Config.DisableFossilSyncOverNATS is false.
+// server and subscribes to two subjects for incoming xfer payloads,
+// dispatching both to the hub repo's HandleSync:
+//
+//  1. "<prefix>.<project-code>.sync" — the broadcast subject used by
+//     external leaf-agent pushes. Joined as a NATS queue group keyed on
+//     the project-code so that across a multi-hub cluster only ONE hub
+//     responds to any given broadcast request. Without the queue group,
+//     every hub on the project would answer and nats.Request would
+//     non-deterministically pick the first reply — see #162.
+//
+//  2. "<prefix>.<project-code>.sync.<peer-id>" — a per-peer addressed
+//     subject. Used by hub-to-hub pulls triggered by .commit
+//     notifications: the puller addresses the originating peer
+//     directly so the response is deterministic regardless of how many
+//     other hubs share the project-code.
+//
+// peerID is the hub's NATS server name. Reconnects keep the same server
+// name because the embedded server's name is stable across the client's
+// reconnect window. Invoked by NewHub when Config.DisableFossilSyncOverNATS
+// is false.
 func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 	projectCode, err := h.repo.handle.Config("project-code")
 	if err != nil {
@@ -340,6 +363,11 @@ func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 		prefix = "fossil"
 	}
 	subject := prefix + "." + projectCode + ".sync"
+	peerID := h.server.Name()
+	if peerID == "" {
+		return fmt.Errorf("hub: NATS server name is empty; cannot derive peer-id for addressed .sync subject")
+	}
+	peerSubject := subject + "." + peerID
 
 	nc, err := nats.Connect(h.natsURL,
 		nats.Name("edgesync-hub"),
@@ -353,7 +381,7 @@ func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 		return fmt.Errorf("hub: connect local NATS for fossil-sync subscriber: %w", err)
 	}
 
-	sub, err := nc.Subscribe(subject, func(msg *nats.Msg) {
+	handle := func(msg *nats.Msg) {
 		respBytes, hsErr := h.repo.handle.HandleSync(context.Background(), msg.Data)
 		if hsErr != nil {
 			// Empty response signals failure to the caller without hanging.
@@ -361,32 +389,52 @@ func (h *Hub) startFossilSyncSubscriber(cfg Config) error {
 			return
 		}
 		_ = msg.Respond(respBytes)
-	})
-	if err != nil {
-		nc.Close()
-		return fmt.Errorf("hub: subscribe %s: %w", subject, err)
 	}
 
-	// Flush so the server has registered the subscription before NewHub
+	// Queue-group scope is the project-code so cross-project hub clusters
+	// (unlikely today but cheap to guarantee) don't share a queue.
+	queue := "sync-" + projectCode
+	sub, err := nc.QueueSubscribe(subject, queue, handle)
+	if err != nil {
+		nc.Close()
+		return fmt.Errorf("hub: queue-subscribe %s: %w", subject, err)
+	}
+
+	peerSub, err := nc.Subscribe(peerSubject, handle)
+	if err != nil {
+		_ = sub.Unsubscribe()
+		nc.Close()
+		return fmt.Errorf("hub: subscribe %s: %w", peerSubject, err)
+	}
+
+	// Flush so the server has registered the subscriptions before NewHub
 	// returns. Tests that publish immediately after NewHub depend on this.
 	if err := nc.FlushTimeout(2 * time.Second); err != nil {
 		_ = sub.Unsubscribe()
+		_ = peerSub.Unsubscribe()
 		nc.Close()
 		return fmt.Errorf("hub: flush fossil-sync subscription: %w", err)
 	}
 
 	h.natsClient = nc
 	h.natsSyncSub = sub
+	h.natsPeerSyncSub = peerSub
 	h.syncSubject = subject
+	h.peerSyncSubject = peerSubject
+	h.peerID = peerID
 	return nil
 }
 
 // commitNotification is the JSON payload published on the .commit subject
-// when a new commit lands. Peers decode it and pull the manifest via the
-// .sync subject.
+// when a new commit lands. Peers decode it and pull the manifest from the
+// originating peer via the addressed "<prefix>.<project-code>.sync.<peer-id>"
+// subject. PeerID is the publisher hub's NATS server name; pullers MUST
+// route requests through it rather than the broadcast .sync subject to
+// avoid the multi-responder race documented in #162.
 type commitNotification struct {
-	RID  int64  `json:"rid"`
-	UUID string `json:"uuid"`
+	RID    int64  `json:"rid"`
+	UUID   string `json:"uuid"`
+	PeerID string `json:"peer_id"`
 }
 
 // startCommitSubscriber subscribes to "<prefix>.<project-code>.commit" and,
@@ -410,14 +458,33 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 	}
 	commitSubject := prefix + "." + projectCode + ".commit"
 	syncSubject := prefix + "." + projectCode + ".sync"
+	ownPeerID := h.peerID
 
-	pullTransport := newNATSTransport(h.natsClient, syncSubject, 0)
 	sub, err := h.natsClient.Subscribe(commitSubject, func(msg *nats.Msg) {
 		var n commitNotification
 		if jsonErr := json.Unmarshal(msg.Data, &n); jsonErr != nil {
 			log.Printf("hub commit subscriber: decode notification: %v", jsonErr)
 			return
 		}
+		// PeerID is required: without it we'd have to fall back to the
+		// broadcast .sync subject, which is exactly the multi-responder
+		// race #162 fixes. Drop notifications missing it (would only
+		// happen against an older publisher that pre-dates this fix).
+		if n.PeerID == "" {
+			log.Printf("hub commit subscriber: notification missing peer_id rid=%d uuid=%s; refusing broadcast pull (see #162)", n.RID, n.UUID)
+			return
+		}
+		// Self-notifications can happen even with NoEcho when a
+		// publish from this hub round-trips back via an upstream leaf.
+		// Skip them so we don't try to pull from ourselves.
+		if n.PeerID == ownPeerID {
+			return
+		}
+		// Address the pull at the publishing peer directly via its
+		// per-peer .sync subject so exactly that peer responds — no
+		// race with stale subscribers on the broadcast subject.
+		peerSyncSubject := syncSubject + "." + n.PeerID
+		pullTransport := newNATSTransport(h.natsClient, peerSyncSubject, 0)
 		// Pull is naturally idempotent — if we already have the uuid,
 		// the sync round converges with zero rounds / zero blobs. So
 		// we skip the up-front existence check and let the protocol
@@ -429,7 +496,7 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 			ProjectCode: projectCode,
 			PeerID:      "edgesync-hub",
 		}); syncErr != nil {
-			log.Printf("hub commit subscriber: pull triggered by notification rid=%d uuid=%s: %v", n.RID, n.UUID, syncErr)
+			log.Printf("hub commit subscriber: pull triggered by notification rid=%d uuid=%s peer=%s: %v", n.RID, n.UUID, n.PeerID, syncErr)
 		}
 	})
 	if err != nil {
@@ -441,9 +508,12 @@ func (h *Hub) startCommitSubscriber(cfg Config) error {
 	}
 
 	// Wire publish hook on the repo so future commits notify peers.
+	// PeerID is required so receivers can address their pull-back at
+	// this specific hub rather than fanning out a broadcast request
+	// that's vulnerable to the #162 multi-responder race.
 	nc := h.natsClient
 	h.repo.publish = func(rid int64, uuid string) {
-		payload, jsonErr := json.Marshal(commitNotification{RID: rid, UUID: uuid})
+		payload, jsonErr := json.Marshal(commitNotification{RID: rid, UUID: uuid, PeerID: ownPeerID})
 		if jsonErr != nil {
 			log.Printf("hub commit publish: encode notification rid=%d uuid=%s: %v", rid, uuid, jsonErr)
 			return
@@ -570,6 +640,9 @@ func (h *Hub) Stop() error {
 		}
 		if h.natsSyncSub != nil {
 			_ = h.natsSyncSub.Unsubscribe()
+		}
+		if h.natsPeerSyncSub != nil {
+			_ = h.natsPeerSyncSub.Unsubscribe()
 		}
 		if h.natsClient != nil {
 			h.natsClient.Close()


### PR DESCRIPTION
## Summary

Closes the multi-responder race on the hub-to-hub `.sync` request documented in #162 and reproduced by the failing 3-hub test added in #180. Going forward, commit propagation across 3+ hub topologies is deterministic regardless of how many peers share a project-code.

## Option chosen — B (per-peer addressed reply subjects)

Option A (queue group on the broadcast `.sync`) is listed in #162 as the cheap path, but its documented downside is fatal here: NATS load-balances to *some* subscriber, and if the chosen subscriber is a stale peer (doesn't yet have the new commit) the pull converges against zero blobs — exactly the silent-stale-state failure the issue is trying to fix. Option B addresses the request at the specific peer that published `.commit`, so the responder is always the one with the data. No race, no retry-with-fallback machinery needed.

Hybrid kept: the broadcast `.sync` subject still exists as a NATS **queue group** (`sync-<project-code>`) so external leaf-agent pushes — which target the broadcast subject — get exactly one responder. Leaf-agent push carries the data, so any single responder is fine: the push lands, that hub's commit hook fires, and the per-peer pull pipeline takes over. This preserves the existing leaf-agent NATS-push contract (`sim/hub_nats_sync_test.go`'s `TestHubNATSFossilSync_LeafPushLandsOnHub` is unchanged and still green).

### What changed

- `commitNotification` gains a `peer_id` field (the hub's NATS server name).
- Each hub subscribes to `<prefix>.<code>.sync.<peer-id>` in addition to the existing broadcast subject.
- The broadcast subject is now a queue subscription keyed on the project-code.
- The commit subscriber decodes `peer_id` and routes its pull-back at `<prefix>.<code>.sync.<peer-id>`. Refuses to fall back to the broadcast subject — that's the bug we're fixing, so silently regressing to it would be worse than dropping the notification.
- Self-notifications (publish from this hub round-tripping back via an upstream leaf, which `NoEcho` doesn't catch across leaf links) are dropped.

## Test evidence

### `TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll`

**Pre-fix** (revert `hub/hub.go` to `main`, keep the test's `t.Skip` removed):

```
=== RUN   TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll
    cross_leaf_test.go:498: timeout after 10s waiting for: A sees from-b.txt at trunk
--- FAIL: TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll (10.06s)
FAIL
FAIL	github.com/danmestas/EdgeSync/hub	10.491s
```

**Post-fix:**

```
=== RUN   TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll
--- PASS: TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll (0.14s)
PASS
ok  	github.com/danmestas/EdgeSync/hub	0.548s
```

### 10x flake check (the gate for "stable enough to land")

```
$ go test ./hub/ -count=10 -short -run TestCrossLeaf -timeout 120s
ok  	github.com/danmestas/EdgeSync/hub	36.529s
```

All 10 iterations clean. No flake. (The 3-hub case completes in ~150ms post-fix; most of the 36s is the other cross-leaf tests in the file, which involve leaf-link wait barriers.)

The `t.Skip` previously gating this test under `-short` is removed; the test now runs under both `-short` (CI mode) and full mode and serves as the regression sentinel for 3+ hub topologies.

## Local CI

| Command | Outcome |
|---|---|
| `go test ./hub/ -count=1 -timeout 120s` | PASS (4.7s) |
| `go test ./hub/ -count=1 -short -timeout 60s` | PASS (9.7s) |
| `go test ./hub/ -count=10 -short -run TestCrossLeaf -timeout 120s` | PASS (36.5s) |
| `go vet ./...` (root + leaf + bridge) | clean |
| `gofmt -l hub/hub.go hub/cross_leaf_test.go` | clean |
| `make ci-fast` | PASS — no flake hit on `TestNotifyCLIPairAndDevices` (#170) this run |
| `sim` `TestHubNATSFossilSync_*` | PASS |

`make ci-fast` was clean on the run that landed the commit. If a #170-style flake hits on the remote CI lane, it's that separate issue and unrelated to this fix.

## Diff size

2 files changed, 97 insertions(+), 26 deletions(-)
- `hub/hub.go` — fix in `startFossilSyncSubscriber`, `startCommitSubscriber`, plus the notification struct.
- `hub/cross_leaf_test.go` — remove the `t.Skip` block; replace with a sentinel comment.

## Risk

- **Wire format**: `commitNotification` gains a field; JSON unmarshal is forward-compatible, but a new hub receiving an old notification (no `peer_id`) refuses to act on it. That's intentional — the alternative (broadcast fallback) is the bug. Old↔new across a leaf cluster: old publisher, new subscriber → notification dropped, no pull. New publisher, old subscriber → old code does broadcast pull, vulnerable to the race; this is no worse than today. In practice EdgeSync hub binaries deploy together, so the cross-version window is bounded.
- **Queue group on broadcast subject**: changes leaf-agent push behaviour from "every hub answers, first wins" to "one hub answers". For 2-hub topologies this is identical (single responder either way after `NoEcho`). For 3+ hub topologies it's strictly better — same race, same data-loss risk on the existing broadcast path is gone. `sim/hub_nats_sync_test.go::TestHubNATSFossilSync_LeafPushLandsOnHub` covers the contract and stays green.

No third-party (NATS server) bugs were exposed by this work — the race is in EdgeSync's own protocol design, not in nats-server.

## Test plan

- [x] `TestCrossLeaf_ThreeHubs_CommitAnnouncePropagatesToAll` fails on `main` (verified above), passes after the fix.
- [x] 10x flake check on `-short TestCrossLeaf` clean.
- [x] All existing `TestCrossLeaf_*` 2-hub tests continue to pass.
- [x] `sim` `TestHubNATSFossilSync_*` (the leaf-agent NATS push path) still green.
- [x] `make ci-fast` green locally.
- [ ] Remote CI green on push.

Closes #162
Closes #179