### PR TITLE
feat(hub): Hub.EnsureUser — idempotent user-table registration (closes #183)

### DIFF
--- a/hub/repo.go
+++ b/hub/repo.go
@@ -35,6 +35,15 @@ type Repo struct {
 	closeMu sync.Mutex
 	closed  bool
 
+	// usersMu serializes EnsureUser's get-then-create sequence so two
+	// in-process callers racing on the same login cannot both observe
+	// "absent" and then both attempt CreateUser (the loser would surface
+	// a UNIQUE-constraint error from the underlying user table).
+	// AddUser / RemoveUser / SetUserCaps don't acquire this — they're
+	// single-statement and their existing error contracts already cover
+	// the duplicate / missing cases callers must reason about.
+	usersMu sync.Mutex
+
 	// publish, when non-nil, is invoked after a successful Commit with the
 	// new commit's rid and uuid. NewHub wires this to a NATS publisher on
 	// "<prefix>.<project-code>.commit" so peer hubs can pull the new
@@ -154,6 +163,38 @@ func (r *Repo) SetUserCaps(login, caps string) error {
 	}
 	if err := r.handle.SetCaps(login, caps); err != nil {
 		return fmt.Errorf("hub: set caps for %q: %w", login, err)
+	}
+	return nil
+}
+
+// EnsureUser registers a user with the given capabilities if not already
+// registered. Idempotent: repeated calls with the same login return nil and
+// do not modify the existing row, even when caps differ — existing caps are
+// PRESERVED. Callers that need replace-on-conflict semantics should use
+// SetUserCaps (or RemoveUser + AddUser) explicitly.
+//
+// Returns an error only for genuine failures (login empty, underlying repo
+// unreachable, etc.). The check-then-create sequence is serialized by an
+// internal mutex so concurrent in-process callers racing on the same login
+// all return nil with exactly one registration ultimately landing.
+func (r *Repo) EnsureUser(login, caps string) error {
+	if login == "" {
+		return errors.New("hub: EnsureUser: login is required")
+	}
+	r.usersMu.Lock()
+	defer r.usersMu.Unlock()
+	if _, err := r.handle.GetUser(login); err == nil {
+		return nil
+	}
+	if err := r.handle.CreateUser(libfossil.UserOpts{Login: login, Caps: caps}); err != nil {
+		// Double-check in case a concurrent out-of-process writer landed
+		// the user between our GetUser and CreateUser (unlikely against
+		// our in-process serialization, but the underlying repo file is
+		// shared state). Treat that as success, matching the contract.
+		if _, getErr := r.handle.GetUser(login); getErr == nil {
+			return nil
+		}
+		return fmt.Errorf("hub: ensure user %q: %w", login, err)
 	}
 	return nil
 }

--- a/hub/users.go
+++ b/hub/users.go
@@ -25,3 +25,14 @@ func (h *Hub) RemoveUser(login string) error { return h.repo.RemoveUser(login) }
 
 // SetUserCaps replaces the caps string on an existing user.
 func (h *Hub) SetUserCaps(login, caps string) error { return h.repo.SetUserCaps(login, caps) }
+
+// EnsureUser registers a user with the given capabilities if not already
+// registered. Idempotent: repeated calls with the same login return nil and
+// do not modify the existing row, even when caps differ — existing caps are
+// PRESERVED. Callers that need replace-on-conflict semantics should use
+// SetUserCaps (or RemoveUser + AddUser) explicitly.
+//
+// Returns an error only for genuine failures (login empty, underlying repo
+// unreachable, etc.). Safe for concurrent in-process callers racing on the
+// same login.
+func (h *Hub) EnsureUser(login, caps string) error { return h.repo.EnsureUser(login, caps) }

--- a/hub/users_test.go
+++ b/hub/users_test.go
@@ -1,0 +1,117 @@
+package hub
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestHub_EnsureUser covers the contract documented on Hub.EnsureUser:
+// first-time registration, idempotent re-call, caps-change-preserves-
+// existing, concurrent racing callers, and the empty-login failure mode.
+//
+// Test gap: the "underlying repo unreachable / fossil-lock contention"
+// failure mode isn't covered here — exercising it cleanly requires either
+// closing the hub mid-call (data race on the libfossil handle) or
+// fault-injection at the libfossil layer that isn't currently exposed.
+// Acceptable: the cap-empty / login-empty path proves error wiring, and
+// the underlying CreateUser/GetUser error paths are already covered by
+// libfossil's own user_test.go.
+func TestHub_EnsureUser(t *testing.T) {
+	t.Run("first-time registration creates user with caps", func(t *testing.T) {
+		h := newTestHub(t)
+		if err := h.EnsureUser("alice", "i"); err != nil {
+			t.Fatalf("EnsureUser(alice, i): %v", err)
+		}
+		if !h.HasUser("alice") {
+			t.Fatal("HasUser(alice) = false after EnsureUser")
+		}
+		got, err := h.GetUser("alice")
+		if err != nil {
+			t.Fatalf("GetUser(alice): %v", err)
+		}
+		if got.Login != "alice" || got.Caps != "i" {
+			t.Errorf("GetUser = %+v, want {Login:alice Caps:i}", got)
+		}
+	})
+
+	t.Run("duplicate call with same caps is a no-op", func(t *testing.T) {
+		h := newTestHub(t)
+		if err := h.EnsureUser("bob", "i"); err != nil {
+			t.Fatalf("EnsureUser bob first: %v", err)
+		}
+		if err := h.EnsureUser("bob", "i"); err != nil {
+			t.Fatalf("EnsureUser bob second: %v", err)
+		}
+		if !h.HasUser("bob") {
+			t.Fatal("HasUser(bob) = false after two EnsureUser calls")
+		}
+		got, err := h.GetUser("bob")
+		if err != nil {
+			t.Fatalf("GetUser(bob): %v", err)
+		}
+		if got.Caps != "i" {
+			t.Errorf("GetUser caps = %q, want %q", got.Caps, "i")
+		}
+	})
+
+	t.Run("caps change on duplicate preserves original caps", func(t *testing.T) {
+		h := newTestHub(t)
+		if err := h.EnsureUser("carol", "i"); err != nil {
+			t.Fatalf("EnsureUser carol i: %v", err)
+		}
+		// Second call with different caps must NOT mutate the row.
+		if err := h.EnsureUser("carol", "a"); err != nil {
+			t.Fatalf("EnsureUser carol a (duplicate): %v", err)
+		}
+		got, err := h.GetUser("carol")
+		if err != nil {
+			t.Fatalf("GetUser(carol): %v", err)
+		}
+		if got.Caps != "i" {
+			t.Errorf("GetUser caps = %q, want %q (caps must be preserved on duplicate)", got.Caps, "i")
+		}
+	})
+
+	t.Run("concurrent callers all return nil and land exactly one user", func(t *testing.T) {
+		h := newTestHub(t)
+		const n = 5
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		start := make(chan struct{})
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				errs[i] = h.EnsureUser("dana", "i")
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+		for i, err := range errs {
+			if err != nil {
+				t.Errorf("goroutine %d: EnsureUser: %v", i, err)
+			}
+		}
+		users, err := h.ListUsers()
+		if err != nil {
+			t.Fatalf("ListUsers: %v", err)
+		}
+		var danaCount int
+		for _, u := range users {
+			if u.Login == "dana" {
+				danaCount++
+			}
+		}
+		if danaCount != 1 {
+			t.Errorf("ListUsers count(dana) = %d, want 1", danaCount)
+		}
+	})
+
+	t.Run("empty login is rejected", func(t *testing.T) {
+		h := newTestHub(t)
+		if err := h.EnsureUser("", "i"); err == nil {
+			t.Fatal("EnsureUser with empty login should error")
+		}
+	})
+}


### PR DESCRIPTION
Closes #183.

## Summary

Add `Hub.EnsureUser(login, caps string) error` as an idempotent counterpart to `Hub.AddUser`. Consumers (sesh's `registerOperatorUser`, etc.) need "register this user if not already registered" semantics; today `AddUser` errors on duplicate, forcing each consumer to write check-then-act + race-recheck wrappers (~35 lines wrapping a 1-line primitive). The user-table layer is the right place to own that idempotency.

## API shape

```go
// EnsureUser registers a user with the given capabilities if not already
// registered. Idempotent: repeated calls with the same login return nil and
// do not modify the existing row, even when caps differ — existing caps are
// PRESERVED. Callers that need replace-on-conflict semantics should use
// SetUserCaps (or RemoveUser + AddUser) explicitly.
//
// Returns an error only for genuine failures (login empty, underlying repo
// unreachable, etc.). Safe for concurrent in-process callers racing on the
// same login.
func (h *Hub) EnsureUser(login, caps string) error
```

Also exposed at the `*Repo` layer (`Repo.EnsureUser`) so CLI-style callers using `OpenRepo` get the same primitive without spinning up a full Hub.

## Implementation choice — option (a) with a mutex

`GetUser` → if not found, `CreateUser`. Serialized by a new `Repo.usersMu` mutex so concurrent in-process callers racing on the same login can't both observe "absent" and then both attempt `CreateUser` (the loser would surface a UNIQUE-constraint error from the underlying user table).

Picked (a) over (b) "catch CreateUser's already-exists error" because libfossil's `CreateUser` surfaces a wrapped SQLite UNIQUE error with **no sentinel or typed shape** — see `libfossil/internal/auth/user.go` line 37: `return fmt.Errorf("insert user %q: %w", login, err)`. Per upstream-fix policy, string-matching that in EdgeSync would be brittle, and filing libfossil for a typed `ErrUserExists` would block this PR. Option (a) is clean today and survives a future libfossil typed-error addition without a rewrite.

After `CreateUser` failure the code does one more `GetUser` re-check to absorb the rare cross-process race (two binaries against the same repo file) — that's not string-matching, it's recovering by querying canonical state.

`AddUser` / `RemoveUser` / `SetUserCaps` are intentionally NOT brought under the mutex: their existing error contracts already cover the duplicate / missing cases callers must reason about, and bracketing them would change observable concurrency semantics.

## Test coverage

`TestHub_EnsureUser` in `hub/users_test.go`:

- **First-time registration**: `EnsureUser("alice", "i")` → `HasUser=true`, `GetUser` returns `{alice, i}`.
- **Duplicate same-caps**: two calls with `("bob", "i")` both return nil; row unchanged.
- **Duplicate different-caps**: `("carol", "i")` then `("carol", "a")` → second returns nil; `GetUser` still returns caps="i" (preservation contract).
- **Concurrent racers**: 5 goroutines call `EnsureUser("dana", "i")` simultaneously; all return nil; `ListUsers` count for "dana" = exactly 1. Verified with `-race`.
- **Empty login**: `EnsureUser("", "i")` returns error.

Test gap (documented in test header): the "underlying repo unreachable / fossil-lock contention" failure mode isn't covered cleanly — exercising it requires either closing the hub mid-call (data race on the libfossil handle) or fault injection at the libfossil layer that isn't currently exposed. The empty-login path proves error wiring, and the underlying primitives' error paths are covered by libfossil's own `user_test.go`.

## Local CI

- `go test ./hub/ -run 'TestHub_EnsureUser' -race -count=1 -timeout 60s` — 6/6 pass
- `go test ./hub/ -count=1 -timeout 120s` — 51/51 pass (no regression)
- `go test ./... -count=1 -timeout 300s` — 63 pass, 2 pre-existing iroh failures (missing `iroh-sidecar` binary, environmental; confirmed they fail identically on `main`)
- `GOWORK=off go vet ./...` + `cd leaf && rtk go vet ./...` + `cd bridge && rtk go vet ./...` — clean
- `go build -buildvcs=false ./cmd/edgesync/` — clean
- `gofmt -l hub/users.go hub/users_test.go hub/repo.go` — clean
- `cd leaf && rtk go test ./... -short -count=1` — 159 pass
- `cd bridge && rtk go test ./... -short -count=1` — 14 pass

## Consumer cleanup unblocked downstream

After this lands and sesh bumps the EdgeSync pin, `sesh/cli/bootstrap.go`'s `registerOperatorUser` collapses from ~35 lines (HasUser pre-check + AddUser + AddUser-error race-recheck path) to ~10 lines. Filed as a sesh follow-up, separate PR — not in scope here.

## Diff size

3 files, 169 insertions, 0 deletions.

- `hub/repo.go` — add `Repo.usersMu` and `Repo.EnsureUser` (41 lines).
- `hub/users.go` — add `Hub.EnsureUser` thin wrapper (11 lines).
- `hub/users_test.go` — new test file (117 lines).