### PR TITLE
fix(hub): resolve TestNotifyCLIPairAndDevices flake (closes #170)

### DIFF
--- a/cmd/edgesync/notify_test.go
+++ b/cmd/edgesync/notify_test.go
@@ -23,10 +23,10 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "tempdir: %s\n", err)
 		os.Exit(2)
 	}
-	defer os.RemoveAll(dir)
 
 	root, err := findRepoRoot()
 	if err != nil {
+		os.RemoveAll(dir)
 		fmt.Fprintf(os.Stderr, "find repo root: %s\n", err)
 		os.Exit(2)
 	}
@@ -35,11 +35,16 @@ func TestMain(m *testing.M) {
 	cmd := exec.Command("go", "build", "-buildvcs=false", "-o", sharedBinary, "./cmd/edgesync/")
 	cmd.Dir = root
 	if out, err := cmd.CombinedOutput(); err != nil {
+		os.RemoveAll(dir)
 		fmt.Fprintf(os.Stderr, "build edgesync binary: %s\n%s", err, out)
 		os.Exit(2)
 	}
 
-	os.Exit(m.Run())
+	// os.Exit skips deferred functions, so clean up explicitly between
+	// running tests and exiting. (Ousterhout follow-up to PR #186.)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 // findRepoRoot locates the EdgeSync repo root (parent of cmd/) starting from

--- a/cmd/edgesync/notify_test.go
+++ b/cmd/edgesync/notify_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -8,39 +9,65 @@ import (
 	"testing"
 )
 
-// buildBinary builds the edgesync binary into a temp dir and returns its path.
-func buildBinary(t *testing.T) string {
-	t.Helper()
-	bin := filepath.Join(t.TempDir(), "edgesync")
-	cmd := exec.Command("go", "build", "-buildvcs=false", "-o", bin, "./cmd/edgesync/")
-	// Build from the repo root (where go.mod lives).
-	cmd.Dir = repoRoot(t)
-	out, err := cmd.CombinedOutput()
+// sharedBinary is the path to the edgesync binary built once by TestMain
+// and reused across every test in this package. Building only once avoids a
+// build-storm — without this, each test's buildBinary() invocation ran its own
+// `go build`, and under cold-cache / parallel-load the cumulative cost pushed
+// the package past `go test -timeout=30s` (see issue #170).
+var sharedBinary string
+
+func TestMain(m *testing.M) {
+	// Build into a temp dir that survives until the process exits.
+	dir, err := os.MkdirTemp("", "edgesync-test-bin-")
 	if err != nil {
-		t.Fatalf("build failed: %s\n%s", err, out)
+		fmt.Fprintf(os.Stderr, "tempdir: %s\n", err)
+		os.Exit(2)
 	}
-	return bin
+	defer os.RemoveAll(dir)
+
+	root, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "find repo root: %s\n", err)
+		os.Exit(2)
+	}
+
+	sharedBinary = filepath.Join(dir, "edgesync")
+	cmd := exec.Command("go", "build", "-buildvcs=false", "-o", sharedBinary, "./cmd/edgesync/")
+	cmd.Dir = root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "build edgesync binary: %s\n%s", err, out)
+		os.Exit(2)
+	}
+
+	os.Exit(m.Run())
 }
 
-// repoRoot returns the root of the EdgeSync repo (parent of cmd/).
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	// This test file is in cmd/edgesync/, so go two levels up.
+// findRepoRoot locates the EdgeSync repo root (parent of cmd/) starting from
+// the test's working directory.
+func findRepoRoot() (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		t.Fatal(err)
+		return "", err
 	}
-	// When running tests, cwd is the package dir (cmd/edgesync/).
-	// Go up to repo root.
+	// When `go test` runs, cwd is the package dir (cmd/edgesync/).
 	root := filepath.Dir(filepath.Dir(wd))
 	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
-		t.Fatalf("could not find repo root from %s", wd)
+		return "", fmt.Errorf("could not find repo root from %s: %w", wd, err)
 	}
-	return root
+	return root, nil
+}
+
+// edgesyncBin returns the shared edgesync binary path.
+func edgesyncBin(t *testing.T) string {
+	t.Helper()
+	if sharedBinary == "" {
+		t.Fatal("sharedBinary is empty — TestMain did not run")
+	}
+	return sharedBinary
 }
 
 func TestNotifyCLIInit(t *testing.T) {
-	bin := buildBinary(t)
+	bin := edgesyncBin(t)
 	tmp := t.TempDir()
 
 	// -R points to a fake repo path — init creates notify.fossil next to it.
@@ -65,7 +92,7 @@ func TestNotifyCLIInit(t *testing.T) {
 }
 
 func TestNotifyCLIPairAndDevices(t *testing.T) {
-	bin := buildBinary(t)
+	bin := edgesyncBin(t)
 	tmp := t.TempDir()
 	fakeRepo := filepath.Join(tmp, "project.fossil")
 
@@ -104,7 +131,7 @@ func TestNotifyCLIPairAndDevices(t *testing.T) {
 }
 
 func TestNotifyCLIUnpair(t *testing.T) {
-	bin := buildBinary(t)
+	bin := edgesyncBin(t)
 	tmp := t.TempDir()
 	fakeRepo := filepath.Join(tmp, "project.fossil")
 
@@ -122,7 +149,7 @@ func TestNotifyCLIUnpair(t *testing.T) {
 }
 
 func TestNotifyCLISendAndThreads(t *testing.T) {
-	bin := buildBinary(t)
+	bin := edgesyncBin(t)
 	tmp := t.TempDir()
 	fakeRepo := filepath.Join(tmp, "project.fossil")
 


### PR DESCRIPTION
## Summary

`make ci-fast` runs `go test -short -count=1 -timeout=30s ./...`. The `cmd/edgesync` package contained 4 black-box tests, each of which invoked `go build ./cmd/edgesync/` inside its own body via `buildBinary(t)`. Four serial cold-cache builds plus parallel test-binary build contention on the rest of the module push the package over the 30s ceiling — the runtime supervisor SIGKILLs the test process while the inner `go build` child is mid-Wait, which surfaces in the backtrace as a hang in `os/exec.Cmd.Wait` (`syscall.wait4`) — matching the symptom in issue #170.

The flake is structural, not logical. The fix is to build the binary once in `TestMain` and share it across the tests.

## Diagnosis evidence

Pre-fix, cold cache:

```
=== RUN   TestNotifyCLIInit
--- PASS: TestNotifyCLIInit            (2.65s)
=== RUN   TestNotifyCLIPairAndDevices
--- PASS: TestNotifyCLIPairAndDevices  (2.31s)
=== RUN   TestNotifyCLIUnpair
--- PASS: TestNotifyCLIUnpair          (2.08s)
=== RUN   TestNotifyCLISendAndThreads
--- PASS: TestNotifyCLISendAndThreads  (1.98s)
PASS
ok    github.com/danmestas/EdgeSync/cmd/edgesync   9.903s
```

Roughly 2-3s per test, 100% of which is the `go build` invocation. Under the simultaneous build pressure of `go test ./...` across the whole root module (`cli/repo`, `hub`, `sim`, …), cmd/edgesync's wall-clock time is sensitive to host load and was the only package consistently brushing 13s+ (issue body).

## Root cause

`cmd/edgesync/notify_test.go:12-23` — `buildBinary(t)` invoked `go build` per-test. 4 redundant builds.

## Fix

`TestMain` builds the binary once into an `os.MkdirTemp` directory that survives the test process. All 4 tests pull `sharedBinary` from a package-scope var.

## Post-fix verification

Same package, cold cache, post-fix:

```
=== RUN   TestNotifyCLIInit
--- PASS: TestNotifyCLIInit            (0.76s)
=== RUN   TestNotifyCLIPairAndDevices
--- PASS: TestNotifyCLIPairAndDevices  (0.07s)
=== RUN   TestNotifyCLIUnpair
--- PASS: TestNotifyCLIUnpair          (0.05s)
=== RUN   TestNotifyCLISendAndThreads
--- PASS: TestNotifyCLISendAndThreads  (0.10s)
PASS
ok    github.com/danmestas/EdgeSync/cmd/edgesync   5.113s
```

- `go test ./cmd/edgesync/ -run TestNotifyCLIPairAndDevices -count=50` — 50/50 PASS
- `go test ./cmd/edgesync/ -count=50` (all 4 tests, 200 invocations total) — 200/200 PASS
- `go test -race ./cmd/edgesync/ -count=20` (80 invocations) — 80/80 PASS
- `make ci-fast` (cold cache) — completes in ~67s wall; cmd/edgesync at 3.56s
- `make ci-fast` (warm cache) — completes in ~21s wall; cmd/edgesync at 3.20s
- `go vet ./...` (root + leaf + bridge) clean
- `gofmt -l cmd/edgesync/` clean
- Full root-module `go test ./...` — only 2 pre-existing unrelated failures (`TestIrohPeerSync`, `TestIrohConvergence`, both need `iroh-sidecar` binary that isn't built in this run; confirmed by reproducing on `main` before this change applied)

## Diff size

50 insertions, 23 deletions in 1 file.

## Risk

Low. Test-only change, no production-code touched. `TestMain` is the canonical Go idiom for shared per-package setup.

## Test plan

- [x] Target test 50× green
- [x] Whole `cmd/edgesync` package 50× green
- [x] -race 20× green
- [x] `make ci-fast` end-to-end on cold and warm cache
- [x] go vet + gofmt clean